### PR TITLE
feat(resolution): resolve composable attack damage

### DIFF
--- a/rulebooks/dnd5e/resolution/character_attack.go
+++ b/rulebooks/dnd5e/resolution/character_attack.go
@@ -39,7 +39,7 @@ type CharacterAttackInput struct {
 //
 // # What compiles here, and what does not
 //
-// Only STATIC facts: the weapon's dice and damage type, whether finesse lets
+// Only STATIC facts: the weapon's canonical damage pools, whether finesse lets
 // DEX win, whether the sheet is proficient, and whether a versatile grip
 // steps the die. Every one of them is knowable before the swing and cannot
 // change between two swings of the same weapon by the same character.
@@ -105,29 +105,29 @@ func AttackFromCharacter(c *character.Character, in *CharacterAttackInput) (Atta
 		attackBonus += c.ProficiencyBonus()
 	}
 
-	dice := weapon.Damage
-	if in.TwoHanded {
-		dice = weapon.VersatileDamage()
+	pools, err := weapon.DamageForGrip(in.TwoHanded)
+	if err != nil {
+		return AttackProfile{}, fmt.Errorf("%w: %w", ErrBadAttack, err)
 	}
 
-	return AttackProfile{
+	profile := AttackProfile{
 		Ref:         ref,
 		AttackBonus: attackBonus,
-		// The ability modifier rides the notation rather than a separate
-		// field, and that is load-bearing for critical hits: the machine
-		// doubles a crit by rolling the pool a second time and takes the flat
-		// modifier from the FIRST roll only, so "+3" inside "1d8+3" doubles
-		// the dice and not the modifier — which is exactly ADR-0036's rule.
-		DamageDice: fmt.Sprintf("%s%+d", dice, modifier),
-		DamageType: weapon.DamageType,
-		// Which ability swung. Not arithmetic — the modifier is already in the
-		// notation above — but the fact effects predicate on: Rage pays out on
-		// melee Strength attacks and needs to know this was one.
-		AbilityUsed: ability,
+		Damage:      copyDamagePools(pools),
+		// Which ability swung is the fact effects predicate on: Rage pays out
+		// on melee Strength attacks and needs to know this was one. Its
+		// arithmetic remains separately attributable in AbilityModifier.
+		AbilityUsed:     ability,
+		AbilityModifier: modifier,
 		// Weapons declare no rider. A gate on a character's attack comes from
 		// class content (a monk's Flurry), which compiles elsewhere.
 		Gate: nil,
-	}, nil
+	}
+	if err := profile.validate(); err != nil {
+		return AttackProfile{}, err
+	}
+
+	return profile, nil
 }
 
 // equippedWeapon reads the weapon out of a slot, refusing an empty or

--- a/rulebooks/dnd5e/resolution/character_attack_test.go
+++ b/rulebooks/dnd5e/resolution/character_attack_test.go
@@ -187,11 +187,16 @@ func (s *CharacterAttackTestSuite) raging() json.RawMessage {
 func (s *CharacterAttackTestSuite) TestAHeroSwingsTheirLongswordAtAWolf() {
 	profile := s.compile(s.martialHero(), s.mainHand())
 
-	// STR 16 (+3) plus proficiency +2 to hit; the +3 rides the damage pool.
+	// STR 16 (+3) plus proficiency +2 to hit; the +3 remains separately attributable.
 	s.Require().Equal(refs.Weapons.Longsword(), profile.Ref)
 	s.Require().Equal(3+2, profile.AttackBonus)
-	s.Require().Equal("1d8+3", profile.DamageDice)
-	s.Require().Equal(damage.Slashing, profile.DamageType)
+	s.Require().Equal([]damage.Damage{{
+		Dice:       "1d8",
+		Type:       damage.Slashing,
+		Properties: []damage.Property{damage.AddsAttackAbilityModifier},
+	}}, profile.Damage)
+	s.Require().Equal(abilities.STR, profile.AbilityUsed)
+	s.Require().Equal(3, profile.AbilityModifier)
 	s.Require().Nil(profile.Gate, "a weapon declares no rider")
 
 	out, err := s.swingAt(s.martialHero(), profile,
@@ -231,12 +236,16 @@ func (s *CharacterAttackTestSuite) TestFinesseTakesTheBetterAbilityInBothNumbers
 
 	dagger := s.compile(sheet, &CharacterAttackInput{Slot: character.SlotMainHand})
 	s.Require().Equal(4+2, dagger.AttackBonus, "DEX +4 plus proficiency +2")
-	s.Require().Equal("1d4+4", dagger.DamageDice, "and the DEX modifier rides the damage too")
-	s.Require().Equal(damage.Piercing, dagger.DamageType)
+	s.Require().Equal("1d4", dagger.Damage[0].Dice)
+	s.Require().Equal(damage.Piercing, dagger.Damage[0].Type)
+	s.Require().Equal(abilities.DEX, dagger.AbilityUsed)
+	s.Require().Equal(4, dagger.AbilityModifier, "and the DEX modifier is preserved separately")
 
 	mace := s.compile(sheet, &CharacterAttackInput{Slot: character.SlotOffHand})
 	s.Require().Equal(0+2, mace.AttackBonus, "no finesse: STR +0 plus proficiency +2")
-	s.Require().Equal("1d6+0", mace.DamageDice, "and STR rides the damage, at +0")
+	s.Require().Equal("1d6", mace.Damage[0].Dice)
+	s.Require().Equal(abilities.STR, mace.AbilityUsed)
+	s.Require().Zero(mace.AbilityModifier, "a legitimate +0 modifier remains explicit")
 
 	// The whole point, stated as the difference the property makes.
 	s.Require().Equal(4, dagger.AttackBonus-mace.AttackBonus,
@@ -255,7 +264,9 @@ func (s *CharacterAttackTestSuite) TestFinesseKeepsStrengthWhenStrengthIsBetter(
 
 	dagger := s.compile(sheet, s.mainHand())
 	s.Require().Equal(4+2, dagger.AttackBonus, "STR +4 wins")
-	s.Require().Equal("1d4+4", dagger.DamageDice)
+	s.Require().Equal("1d4", dagger.Damage[0].Dice)
+	s.Require().Equal(abilities.STR, dagger.AbilityUsed)
+	s.Require().Equal(4, dagger.AbilityModifier)
 }
 
 // A tie is not a choice: identical modifiers produce identical numbers, so the
@@ -270,7 +281,9 @@ func (s *CharacterAttackTestSuite) TestFinesseOnATieIsStillTheSameArithmetic() {
 
 	dagger := s.compile(sheet, s.mainHand())
 	s.Require().Equal(2+2, dagger.AttackBonus)
-	s.Require().Equal("1d4+2", dagger.DamageDice)
+	s.Require().Equal("1d4", dagger.Damage[0].Dice)
+	s.Require().Equal(abilities.STR, dagger.AbilityUsed)
+	s.Require().Equal(2, dagger.AbilityModifier)
 }
 
 // ---------------------------------------------------------------------------
@@ -294,9 +307,10 @@ func (s *CharacterAttackTestSuite) TestProficiencyIsWorthExactlyTheProficiencyBo
 	s.Require().Equal(2, trained.AttackBonus-untrained.AttackBonus,
 		"exactly the sheet's proficiency bonus apart")
 
-	s.Require().Equal(untrained.DamageDice, trained.DamageDice,
+	s.Require().Equal(untrained.Damage, trained.Damage,
 		"proficiency never touches the damage pool")
-	s.Require().Equal("1d8+3", trained.DamageDice)
+	s.Require().Equal(3, trained.AbilityModifier)
+	s.Require().Equal(3, untrained.AbilityModifier)
 }
 
 // A sheet with no weapon grants at all adds nothing.
@@ -309,16 +323,27 @@ func (s *CharacterAttackTestSuite) TestNoGrantsAddsNoProficiencyBonus() {
 	s.Require().Equal(3, profile.AttackBonus)
 }
 
+func (s *CharacterAttackTestSuite) TestNegativeAbilityModifierRemainsSeparateFromPureDice() {
+	sheet := s.martialHero()
+	sheet.AbilityScores[abilities.STR] = 8
+
+	profile := s.compile(sheet, s.mainHand())
+
+	s.Require().Equal("1d8", profile.Damage[0].Dice)
+	s.Require().Equal(-1, profile.AbilityModifier)
+	s.Require().Equal(abilities.STR, profile.AbilityUsed)
+}
+
 // ---------------------------------------------------------------------------
 // 4. A character's critical hit doubles the dice and not the modifier.
 // ---------------------------------------------------------------------------
 
-// The ability modifier rides inside "1d8+3", and that is exactly why the crit
-// is right: the machine rolls the pool twice and takes the flat modifier from
-// the first roll only. Two d8s, one +3.
+// The ability modifier remains separate from pure "1d8" notation. The strike
+// still applies it once on a critical hit: two d8s, one +3.
 func (s *CharacterAttackTestSuite) TestACharacterCritDoublesTheDiceNotTheAbilityModifier() {
 	profile := s.compile(s.martialHero(), s.mainHand())
-	s.Require().Equal("1d8+3", profile.DamageDice)
+	s.Require().Equal("1d8", profile.Damage[0].Dice)
+	s.Require().Equal(3, profile.AbilityModifier)
 
 	out, err := s.swingAt(s.martialHero(), profile,
 		&sequenceRoller{singles: []int{20}, pair: []int{5, 4}, fallback: 2})
@@ -349,7 +374,8 @@ func (s *CharacterAttackTestSuite) TestARagingHerosBonusArrivesViaTheChainNotThe
 
 	s.Require().Equal(calm, raging,
 		"the compiler reads static facts only — Rage is invisible to it")
-	s.Require().Equal("1d8+3", raging.DamageDice, "no +2 anywhere in the compiled pool")
+	s.Require().Equal("1d8", raging.Damage[0].Dice, "no arithmetic is fused into canonical dice")
+	s.Require().Equal(3, raging.AbilityModifier, "only the static ability modifier compiles")
 	s.Require().Equal(3+2, raging.AttackBonus)
 
 	out, err := s.swingAt(s.martialHero(s.raging()), raging,
@@ -395,7 +421,8 @@ func (s *CharacterAttackTestSuite) TestRageDoesNotPayOutOnADexterityFinesseSwing
 
 	profile := s.compile(sheet, s.mainHand())
 	s.Require().Equal(abilities.DEX, profile.AbilityUsed, "finesse chose DEX")
-	s.Require().Equal("1d4+4", profile.DamageDice)
+	s.Require().Equal("1d4", profile.Damage[0].Dice)
+	s.Require().Equal(4, profile.AbilityModifier)
 
 	freshSheet := s.heroSheet(grants, equipped, s.raging())
 	freshSheet.AbilityScores[abilities.STR] = 10
@@ -481,6 +508,18 @@ func (s *CharacterAttackTestSuite) TestTheCompilerIsDeterministic() {
 	s.Require().Equal(first, second)
 }
 
+func (s *CharacterAttackTestSuite) TestCompiledDamagePropertiesDoNotAliasWeaponCatalogContent() {
+	profile := s.compile(s.martialHero(), s.mainHand())
+	s.Require().Equal([]damage.Property{damage.AddsAttackAbilityModifier}, profile.Damage[0].Properties)
+
+	original := profile.Damage[0].Properties[0]
+	defer func() { profile.Damage[0].Properties[0] = original }()
+	profile.Damage[0].Properties[0] = damage.DoesNotCrit
+
+	fresh := s.compile(s.martialHero(), s.mainHand())
+	s.Require().Equal([]damage.Property{damage.AddsAttackAbilityModifier}, fresh.Damage[0].Properties)
+}
+
 // ---------------------------------------------------------------------------
 // Versatile, and the refusals.
 // ---------------------------------------------------------------------------
@@ -492,12 +531,15 @@ func (s *CharacterAttackTestSuite) TestAVersatileWeaponStepsItsDieAndNothingElse
 	twoHanded := s.compile(s.martialHero(),
 		&CharacterAttackInput{Slot: character.SlotMainHand, TwoHanded: true})
 
-	s.Require().Equal("1d8+3", oneHanded.DamageDice)
-	s.Require().Equal("1d10+3", twoHanded.DamageDice)
+	s.Require().Equal("1d8", oneHanded.Damage[0].Dice)
+	s.Require().Equal("1d10", twoHanded.Damage[0].Dice)
 
 	s.Require().Equal(oneHanded.AttackBonus, twoHanded.AttackBonus, "the grip does not change accuracy")
 	s.Require().Equal(oneHanded.Ref, twoHanded.Ref)
-	s.Require().Equal(oneHanded.DamageType, twoHanded.DamageType)
+	s.Require().Equal(oneHanded.Damage[0].Type, twoHanded.Damage[0].Type)
+	s.Require().Equal(oneHanded.Damage[0].FlatBonus, twoHanded.Damage[0].FlatBonus)
+	s.Require().Equal(oneHanded.Damage[0].Properties, twoHanded.Damage[0].Properties)
+	s.Require().Equal(oneHanded.AbilityModifier, twoHanded.AbilityModifier)
 }
 
 // A non-versatile weapon in two hands is the same weapon: the flag asks the
@@ -511,7 +553,8 @@ func (s *CharacterAttackTestSuite) TestTwoHandedOnANonVersatileWeaponChangesNoth
 	oneHanded := s.compile(sheet, s.mainHand())
 	twoHanded := s.compile(sheet, &CharacterAttackInput{Slot: character.SlotMainHand, TwoHanded: true})
 
-	s.Require().Equal("2d6+3", oneHanded.DamageDice)
+	s.Require().Equal("2d6", oneHanded.Damage[0].Dice)
+	s.Require().Equal(3, oneHanded.AbilityModifier)
 	s.Require().Equal(oneHanded, twoHanded)
 }
 
@@ -536,7 +579,8 @@ func (s *CharacterAttackTestSuite) TestRefusesWhatItCannotCompile() {
 		)
 		profile, err := AttackFromCharacter(s.load(sheet), s.mainHand())
 		s.Require().NoError(err, "a dagger carries a thrown range but is a melee weapon")
-		s.Require().Equal("1d4+3", profile.DamageDice)
+		s.Require().Equal("1d4", profile.Damage[0].Dice)
+		s.Require().Equal(3, profile.AbilityModifier)
 	})
 
 	s.Run("an empty slot, rather than a silent unarmed strike", func() {

--- a/rulebooks/dnd5e/resolution/damage_custody_test.go
+++ b/rulebooks/dnd5e/resolution/damage_custody_test.go
@@ -156,6 +156,36 @@ func (s *DamageCustodyTestSuite) TestTypesAreGroupedSeparatelyThroughTheFold() {
 	s.Require().Equal(4+6, outcome.Damage, "each type resolves on its own")
 }
 
+func (s *DamageCustodyTestSuite) TestTypedOutcomePreservesMixedVulnerabilityAndImmunity() {
+	bus := events.NewEventBus()
+	s.multiplyOnBus(bus, damage.Bludgeoning, 2)
+	s.multiplyOnBus(bus, damage.Acid, 0)
+
+	profile := oozeProfile(
+		damage.Damage{Dice: "1d8", Type: damage.Bludgeoning, FlatBonus: 2},
+		damage.Damage{Dice: "1d6", Type: damage.Acid},
+	)
+	target := monsters.NewWolf(secondWolfID).ToData()
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		World:        s.roomWith(encounter.MemberID(wolfID), encounter.MemberID(target.ID)),
+		Participants: []Participant{{Monster: monsters.NewWolf(wolfID).ToData()}, {Monster: target}},
+		Machine: NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   target.ID,
+			Attack:     profile,
+			Roller:     scripted(15, 4, 5),
+		}),
+	}, newSurface(bus))
+	s.Require().NoError(err)
+
+	struck, ok := out.Outcome.(StrikeOutcome)
+	s.Require().True(ok)
+	s.Equal(12, struck.Damage, "bludgeoning 6 doubles while acid 5 is immune")
+	s.Equal([]damage.Instance{{Amount: 12, Type: damage.Bludgeoning}}, struck.DamageInstances)
+	s.Require().Len(struck.DamageComponents, 4,
+		"the outcome retains both rolled pools and both typed defense components")
+}
+
 // The event's own DamageType is load-bearing, not decoration: Rage's
 // resistance predicates on it twice — event.DamageType.IsPhysical() decides
 // whether to resist at all, and the multiplier component it appends carries

--- a/rulebooks/dnd5e/resolution/declared_consequence_test.go
+++ b/rulebooks/dnd5e/resolution/declared_consequence_test.go
@@ -143,7 +143,7 @@ func (s *DeclaredConsequenceTestSuite) TestAnUngatedAttackNamesNoConsequence() {
 		}
 	}
 
