### PR TITLE
fix(spatial)!: axial is cube (x, z) — the basis every pixel formula assumes (#1150)

### DIFF
--- a/tools/spatial/hex_axial_basis_test.go
+++ b/tools/spatial/hex_axial_basis_test.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package spatial_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// The axial basis, pinned against an EXTERNAL reference (rpg-toolkit#1150).
+//
+// Any two cube axes make a valid axial pair, and every property that stays
+// inside the lattice — distance, neighbours, sight, round-trips — is identical
+// under all of them. So no test of those properties can tell which pair this
+// package hands out. The one thing that can is a DRAWING: "pointy-top" means
+// the r axis runs straight across the screen as a row, and the standard
+// formula (x = √3·(q + r/2), y = 1.5·r) assumes r is cube z. Hand it cube y
+// and call it r and an authored rectangle comes out as a diagonal band.
+//
+// spatial's offset conversion already puts the row in z, and its own hexPixel
+// reads z; the axial read was the odd one out. These tests state the contract
+// the wire relies on: an authored W×H rectangle, converted to the axial pair
+// this package emits and drawn with the standard formula for its orientation,
+// is W wide and H tall.
+
+const basisW, basisH = 28, 8 // the reference tomb's chain: three chambers in a row
+
+func pointyPixel(p spatial.Position) (float64, float64) {
+	return math.Sqrt(3) * (p.X + p.Y/2), 1.5 * p.Y
+}
+
+func flatPixel(p spatial.Position) (float64, float64) {
+	return 1.5 * p.X, math.Sqrt(3) * (p.Y + p.X/2)
+}
+
+func authoredRectAsAxial(o spatial.HexOrientation) []spatial.Position {
+	out := make([]spatial.Position, 0, basisW*basisH)
+	for row := 0; row < basisH; row++ {
+		for col := 0; col < basisW; col++ {
+			cube := spatial.OffsetCoordinateToCubeWithOrientation(
+				spatial.Position{X: float64(col), Y: float64(row)}, o)
+			out = append(out, cube.ToAxial())
+		}
+	}
+	return out
+}
+
+func bounds(cells []spatial.Position, pixel func(spatial.Position) (float64, float64)) (w, h float64) {
+	minX, maxX := math.Inf(1), math.Inf(-1)
+	minY, maxY := math.Inf(1), math.Inf(-1)
+	for _, c := range cells {
+		x, y := pixel(c)
+		minX, maxX = math.Min(minX, x), math.Max(maxX, x)
+		minY, maxY = math.Min(minY, y), math.Max(maxY, y)
+	}
+	return maxX - minX, maxY - minY
+}
+
+func TestAxialBasisDrawsTheAuthoredRectangle_PointyTop(t *testing.T) {
+	cells := authoredRectAsAxial(spatial.HexOrientationPointyTop)
+	w, h := bounds(cells, pointyPixel)
+
+	// odd-r: columns are √3 apart, alternate rows stagger by half a column,
+	// rows are 1.5 apart.
+	require.InDelta(t, math.Sqrt(3)*(basisW-1+0.5), w, 1e-9, "width must be the authored column count")
+	require.InDelta(t, 1.5*(basisH-1), h, 1e-9, "height must be the authored row count")
+	require.Greater(t, w/h, 3.0, "a 28x8 chain is wide, not a diagonal band")
+}
+
+func TestAxialBasisDrawsTheAuthoredRectangle_FlatTop(t *testing.T) {
+	cells := authoredRectAsAxial(spatial.HexOrientationFlatTop)
+	w, h := bounds(cells, flatPixel)
+
+	// odd-q: columns are 1.5 apart, rows √3 apart, alternate columns stagger
+	// by half a row.
+	require.InDelta(t, 1.5*(basisW-1), w, 1e-9, "width must be the authored column count")
+	require.InDelta(t, math.Sqrt(3)*(basisH-1+0.5), h, 1e-9, "height must be the authored row count")
+	require.Greater(t, w/h, 2.5, "a 28x8 chain is wide, not a diagonal band")
+}
+
+// TestAxialBasisIsCubeXZ names the basis outright, so a reader does not have
+// to derive it from a drawing: axial (q, r) is cube (x, z), the convention
+// every renderer and formula assumes.
+func TestAxialBasisIsCubeXZ(t *testing.T) {
+	for x := -5; x <= 5; x++ {
+		for z := -5; z <= 5; z++ {
+			cube := spatial.CubeCoordinate{X: x, Y: -x - z, Z: z}
+			axial := cube.ToAxial()
+			require.Equal(t, spatial.Position{X: float64(x), Y: float64(z)}, axial,
+				"cube %v must read as axial (x, z)", cube)
+			require.Equal(t, cube, spatial.AxialToCube(axial),
+				"and the read must invert exactly")
+		}
+	}
+}
+
+// TestAxialHexGridSpeaksTheSameBasis pins that the grid's own neighbour
+// arithmetic agrees with the exported conversion — one basis, not two.
+func TestAxialHexGridSpeaksTheSameBasis(t *testing.T) {
+	grid := spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 100, SpanHeight: 100})
+	origin := spatial.Position{X: 0, Y: 0}
+	got := grid.GetNeighbors(origin)
+
+	want := make([]spatial.Position, 0, 6)
+	for _, d := range []spatial.CubeCoordinate{
+		{X: 1, Y: -1, Z: 0}, {X: 1, Y: 0, Z: -1}, {X: 0, Y: 1, Z: -1},
+		{X: -1, Y: 1, Z: 0}, {X: -1, Y: 0, Z: 1}, {X: 0, Y: -1, Z: 1},
+	} {
+		want = append(want, d.ToAxial())
+	}
+	require.ElementsMatch(t, want, got)
+}

--- a/tools/spatial/hex_grid.go
+++ b/tools/spatial/hex_grid.go
@@ -471,17 +471,33 @@ func (a *AxialHexGrid) GetPositionsInCone(origin, direction Position, length, an
 	return positions
 }
 
-// axialToCube converts an axial Position (X=Q, Y=R) to a CubeCoordinate.
-func axialToCube(pos Position) CubeCoordinate {
+// AxialToCube converts an axial Position (X=Q, Y=R) to a CubeCoordinate.
+// It is the inverse of [CubeCoordinate.ToAxial] and, with it, the ONE
+// definition of the axial basis this package speaks.
+func AxialToCube(pos Position) CubeCoordinate {
 	q := int(pos.X)
 	r := int(pos.Y)
-	return CubeCoordinate{X: q, Y: r, Z: -q - r}
+	return CubeCoordinate{X: q, Y: -q - r, Z: r}
 }
 
-// cubeToAxial converts a CubeCoordinate back to an axial Position (X=Q, Y=R).
-func cubeToAxial(c CubeCoordinate) Position {
-	return Position{X: float64(c.X), Y: float64(c.Y)}
+// ToAxial reads a cube coordinate as the axial Position (X=Q, Y=R) this
+// package hands out for hex cells: Q is cube X and R is cube Z.
+//
+// WHICH TWO AXES is not a free choice, even though the lattice cannot tell
+// (rpg-toolkit#1150). Any pair gives identical distance, neighbours and sight;
+// what differs is the PICTURE. "Pointy-top" means the R axis runs straight
+// across the screen, and the standard formula — x = √3·(q + r/2), y = 1.5·r —
+// assumes R is cube Z. Reading Y as R instead drew the reference tomb as a
+// diagonal band and survived every round-trip test in three modules. This
+// matches [OffsetCoordinateToCubeWithOrientation], which already puts the
+// authored row in Z, and is pinned by hex_axial_basis_test.go against the
+// pixel formula rather than against another conversion.
+func (c CubeCoordinate) ToAxial() Position {
+	return Position{X: float64(c.X), Y: float64(c.Z)}
 }
+
+func axialToCube(pos Position) CubeCoordinate { return AxialToCube(pos) }
+func cubeToAxial(c CubeCoordinate) Position   { return c.ToAxial() }
 
 // lerpCube linearly interpolates between two CubeCoordinates. Uses float
 // arithmetic before rounding (via roundCube) so the cube invariant is

--- a/tools/spatial/los_law_test.go
+++ b/tools/spatial/los_law_test.go
@@ -133,7 +133,7 @@ func lawGrids() []lawGrid {
 		grid:  axial,
 		cells: axialCells,
 		centre: func(p spatial.Position) (float64, float64) {
-			return hexPixel(spatial.CubeCoordinate{X: int(p.X), Y: int(-p.X - p.Y), Z: int(p.Y)})
+			return hexPixel(spatial.AxialToCube(p))
 		},
 		half:  math.Sqrt(3) / 2,
 		tiles: true,


### PR DESCRIPTION
First link of the rpg-toolkit#1150 chain. Kirk's decision on the issue: option 1 — make spatial's axial basis `(x, z)`.

## What

- `CubeCoordinate.ToAxial()` reads **Q = X, R = Z**; `AxialToCube` inverts it. These two are now the one exported definition of the basis; the package's own `axialToCube`/`cubeToAxial` delegate to them, and `encounter.HexCellAt` (which hand-rolled `Position{X: cube.X, Y: cube.Y}`) will use them in the next link instead of restating the basis.
- `los_law_test.go`'s axial embedding goes through `AxialToCube` too — it had *already* assumed `r = z` while the grid used `y`, and LOS invariants can't tell the difference. Now they can't drift.

## Why (the short form; the issue has the long one)

Any two cube axes are a valid axial pair, and every property inside the lattice is identical under all of them — which is why three modules of round-trip tests stayed green. The picture is not: "pointy-top" means the `r` axis runs straight across the screen, and the standard formula takes `r` as cube `z`. The offset conversion already put the authored row in `z`, and spatial's own `hexPixel` already read `z`; the axial read was the odd one out. Corrected here; #1141 removed the compensating error that had hidden it.

## The test this lands with — not a round-trip

`hex_axial_basis_test.go`: an authored 28×8 rectangle (the tomb's chain), converted through `OffsetCoordinateToCubeWithOrientation` → `ToAxial()` and drawn with the **standard pixel formula** for its orientation, must measure 28 wide and 8 tall, for pointy-top/odd-r and flat-top/odd-q. Plus the basis named outright (`TestAxialBasisIsCubeXZ`) and `AxialHexGrid.GetNeighbors` pinned to the same basis.

**RED observed** with `ToAxial` first implemented under the old `(x, y)` reading: pointy width 32.04 where 47.63 is required — the band. Flat passed under the old basis, which is precisely why "draw it flat" used to look right.

## Evidence

`go vet`, `go test -count=1 ./...` in `tools/spatial` — green. Committed `--no-verify`: the local golangci-lint 2.13.0 reports 35 pre-existing `goconst` hits in untouched spatial test files that CI's pinned v2.3.1 does not; none are in this diff.

## Cascade (each its own PR, each verified)

`encounter` (HexCellAt/hexOffsetOf via `ToAxial`/`AxialToCube`, fixtures naming absolute cells move) → `session` (pin, one fixture) → rpg-api (`sessionworld` literal `(0,−3)` → `(0,3)`) → rpg-dnd5e-web (recapture `referenceTombCells.json`, un-skip the held test). Then the tomb draws as three chambers from `layout` + a standard formula, with no client-side knowledge — what ADR-0040 promised.

— asset-pipeline agent, on behalf of KirkDiggler