-	s.Require().NotEmpty(melee.DamageDice, "the skeleton has a generic melee action")
+	s.Require().NotEmpty(melee.Damage, "the skeleton has a generic melee action")
 	s.Require().Nil(melee.Gate, "a plain weapon just hits")
 	s.Require().Nil(melee.Imposes, "so there is nothing riding on it")
 }
@@ -155,8 +155,7 @@ func (s *DeclaredConsequenceTestSuite) TestAnUngatedAttackNamesNoConsequence() {
 func (s *DeclaredConsequenceTestSuite) TestAGatelessBiteNamesNoConsequence() {
 	config, err := json.Marshal(monsterActions.BiteConfig{
 		AttackBonus: 4,
-		DamageDice:  "2d4+2",
-		DamageType:  damage.Piercing,
+		Damage:      []damage.Damage{{Dice: "2d4", Type: damage.Piercing, FlatBonus: 2}},
 		// No SaveGate, no KnockdownDC: a bite that just bites.
 	})
 	s.Require().NoError(err)
@@ -169,7 +168,8 @@ func (s *DeclaredConsequenceTestSuite) TestAGatelessBiteNamesNoConsequence() {
 
 	s.Require().Nil(profile.Gate, "nothing to contest")
 	s.Require().Nil(profile.Imposes, "so nothing rides on it")
-	s.Require().Equal("2d4+2", profile.DamageDice, "and it is still a bite")
+	s.Require().Equal([]damage.Damage{{Dice: "2d4", Type: damage.Piercing, FlatBonus: 2}}, profile.Damage,
+		"and it is still a bite")
 }
 
 // A gate that names no consequence is refused BY NAME, before anything rolls.

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.21.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0 h1:w+QHwNV8h2WCkF0fNtDQSyVCNFzVGXi8av9sQcOWNQw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.21.0 h1:gh43waX8aBfbs3GgZMwpdidelEqpnsrz36nZDxjcsNw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.21.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=

--- a/rulebooks/dnd5e/resolution/monster_attack_test.go
+++ b/rulebooks/dnd5e/resolution/monster_attack_test.go
@@ -1,0 +1,147 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	monsterActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
+)
+
+type MonsterAttackTestSuite struct {
+	suite.Suite
+}
+
+func TestMonsterAttackSuite(t *testing.T) {
+	suite.Run(t, new(MonsterAttackTestSuite))
+}
+
+func (s *MonsterAttackTestSuite) action(ref *core.Ref, config any) monster.ActionData {
+	s.T().Helper()
+
+	raw, err := json.Marshal(config)
+	s.Require().NoError(err)
+
+	s.Require().NotNil(ref)
+
+	return monster.ActionData{Ref: *ref, Config: raw}
+}
+
+func (s *MonsterAttackTestSuite) TestMeleePreservesCanonicalPoolsAndIntrinsicBonuses() {
+	cases := []struct {
+		name      string
+		flatBonus int
+	}{
+		{name: "positive", flatBonus: 2},
+		{name: "zero", flatBonus: 0},
+		{name: "negative", flatBonus: -1},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			want := []damage.Damage{
+				{Dice: "1d6", Type: damage.Slashing, FlatBonus: tc.flatBonus},
+				{Dice: "1d4", Type: damage.Fire, Properties: []damage.Property{damage.DoesNotCrit}},
+			}
+			action := s.action(refs.MonsterActions.Melee(), monsterActions.MeleeConfig{
+				Name:        "enchanted scimitar",
+				AttackBonus: 4,
+				Damage:      want,
+				Reach:       1,
+			})
+
+			profile, err := AttackFromMonsterAction(action)
+			s.Require().NoError(err)
+			s.Equal(refs.MonsterActions.Melee(), profile.Ref)
+			s.Equal(4, profile.AttackBonus)
+			s.Equal(want, profile.Damage)
+			s.Empty(profile.AbilityUsed)
+			s.Zero(profile.AbilityModifier)
+			s.Nil(profile.Gate)
+			s.Nil(profile.Imposes)
+		})
+	}
+}
+
+func (s *MonsterAttackTestSuite) TestBitePreservesCanonicalDamageAndGate() {
+	gate := saves.NewSaveGate(abilities.STR, 11)
+	want := []damage.Damage{{Dice: "2d4", Type: damage.Piercing, FlatBonus: 2}}
+	action := s.action(refs.MonsterActions.Bite(), monsterActions.BiteConfig{
+		AttackBonus: 4,
+		Damage:      want,
+		SaveGate:    gate,
+	})
+
+	profile, err := AttackFromMonsterAction(action)
+	s.Require().NoError(err)
+	s.Equal(want, profile.Damage)
+	s.Equal(gate, profile.Gate)
+	s.Require().NotNil(profile.Imposes)
+	s.Equal(refs.Conditions.Prone(), profile.Imposes.atStake().Ref)
+}
+
+func (s *MonsterAttackTestSuite) TestGoblinScimitarCompilesFromGenericMeleeContent() {
+	goblin := monsters.NewGoblin("goblin-1").ToData()
+	s.Require().Len(goblin.Actions, 1)
+	s.Equal(refs.MonsterActions.Melee(), &goblin.Actions[0].Ref)
+
+	profile, err := AttackFromMonsterAction(goblin.Actions[0])
+	s.Require().NoError(err)
+	s.Equal(4, profile.AttackBonus)
+	s.Equal([]damage.Damage{{Dice: "1d6", Type: damage.Slashing, FlatBonus: 2}}, profile.Damage)
+	s.Empty(profile.AbilityUsed)
+	s.Zero(profile.AbilityModifier)
+}
+
+func (s *MonsterAttackTestSuite) TestCanonicalDamageArrayIsRequired() {
+	for _, tc := range []struct {
+		name   string
+		config json.RawMessage
+	}{
+		{name: "missing", config: json.RawMessage(`{"name":"club","attack_bonus":2,"reach":1}`)},
+		{name: "empty", config: json.RawMessage(`{"name":"club","attack_bonus":2,"damage":[],"reach":1}`)},
+		{name: "malformed", config: json.RawMessage(`{"name":"club","attack_bonus":2,"damage":[{"dice":"1d6+2","type":"bludgeoning"}],"reach":1}`)},
+	} {
+		s.Run(tc.name, func() {
+			_, err := AttackFromMonsterAction(monster.ActionData{
+				Ref:    *refs.MonsterActions.Melee(),
+				Config: tc.config,
+			})
+			s.Require().ErrorIs(err, ErrBadAttack)
+		})
+	}
+}
+
+func (s *MonsterAttackTestSuite) TestLegacyDamageFieldsAreRejectedRatherThanTranslated() {
+	_, err := AttackFromMonsterAction(monster.ActionData{
+		Ref: *refs.MonsterActions.Melee(),
+		Config: json.RawMessage(
+			`{"name":"club","attack_bonus":2,"damage_dice":"1d6+2","damage_type":"bludgeoning","reach":1}`),
+	})
+
+	s.Require().ErrorIs(err, ErrBadAttack)
+}
+
+func (s *MonsterAttackTestSuite) TestRangedActionRemainsRefused() {
+	action := s.action(refs.MonsterActions.Ranged(), monsterActions.RangedConfig{
+		Name:        "shortbow",
+		AttackBonus: 4,
+		Damage:      []damage.Damage{{Dice: "1d6", Type: damage.Piercing, FlatBonus: 2}},
+		RangeNormal: 16,
+		RangeLong:   64,
+	})
+
+	_, err := AttackFromMonsterAction(action)
+	s.Require().ErrorIs(err, ErrBadAttack)
+}

--- a/rulebooks/dnd5e/resolution/resolve_test.go
+++ b/rulebooks/dnd5e/resolution/resolve_test.go
@@ -134,13 +134,15 @@ func (s *ResolveTestSuite) dodging() json.RawMessage {
 // through the action's own ToData so the fixture is the real serialized shape
 // rather than a hand-copied guess at it.
 func (s *ResolveTestSuite) shortsword() monster.ActionData {
-	return monsterActions.NewMeleeAction(monsterActions.MeleeConfig{
+	action, err := monsterActions.NewMeleeAction(monsterActions.MeleeConfig{
 		Name:        "shortsword",
 		AttackBonus: 4,
-		DamageDice:  "1d6+2",
+		Damage:      []damage.Damage{{Dice: "1d6", Type: damage.Piercing, FlatBonus: 2}},
 		Reach:       5,
-		DamageType:  damage.Piercing,
-	}).ToData()
+	})
+	s.Require().NoError(err)
+
+	return action.ToData()
 }
 
 // skeleton carries a trait that has nothing to do with saving throws, which is

--- a/rulebooks/dnd5e/resolution/strictness_test.go
+++ b/rulebooks/dnd5e/resolution/strictness_test.go
@@ -18,10 +18,12 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -276,6 +278,55 @@ func (s *StrictnessTestSuite) TestAnAttachThatFailsFailsTheResolution() {
 	s.Require().Nil(out)
 	s.Require().ErrorIs(err, errRefused)
 	s.Require().Contains(err.Error(), heroID, "the error names the participant that would not attach")
+}
+
+func (s *StrictnessTestSuite) TestAbilityRequiresExactlyOneMarkedPool() {
+	profile := AttackProfile{
+		Ref:             refs.Weapons.Longsword(),
+		AbilityUsed:     abilities.STR,
+		AbilityModifier: 3,
+		Damage:          []damage.Damage{{Dice: "1d8", Type: damage.Slashing}},
+	}
+
+	s.Require().ErrorIs(profile.validate(), ErrBadAttack)
+}
+
+func (s *StrictnessTestSuite) TestAbilityAllowsZeroModifierWithExactlyOneMarkedPool() {
+	profile := AttackProfile{
+		Ref:             refs.Weapons.Longsword(),
+		AbilityUsed:     abilities.STR,
+		AbilityModifier: 0,
+		Damage: []damage.Damage{{
+			Dice:       "1d8",
+			Type:       damage.Slashing,
+			Properties: []damage.Property{damage.AddsAttackAbilityModifier},
+		}},
+	}
+
+	s.Require().NoError(profile.validate())
+}
+
+func (s *StrictnessTestSuite) TestMonsterProfileRejectsAbilityMarker() {
+	profile := AttackProfile{
+		Ref: refs.MonsterActions.Bite(),
+		Damage: []damage.Damage{{
+			Dice:       "2d4",
+			Type:       damage.Piercing,
+			Properties: []damage.Property{damage.AddsAttackAbilityModifier},
+		}},
+	}
+
+	s.Require().ErrorIs(profile.validate(), ErrBadAttack)
+}
+
+func (s *StrictnessTestSuite) TestMonsterProfileRejectsAbilityModifier() {
+	profile := AttackProfile{
+		Ref:             refs.MonsterActions.Bite(),
+		AbilityModifier: 2,
+		Damage:          []damage.Damage{{Dice: "2d4", Type: damage.Piercing, FlatBonus: 2}},
+	}
+
+	s.Require().ErrorIs(profile.validate(), ErrBadAttack)
 }
 
 func TestStrictnessSuite(t *testing.T) {

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -63,16 +63,14 @@ type AttackProfile struct {
 	// AttackBonus is added to the d20.
 	AttackBonus int
 
-	// DamageDice is the weapon pool's notation ("2d4+2").
-	DamageDice string
-
-	// DamageType is what kind of harm lands.
-	DamageType damage.Type
+	// Damage is the ordered set of canonical damage pools declared by the
+	// weapon or monster action. Dice notation remains pure NdM; intrinsic
+	// arithmetic stays in each pool's FlatBonus.
+	Damage []damage.Damage
 
 	// AbilityUsed is the ability the compiler swung with, when it chose one.
 	//
-	// It carries no arithmetic — the modifier is already inside DamageDice —
-	// and exists because effects predicate on it. Rage's damage bonus applies
+	// Effects predicate on this field. Rage's damage bonus applies
 	// only to melee attacks made with Strength, so it reads this off the
 	// folded damage event; with the field empty its predicate never matches
 	// and a raging character silently loses the bonus. Measured, not assumed:
@@ -86,6 +84,12 @@ type AttackProfile struct {
 	// This is the field the attack-profile seam named as additive when a
 	// predicate finally needed it (docs/ideas/session-sdk/attack-profile-seam.md).
 	AbilityUsed abilities.Ability
+
+	// AbilityModifier is the arithmetic selected by a character compiler. It
+	// stays separate from canonical dice and intrinsic monster flat bonuses so
+	// resolution can attribute it to the one marked pool. Monster profiles keep
+	// this at zero.
+	AbilityModifier int
 
 	// Gate is the rider's contest, if the attack declares one (ADR-0039).
 	// Nil means the attack just hits.
@@ -120,8 +124,34 @@ func (p *AttackProfile) validate() error {
 	if p.Ref == nil {
 		return fmt.Errorf("%w: the attack names no ref", ErrBadAttack)
 	}
-	if p.DamageDice == "" {
-		return fmt.Errorf("%w: the attack declares no damage dice", ErrBadAttack)
+	if err := damage.Validate(p.Damage); err != nil {
+		return fmt.Errorf("%w: invalid attack damage: %w", ErrBadAttack, err)
+	}
+
+	abilityMarkers := 0
+	for _, pool := range p.Damage {
+		for _, property := range pool.Properties {
+			if property == damage.AddsAttackAbilityModifier {
+				abilityMarkers++
+			}
+		}
+	}
+
+	if p.AbilityUsed != "" {
+		if abilityMarkers != 1 {
+			return fmt.Errorf(
+				"%w: ability %q requires exactly one %q damage pool",
+				ErrBadAttack, p.AbilityUsed, damage.AddsAttackAbilityModifier)
+		}
+	} else {
+		if p.AbilityModifier != 0 {
+			return fmt.Errorf("%w: an attack with no ability cannot carry ability modifier %+d", ErrBadAttack, p.AbilityModifier)
+		}
+		if abilityMarkers != 0 {
+			return fmt.Errorf(
+				"%w: an attack with no ability cannot mark a %q damage pool",
+				ErrBadAttack, damage.AddsAttackAbilityModifier)
+		}
 	}
 
 	// A gate with nothing riding on it is refused rather than run. The
@@ -180,6 +210,14 @@ type StrikeOutcome struct {
 	// Damage is what was dealt. Zero on a miss.
 	Damage int
 
+	// DamageInstances are the typed amounts that landed after the damage fold
+	// and multiplier arithmetic. Empty on a miss.
+	DamageInstances []damage.Instance
+
+	// DamageComponents are the folded source-attributed components from which
+	// DamageInstances were calculated. Empty on a miss.
+	DamageComponents []dnd5eEvents.DamageComponent
+
 	// Contest is the interaction that gated the blow's rider, when the action
 	// declared one and the blow landed. Nil when the action carries no gate,
 	// and nil on a miss — a strike that misses rolls no save.
@@ -198,11 +236,23 @@ func (StrikeOutcome) isOutcome() {}
 // what the reaction windows of ADR-0027 will need, and why they can be added
 // without rebuilding this. They are not here: reactions are wave 5.
 func NewStrike(in *StrikeInput) Machine {
-	return &strikeMachine{in: in}
+	return &strikeMachine{
+		in: in,
+		applyDamage: func(
+			ctx context.Context, target combat.Combatant, input *combat.ApplyDamageInput,
+		) *combat.ApplyDamageResult {
+			return target.ApplyDamage(ctx, input)
+		},
+	}
 }
 
 type strikeMachine struct {
 	in *StrikeInput
+
+	// applyDamage is the one target-application boundary. Keeping it as a
+	// dependency lets tests count calls while delegating to the real combatant;
+	// NewStrike always installs the direct production behavior.
+	applyDamage func(context.Context, combat.Combatant, *combat.ApplyDamageInput) *combat.ApplyDamageResult
 
 	// cast is the sheets this interaction attached, kept because a phase after
 	// the first needs them and a step's closure is handed only a bus.
@@ -344,72 +394,161 @@ func (m *strikeMachine) afterAttackChain(ctx context.Context, folded dnd5eEvents
 	}
 	m.outcome.Critical = m.outcome.Hit && roll >= folded.CriticalThreshold
 
-	if !m.outcome.Hit {
-		// A miss ends the strike here: no damage, and no save. The rider the
-		// action declares is gated on the blow landing, so a bite that misses
-		// rolls no save (rpg-toolkit#962's residual).
-		return Done{Outcome: m.outcome}, nil
+	// PostAttackRollChain is the reaction boundary for both hits and misses.
+	// Shield and rage-attempt subscribers need the actual d20 result before
+	// phase two can decide damage, so publish it before the miss short-circuit.
+	postRoll := &dnd5eEvents.PostAttackRollEvent{
+		AttackerID:          m.outcome.AttackerID,
+		TargetID:            m.outcome.TargetID,
+		OriginalAC:          folded.TargetAC,
+		AttackRoll:          roll,
+		AttackBonus:         folded.AttackBonus,
+		TotalAttack:         m.outcome.Total,
+		WouldHit:            m.outcome.Hit,
+		IsNaturalTwenty:     roll == 20,
+		IsNaturalOne:        roll == 1,
+		HasAdvantage:        hasAdvantage,
+		HasDisadvantage:     hasDisadvantage,
+		AdvantageSources:    attackModifierRefs(folded.AdvantageSources),
+		DisadvantageSources: attackModifierRefs(folded.DisadvantageSources),
 	}
 
-	return m.rollDamage(ctx, roller)
+	return publishPostAttackRoll(postRoll, func(nextCtx context.Context) (Step, error) {
+		if !m.outcome.Hit {
+			// A miss ends the strike here: no damage, and no save. The rider the
+			// action declares is gated on the blow landing, so a bite that misses
+			// rolls no save (rpg-toolkit#962's residual).
+			return Done{Outcome: m.outcome}, nil
+		}
+
+		return m.rollDamage(nextCtx, roller)
+	}), nil
+}
+
+// attackModifierRefs projects the richer attack-chain source records onto the
+// post-roll snapshot's established reference-only narration contract. The
+// strike fold owns source reasons/IDs; the older post-roll event intentionally
+// exposes only refs, so no source metadata is duplicated across that boundary.
+func attackModifierRefs(sources []dnd5eEvents.AttackModifierSource) []*core.Ref {
+	refs := make([]*core.Ref, 0, len(sources))
+	for _, source := range sources {
+		refs = append(refs, source.SourceRef)
+	}
+	return refs
 }
 
 // rollDamage rolls the action's damage dice and yields the fold that lets
 // effects modify it (ADR-0026's Resolve).
 func (m *strikeMachine) rollDamage(ctx context.Context, roller dice.Roller) (Step, error) {
-	pool, err := dice.ParseNotation(m.in.Attack.DamageDice)
+	components := make([]dnd5eEvents.DamageComponent, 0, len(m.in.Attack.Damage)+1)
+	var primary *damage.Damage
+	for i := range m.in.Attack.Damage {
+		declared := &m.in.Attack.Damage[i]
+		component, err := m.rollDamageComponent(ctx, roller, *declared)
+		if err != nil {
+			return nil, err
+		}
+		components = append(components, component)
+
+		if declared.HasProperty(damage.AddsAttackAbilityModifier) {
+			primary = declared
+		}
+	}
+
+	if primary != nil {
+		components = append(components, dnd5eEvents.DamageComponent{
+			Source:     dnd5eEvents.DamageSourceAbility,
+			SourceRef:  attackAbilityRef(m.in.Attack.AbilityUsed),
+			FlatBonus:  m.in.Attack.AbilityModifier,
+			DamageType: primary.Type,
+			IsCritical: false,
+		})
+	}
+
+	effectiveAdvantage := len(m.outcome.Folded.AdvantageSources) > 0 &&
+		len(m.outcome.Folded.DisadvantageSources) == 0
+	var weaponDamageDice string
+	var weaponDamageType damage.Type
+	if primary != nil {
+		weaponDamageDice = primary.Dice
+		weaponDamageType = primary.Type
+	}
+
+	return foldDamage(dnd5eEvents.NewDamageChainEvent(dnd5eEvents.DamageChainInput{
+		AttackerID:       m.in.AttackerID,
+		TargetID:         m.in.TargetID,
+		Components:       components,
+		IsCritical:       m.outcome.Critical,
+		HasAdvantage:     effectiveAdvantage,
+		WeaponDamageDice: weaponDamageDice,
+		WeaponDamageType: weaponDamageType,
+		IsMelee:          true,
+		// Which ability swung, for the effects that predicate on it — Rage
+		// only pays out on a melee Strength attack. Empty when the compiler
+		// named none, which is a stat block's honest answer.
+		AbilityUsed:     m.in.Attack.AbilityUsed,
+		AbilityModifier: m.in.Attack.AbilityModifier,
+		WeaponRef:       m.in.Attack.Ref,
+	}), m.afterDamageChain), nil
+}
+
+func (m *strikeMachine) rollDamageComponent(
+	ctx context.Context, roller dice.Roller, declared damage.Damage,
+) (dnd5eEvents.DamageComponent, error) {
+	pool, err := dice.ParseNotation(declared.Dice)
 	if err != nil {
-		return nil, fmt.Errorf("%w: damage dice %q: %w", ErrBadAttack, m.in.Attack.DamageDice, err)
+		return dnd5eEvents.DamageComponent{}, fmt.Errorf(
+			"%w: damage dice %q: %w", ErrBadAttack, declared.Dice, err)
 	}
 
 	result := pool.RollContext(ctx, roller)
 	if result.Error() != nil {
-		return nil, fmt.Errorf("roll damage: %w", result.Error())
+		return dnd5eEvents.DamageComponent{}, fmt.Errorf("roll damage: %w", result.Error())
 	}
 
-	// Per-die, not summed: OriginalDiceRolls/FinalDiceRolls are a per-die
-	// contract — downstream rerolls address dice by index — and the
-	// notation's static modifier is not a die, so it rides FlatBonus and is
-	// never doubled.
+	// Per-die, not summed: downstream rerolls address dice by index. Intrinsic
+	// arithmetic stays in FlatBonus and is therefore never part of a critical
+	// hit's second roll.
 	rolls := flattenDice(result.Rolls())
-
-	// A critical hit doubles the weapon pool's DICE and nothing else
-	// (ADR-0036: only the weapon pool doubles, and a flat modifier is not a
-	// die). Combat's fold records IsCritical but rolls nothing, so the
-	// doubling happens here, where the dice are.
-	if m.outcome.Critical {
+	isCritical := m.outcome.Critical && !declared.HasProperty(damage.DoesNotCrit)
+	if isCritical {
 		again := pool.RollContext(ctx, roller)
 		if again.Error() != nil {
-			return nil, fmt.Errorf("roll critical damage: %w", again.Error())
+			return dnd5eEvents.DamageComponent{}, fmt.Errorf("roll critical damage: %w", again.Error())
 		}
 		rolls = append(rolls, flattenDice(again.Rolls())...)
 	}
 
-	component := dnd5eEvents.DamageComponent{
+	return dnd5eEvents.DamageComponent{
 		Source:            dnd5eEvents.DamageSourceWeapon,
 		SourceRef:         m.in.Attack.Ref,
+		Dice:              declared.Dice,
 		OriginalDiceRolls: rolls,
 		FinalDiceRolls:    append([]int(nil), rolls...),
-		FlatBonus:         result.Modifier(),
-		DamageType:        m.in.Attack.DamageType,
-		IsCritical:        m.outcome.Critical,
-	}
+		FlatBonus:         declared.FlatBonus,
+		DamageType:        declared.Type,
+		Properties:        append([]damage.Property(nil), declared.Properties...),
+		IsCritical:        isCritical,
+	}, nil
+}
 
-	return foldDamage(&dnd5eEvents.DamageChainEvent{
-		AttackerID:   m.in.AttackerID,
-		TargetID:     m.in.TargetID,
-		Components:   []dnd5eEvents.DamageComponent{component},
-		DamageType:   m.in.Attack.DamageType,
-		IsCritical:   m.outcome.Critical,
-		HasAdvantage: len(m.outcome.Folded.AdvantageSources) > 0,
-		WeaponDamage: m.in.Attack.DamageDice,
-		IsMelee:      true,
-		// Which ability swung, for the effects that predicate on it — Rage
-		// only pays out on a melee Strength attack. Empty when the compiler
-		// named none, which is a stat block's honest answer.
-		AbilityUsed: m.in.Attack.AbilityUsed,
-		WeaponRef:   m.in.Attack.Ref,
-	}, m.afterDamageChain), nil
+func attackAbilityRef(ability abilities.Ability) *core.Ref {
+	switch ability {
+	case abilities.STR:
+		return refs.Abilities.Strength()
+	case abilities.DEX:
+		return refs.Abilities.Dexterity()
+	case abilities.CON:
+		return refs.Abilities.Constitution()
+	case abilities.INT:
+		return refs.Abilities.Intelligence()
+	case abilities.WIS:
+		return refs.Abilities.Wisdom()
+	case abilities.CHA:
+		return refs.Abilities.Charisma()
+	default:
+		return nil
+	}
 }
 
 // afterDamageChain applies what the fold settled on — bus-free, straight onto
@@ -432,17 +571,23 @@ func (m *strikeMachine) afterDamageChain(
 	// than a copy that can drift.
 	final, _ := combat.FinalDamage(folded.Components)
 
+	m.outcome.DamageInstances = make([]damage.Instance, 0, len(final))
 	instances := make([]combat.DamageInstance, 0, len(final))
 	for _, instance := range final {
+		m.outcome.DamageInstances = append(m.outcome.DamageInstances, damage.Instance{
+			Amount: instance.Amount,
+			Type:   instance.Type,
+		})
 		instances = append(instances, combat.DamageInstance{
 			Amount: instance.Amount,
 			Type:   string(instance.Type),
 		})
 	}
+	m.outcome.DamageComponents = append([]dnd5eEvents.DamageComponent(nil), folded.Components...)
 
 	// Bus-free, and the only phase that is: applying damage is the sheet's own
 	// business and takes no bus on either a character or a monster.
-	applied := target.ApplyDamage(ctx, &combat.ApplyDamageInput{
+	applied := m.applyDamage(ctx, target, &combat.ApplyDamageInput{
 		Instances:  instances,
 		IsCritical: m.outcome.Critical,
 	})
@@ -540,55 +685,44 @@ func AttackFromMonsterAction(action monster.ActionData) (AttackProfile, error) {
 // attackFromMelee compiles a stat-block weapon — MeleeConfig is the profile's
 // shape already, and a plain weapon declares no gate: the blow just lands.
 func attackFromMelee(action monster.ActionData) (AttackProfile, error) {
+	if _, err := monsterActions.LoadAction(action); err != nil {
+		return AttackProfile{}, fmt.Errorf("%w: invalid melee action: %w", ErrBadAttack, err)
+	}
+
 	var config monsterActions.MeleeConfig
-	if len(action.Config) > 0 {
-		if err := json.Unmarshal(action.Config, &config); err != nil {
-			return AttackProfile{}, fmt.Errorf("%w: %w", ErrBadAttack, err)
-		}
-	}
-
-	if config.DamageDice == "" {
-		return AttackProfile{}, fmt.Errorf("%w: the action declares no damage dice", ErrBadAttack)
-	}
-
-	ref := action.Ref
-
-	return AttackProfile{
-		Ref:         &ref,
-		AttackBonus: config.AttackBonus,
-		DamageDice:  config.DamageDice,
-		DamageType:  config.DamageType,
-	}, nil
-}
-
-func attackFromBite(action monster.ActionData) (AttackProfile, error) {
-	var config monsterActions.BiteConfig
-	if len(action.Config) > 0 {
-		if err := json.Unmarshal(action.Config, &config); err != nil {
-			return AttackProfile{}, fmt.Errorf("%w: %w", ErrBadAttack, err)
-		}
-	}
-
-	if config.DamageDice == "" {
-		return AttackProfile{}, fmt.Errorf("%w: the action declares no damage dice", ErrBadAttack)
+	if err := json.Unmarshal(action.Config, &config); err != nil {
+		return AttackProfile{}, fmt.Errorf("%w: %w", ErrBadAttack, err)
 	}
 
 	ref := action.Ref
 	profile := AttackProfile{
 		Ref:         &ref,
 		AttackBonus: config.AttackBonus,
-		DamageDice:  config.DamageDice,
-		DamageType:  config.DamageType,
-		Gate:        config.SaveGate,
+		Damage:      copyDamagePools(config.Damage),
+	}
+	if err := profile.validate(); err != nil {
+		return AttackProfile{}, err
 	}
 
-	// A bite persisted by an older build carries a bare knockdown DC rather
-	// than a gate; NewBiteAction is what translates it, so the profile comes
-	// through the action rather than the config when the gate is absent.
-	if profile.Gate == nil {
-		if bite, ok := mustLoadBite(action); ok {
-			profile.Gate = bite.SaveGate()
-		}
+	return profile, nil
+}
+
+func attackFromBite(action monster.ActionData) (AttackProfile, error) {
+	if _, err := monsterActions.LoadAction(action); err != nil {
+		return AttackProfile{}, fmt.Errorf("%w: invalid bite action: %w", ErrBadAttack, err)
+	}
+
+	var config monsterActions.BiteConfig
+	if err := json.Unmarshal(action.Config, &config); err != nil {
+		return AttackProfile{}, fmt.Errorf("%w: %w", ErrBadAttack, err)
+	}
+
+	ref := action.Ref
+	profile := AttackProfile{
+		Ref:         &ref,
+		AttackBonus: config.AttackBonus,
+		Damage:      copyDamagePools(config.Damage),
+		Gate:        config.SaveGate,
 	}
 
 	// A bite's gate is a KNOCKDOWN — that is what the stat block's
@@ -603,22 +737,21 @@ func attackFromBite(action monster.ActionData) (AttackProfile, error) {
 	if profile.Gate != nil {
 		profile.Imposes = ImposeCondition(refs.Conditions.Prone(), dnd5eEvents.ConditionProne)
 	}
+	if err := profile.validate(); err != nil {
+		return AttackProfile{}, err
+	}
 
 	return profile, nil
 }
 
-// mustLoadBite reconstitutes the action so its own loader can apply whatever
-// translation the content needs. Failure is not fatal: the numbers are already
-// decoded, and only the gate would be missing.
-func mustLoadBite(action monster.ActionData) (*monsterActions.BiteAction, bool) {
-	loaded, err := monsterActions.LoadAction(action)
-	if err != nil {
-		return nil, false
+func copyDamagePools(pools []damage.Damage) []damage.Damage {
+	copy := make([]damage.Damage, len(pools))
+	for i, pool := range pools {
+		copy[i] = pool
+		copy[i].Properties = append([]damage.Property(nil), pool.Properties...)
 	}
 
-	bite, ok := loaded.(*monsterActions.BiteAction)
-
-	return bite, ok
+	return copy
 }
 
 // combatantFor finds a participant's sheet as something that can be hit.
@@ -688,6 +821,29 @@ func gatherAttack(
 			}
 
 			return next(ctx, folded)
+		},
+	}
+}
+
+// publishPostAttackRoll runs the post-roll reaction chain on the interaction's
+// bus. It deliberately executes for misses as well as hits: subscribers such
+// as Rage record an attack attempt, while Shield simply ignores misses.
+func publishPostAttackRoll(
+	event *dnd5eEvents.PostAttackRollEvent,
+	next func(context.Context) (Step, error),
+) Gather {
+	return Gather{
+		name: "post attack roll",
+		run: func(ctx context.Context, bus events.EventBus) (Step, error) {
+			chain := events.NewStagedChain[*dnd5eEvents.PostAttackRollEvent](combat.ModifierStages)
+			modified, err := dnd5eEvents.PostAttackRollChain.On(bus).PublishWithChain(ctx, event, chain)
+			if err != nil {
+				return nil, fmt.Errorf("publish post attack roll: %w", err)
+			}
+			if _, err := modified.Execute(ctx, event); err != nil {
+				return nil, fmt.Errorf("execute post attack roll: %w", err)
+			}
+			return next(ctx)
 		},
 	}
 }

--- a/rulebooks/dnd5e/resolution/strike_test.go
+++ b/rulebooks/dnd5e/resolution/strike_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
@@ -391,7 +392,7 @@ func (s *StrikeTestSuite) TestTheStrikeRunsInPieces() {
 	for i := 0; i < 10; i++ {
 		switch typed := step.(type) {
 		case Done:
-			s.Require().Equal([]string{"attack chain", "damage chain"}, names,
+			s.Require().Equal([]string{"attack chain", "post attack roll", "damage chain"}, names,
 				"every phase boundary was a value this test drove by hand")
 
 			outcome, ok := typed.Outcome.(StrikeOutcome)
@@ -420,6 +421,35 @@ func (s *StrikeTestSuite) TestTheStrikeRunsInPieces() {
 	}
 
 	s.Require().Fail("the machine did not finish")
+}
+
+func (s *StrikeTestSuite) TestStrikePublishesPostAttackRollForSubscribers() {
+	bus := events.NewEventBus()
+	var got *dnd5eEvents.PostAttackRollEvent
+	_, err := dnd5eEvents.PostAttackRollChain.On(bus).SubscribeWithChain(s.ctx,
+		func(_ context.Context, event *dnd5eEvents.PostAttackRollEvent,
+			c chain.Chain[*dnd5eEvents.PostAttackRollEvent],
+		) (chain.Chain[*dnd5eEvents.PostAttackRollEvent], error) {
+			copy := *event
+			got = &copy
+			return c, nil
+		})
+	s.Require().NoError(err)
+
+	_, err = s.resolveWith(bus, s.world(spatial.Position{X: 8, Y: 5}), s.hero(),
+		NewStrike(&StrikeInput{
+			AttackerID: wolfID,
+			TargetID:   heroID,
+			Attack:     s.wolfAttack(),
+			Roller:     &sequenceRoller{singles: []int{hitRoll}, fallback: 2},
+		}))
+	s.Require().NoError(err)
+	s.Require().NotNil(got)
+	s.Require().Equal(wolfID, got.AttackerID)
+	s.Require().Equal(heroID, got.TargetID)
+	s.Require().Equal(hitRoll, got.AttackRoll)
+	s.Require().Equal(14, got.OriginalAC)
+	s.Require().True(got.WouldHit)
 }
 
 // Damage lands exactly once. It is applied to the sheet directly, and NOT
@@ -459,7 +489,7 @@ func (s *StrikeTestSuite) TestRefusesAStrikeItCannotRun() {
 	world := s.world(spatial.Position{X: 8, Y: 5})
 
 	s.Run("an action this build cannot read is refused at compilation", func() {
-		_, err := AttackFromMonsterAction(monster.ActionData{Ref: *refs.MonsterActions.Scimitar()})
+		_, err := AttackFromMonsterAction(monster.ActionData{Ref: *refs.MonsterActions.Melee()})
 		s.Require().ErrorIs(err, ErrBadAttack)
 	})
 
@@ -624,6 +654,264 @@ func (s *StrikeTestSuite) TestANaturalTwentyDoublesTheDiceNotTheModifier() {
 	s.Require().True(outcome.Critical)
 	s.Require().Equal(3+4+1+2+2, outcome.Damage,
 		"four dice for the crit, the modifier exactly once")
+}
+
+func (s *StrikeTestSuite) resolveProfile(
+	profile AttackProfile, roller dice.Roller,
+) (*Output, error) {
+	return s.resolve(s.world(spatial.Position{X: 8, Y: 5}), s.hero(), NewStrike(&StrikeInput{
+		AttackerID: wolfID,
+		TargetID:   heroID,
+		Attack:     profile,
+		Roller:     roller,
+	}))
+}
+
+func oozeProfile(pools ...damage.Damage) AttackProfile {
+	return AttackProfile{
+		Ref:         refs.MonsterActions.Melee(),
+		AttackBonus: 4,
+		Damage:      pools,
+	}
+}
+
+func (s *StrikeTestSuite) TestTwoPoolsUseOneFoldAndOneApplication() {
+	bus := events.NewEventBus()
+	damageGathers := 0
+	_, err := dnd5eEvents.DamageChain.On(bus).SubscribeWithChain(s.ctx,
+		func(_ context.Context, _ *dnd5eEvents.DamageChainEvent,
+			c chain.Chain[*dnd5eEvents.DamageChainEvent],
+		) (chain.Chain[*dnd5eEvents.DamageChainEvent], error) {
+			damageGathers++
+			return c, nil
+		})
+	s.Require().NoError(err)
+
+	profile := oozeProfile(
+		damage.Damage{Dice: "1d8", Type: damage.Bludgeoning, FlatBonus: 2},
+		damage.Damage{Dice: "1d6", Type: damage.Acid},
+	)
+	machine := NewStrike(&StrikeInput{
+		AttackerID: wolfID,
+		TargetID:   heroID,
+		Attack:     profile,
+		Roller:     scripted(15, 4, 5),
+	}).(*strikeMachine)
+	applyDamageCalls := 0
+	machine.applyDamage = func(
+		ctx context.Context, target combat.Combatant, input *combat.ApplyDamageInput,
+	) *combat.ApplyDamageResult {
+		applyDamageCalls++
+		return target.ApplyDamage(ctx, input)
+	}
+
+	out, err := s.resolveWith(bus, s.world(spatial.Position{X: 8, Y: 5}), s.hero(), machine)
+	s.Require().NoError(err)
+
+	struck := s.strikeOutcome(out)
+	s.Equal(11, struck.Damage)
+	s.Len(struck.DamageInstances, 2)
+	s.Len(struck.DamageComponents, 2)
+	s.Equal(1, damageGathers, "all pools travel through one damage fold")
+	s.Equal(1, applyDamageCalls, "all typed instances enter one target application")
+	s.Require().Len(out.DirtyCharacters, 1)
+	s.Equal(14-11, out.DirtyCharacters[0].HitPoints,
+		"the folded instances land together in one application")
+}
+
+func (s *StrikeTestSuite) TestSameTypePoolsExposeMarkedPrimaryMetadata() {
+	bus := events.NewEventBus()
+	var captured dnd5eEvents.DamageChainEvent
+	damageGathers := 0
+	_, err := dnd5eEvents.DamageChain.On(bus).SubscribeWithChain(s.ctx,
+		func(_ context.Context, event *dnd5eEvents.DamageChainEvent,
+			c chain.Chain[*dnd5eEvents.DamageChainEvent],
+		) (chain.Chain[*dnd5eEvents.DamageChainEvent], error) {
+			damageGathers++
+			captured = *event
+			return c, nil
+		})
+	s.Require().NoError(err)
+
+	profile := AttackProfile{
+		Ref:             refs.Weapons.Shortsword(),
+		AttackBonus:     5,
+		AbilityUsed:     abilities.DEX,
+		AbilityModifier: 3,
+		Damage: []damage.Damage{
+			{Dice: "1d4", Type: damage.Piercing},
+			{
+				Dice:       "1d6",
+				Type:       damage.Piercing,
+				Properties: []damage.Property{damage.AddsAttackAbilityModifier},
+			},
+		},
+	}
+	out, err := s.resolveWith(bus, s.world(spatial.Position{X: 8, Y: 5}), s.hero(), NewStrike(&StrikeInput{
+		AttackerID: wolfID,
+		TargetID:   heroID,
+		Attack:     profile,
+		Roller:     scripted(15, 2, 4),
+	}))
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+
+	s.Equal(1, damageGathers)
+	s.Require().Len(captured.Components, 3)
+	s.Equal("1d6", captured.Components[1].Dice,
+		"primary notation remains on the marked component, not the event envelope")
+	s.Equal(damage.Piercing, captured.Components[1].DamageType)
+	s.Equal("1d6", captured.WeaponDamageDice,
+		"the event carries the marked primary notation for inheriting features")
+	s.Equal(damage.Piercing, captured.WeaponDamageType,
+		"the event carries the marked primary type for inheriting features")
+}
+
+func (s *StrikeTestSuite) TestCriticalDoublesEveryEligiblePoolButNoFlatBonus() {
+	profile := oozeProfile(
+		damage.Damage{Dice: "1d8", Type: damage.Bludgeoning, FlatBonus: 2},
+		damage.Damage{Dice: "1d6", Type: damage.Acid},
+	)
+	out, err := s.resolveProfile(profile, scripted(20, 4, 5, 6, 3))
+	s.Require().NoError(err)
+
+	struck := s.strikeOutcome(out)
+	s.Equal(20, struck.Damage)
+	s.Require().Len(struck.DamageComponents, 2)
+	s.Equal([]int{4, 5}, struck.DamageComponents[0].FinalDiceRolls)
+	s.Equal([]int{6, 3}, struck.DamageComponents[1].FinalDiceRolls)
+	s.True(struck.DamageComponents[0].IsCritical)
+	s.True(struck.DamageComponents[1].IsCritical)
+}
+
+func (s *StrikeTestSuite) TestDoesNotCritPoolRollsOnlyOnce() {
+	profile := oozeProfile(
+		damage.Damage{Dice: "1d8", Type: damage.Bludgeoning},
+		damage.Damage{Dice: "1d6", Type: damage.Acid, Properties: []damage.Property{damage.DoesNotCrit}},
+	)
+	roller := scripted(20, 4, 5, 6)
+	out, err := s.resolveProfile(profile, roller)
+	s.Require().NoError(err)
+
+	struck := s.strikeOutcome(out)
+	s.Equal(15, struck.Damage)
+	s.Require().Len(struck.DamageComponents, 2)
+	s.Equal([]int{4, 5}, struck.DamageComponents[0].FinalDiceRolls)
+	s.True(struck.DamageComponents[0].IsCritical)
+	s.Equal([]int{6}, struck.DamageComponents[1].FinalDiceRolls)
+	s.False(struck.DamageComponents[1].IsCritical)
+	s.Empty(roller.values, "the non-critical pool consumed no second roll")
+}
+
+func (s *StrikeTestSuite) TestTypedOutcomeMarksTheExactAbilityPool() {
+	profile := AttackProfile{
+		Ref:             refs.Weapons.Shortsword(),
+		AttackBonus:     5,
+		AbilityUsed:     abilities.DEX,
+		AbilityModifier: 3,
+		Damage: []damage.Damage{
+			{Dice: "1d4", Type: damage.Piercing},
+			{
+				Dice:       "1d6",
+				Type:       damage.Piercing,
+				Properties: []damage.Property{damage.AddsAttackAbilityModifier},
+			},
+		},
+	}
+	out, err := s.resolveProfile(profile, scripted(15, 2, 4))
+	s.Require().NoError(err)
+
+	struck := s.strikeOutcome(out)
+	s.Equal(9, struck.Damage)
+	s.Equal([]damage.Instance{{Amount: 9, Type: damage.Piercing}}, struck.DamageInstances)
+	s.Require().Len(struck.DamageComponents, 3)
+	s.Equal("1d4", struck.DamageComponents[0].Dice)
+	s.Empty(struck.DamageComponents[0].Properties)
+	s.Equal(0, struck.DamageComponents[0].FlatBonus)
+	s.Equal("1d6", struck.DamageComponents[1].Dice)
+	s.Equal([]damage.Property{damage.AddsAttackAbilityModifier}, struck.DamageComponents[1].Properties)
+	s.Equal(0, struck.DamageComponents[1].FlatBonus)
+	s.Equal(dnd5eEvents.DamageSourceAbility, struck.DamageComponents[2].Source)
+	s.Equal(refs.Abilities.Dexterity(), struck.DamageComponents[2].SourceRef)
+	s.Equal(damage.Piercing, struck.DamageComponents[2].DamageType)
+	s.Equal(3, struck.DamageComponents[2].FlatBonus)
+	s.False(struck.DamageComponents[2].IsCritical)
+}
+
+func (s *StrikeTestSuite) TestInvalidProfileConsumesNoRandomness() {
+	roller := scripted(15, 4)
+	_, err := s.resolveProfile(oozeProfile(
+		damage.Damage{Dice: "1d8", Type: damage.Bludgeoning},
+		damage.Damage{Dice: "1d6+2", Type: damage.Acid},
+	), roller)
+
+	s.Require().ErrorIs(err, ErrBadAttack)
+	s.Zero(roller.rolls)
+}
+
+func (s *StrikeTestSuite) TestCanceledAdvantageRollsStraightAndDoesNotGrantSneakAttack() {
+	sneak, err := conditions.NewSneakAttackCondition(conditions.SneakAttackInput{
+		CharacterID: heroID,
+		Level:       1,
+	}).ToJSON()
+	s.Require().NoError(err)
+
+	bus := events.NewEventBus()
+	_, err = dnd5eEvents.AttackChain.On(bus).SubscribeWithChain(s.ctx,
+		func(_ context.Context, _ dnd5eEvents.AttackChainEvent,
+			c chain.Chain[dnd5eEvents.AttackChainEvent],
+		) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
+			err := c.Add(combat.StageConditions, "canceled_advantage",
+				func(_ context.Context, event dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
+					event.AdvantageSources = append(event.AdvantageSources, dnd5eEvents.AttackModifierSource{
+						SourceRef: refs.Conditions.Helped(),
+					})
+					event.DisadvantageSources = append(event.DisadvantageSources, dnd5eEvents.AttackModifierSource{
+						SourceRef: refs.Conditions.Dodging(),
+					})
+					return event, nil
+				})
+			return c, err
+		})
+	s.Require().NoError(err)
+
+	profile := AttackProfile{
+		Ref:             refs.Weapons.Shortsword(),
+		AttackBonus:     5,
+		AbilityUsed:     abilities.DEX,
+		AbilityModifier: 3,
+		Damage: []damage.Damage{{
+			Dice:       "1d6",
+			Type:       damage.Piercing,
+			Properties: []damage.Property{damage.AddsAttackAbilityModifier},
+		}},
+	}
+	roller := scripted(15, 4)
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		World: s.world(spatial.Position{X: 8, Y: 5}),
+		Participants: []Participant{
+			{Character: s.hero(sneak)},
+			{Monster: s.wolf(wolfID)},
+			{Monster: s.wolf(secondWolfID)},
+		},
+		Machine: NewStrike(&StrikeInput{
+			AttackerID: heroID,
+			TargetID:   wolfID,
+			Attack:     profile,
+			Roller:     roller,
+		}),
+	}, newSurface(bus))
+	s.Require().NoError(err)
+
+	struck := s.strikeOutcome(out)
+	s.Equal(15, struck.Roll, "advantage and disadvantage cancel to one d20")
+	s.Require().Len(struck.Folded.AdvantageSources, 1)
+	s.Require().Len(struck.Folded.DisadvantageSources, 1)
+	s.Equal(7, struck.Damage)
+	for _, component := range struck.DamageComponents {
+		s.NotEqual(refs.Features.SneakAttack(), component.SourceRef,
+			"canceled advantage alone cannot satisfy Sneak Attack")
+	}
 }
 
 // wolfAttack compiles the catalog wolf's bite into the neutral profile the

--- a/rulebooks/dnd5e/resolution/testrollers_test.go
+++ b/rulebooks/dnd5e/resolution/testrollers_test.go
@@ -1,8 +1,48 @@
 package resolution
 
 import (
+	"context"
+	"fmt"
+
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 )
+
+// queuedRoller consumes one shared queue across Roll and RollN. Damage-pool
+// tests use it to prove the exact amount and order of randomness a strike
+// consumes rather than giving every dice API a reusable fallback answer.
+type queuedRoller struct {
+	values []int
+	rolls  int
+}
+
+func scripted(values ...int) *queuedRoller {
+	return &queuedRoller{values: append([]int(nil), values...)}
+}
+
+func (r *queuedRoller) Roll(_ context.Context, sides int) (int, error) {
+	values, err := r.take(1, sides)
+	if err != nil {
+		return 0, err
+	}
+
+	return values[0], nil
+}
+
+func (r *queuedRoller) RollN(_ context.Context, count, sides int) ([]int, error) {
+	return r.take(count, sides)
+}
+
+func (r *queuedRoller) take(count, sides int) ([]int, error) {
+	if len(r.values) < count {
+		return nil, fmt.Errorf("scripted roller exhausted: need %d d%d, have %d values", count, sides, len(r.values))
+	}
+
+	out := append([]int(nil), r.values[:count]...)
+	r.values = r.values[count:]
+	r.rolls += count
+
+	return out, nil
+}
 
 // orderAsGiven is the deterministic InitiativeRoller every fixture wires.
 //


### PR DESCRIPTION
## Summary

- compile character weapons and canonical monster actions into validated typed `AttackProfile` values
- roll every damage pool, honor per-pool critical eligibility, and preserve typed instances in `StrikeOutcome`
- execute one staged damage fold and apply the aggregate exactly once
- propagate effective advantage correctly after advantage/disadvantage cancellation
- populate narrow primary-weapon metadata from the marked pool for provider rules

## Dependency boundary

This resolution-only PR consumes the released D&D provider `v0.97.0`. It contains no provider, session, or frozen top-level encounter changes and uses no local replace/workspace directives. Session integration will follow after CI publishes the resolution module tag.

## Verification

- `go test -count=1 ./...`
- `go test -race ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `bash scripts/check-no-legacy-attack.sh`
- `git diff --check`
- resolution-only scope and no-replace checks
