### PR TITLE
docs(adr): renumber composable attack damage to ADR-0041 — 0040 collided with #1147

### DIFF
--- a/docs/adr/0036-additional-damage-selective-crit.md
+++ b/docs/adr/0036-additional-damage-selective-crit.md
@@ -4,7 +4,7 @@ Date: 2026-01-20
 
 ## Status
 
-Superseded by [ADR-0040](0040-composable-attack-damage.md)
+Superseded by [ADR-0041](0041-composable-attack-damage.md)
 
 Companion to [ADR-0026: Damage Application via Event Chain](0026-damage-application-via-event-chain.md).
 

--- a/docs/adr/0041-composable-attack-damage.md
+++ b/docs/adr/0041-composable-attack-damage.md
@@ -1,4 +1,4 @@
-# ADR-0040: Composable Attack Damage
+# ADR-0041: Composable Attack Damage
 
 Date: 2026-08-20
 

--- a/docs/adr/DECISIONS.md
+++ b/docs/adr/DECISIONS.md
@@ -79,10 +79,10 @@ because this directory's `README.md` index silently drifted to listing 7 of 37.
 - **0032** — The character package's dispatch is canonical; the encounter
   delegates rather than building a parallel registry. *Rule: default to one
   system.*
-- **0036** *(superseded by [0040-composable-attack-damage.md](0040-composable-attack-damage.md))* —
+- **0036** *(superseded by [0041-composable-attack-damage.md](0041-composable-attack-damage.md))* —
   The proposed selective-critical variant is historical; it does not describe
   the current attack damage rules.
-- **0040** — Attack damage is an ordered collection of typed pools. Exactly one
+- **0041** — Attack damage is an ordered collection of typed pools. Exactly one
   pool receives the attack ability modifier; every eligible attack die,
   including Sneak Attack, doubles on a critical unless that pool explicitly has
   `DoesNotCrit`. Resolution rolls pools, folds one chain, and applies once.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -24,7 +24,7 @@ Each ADR follows this structure:
 **See [DECISIONS.md](DECISIONS.md)** — the cliffnotes digest of every decision,
 one or two lines each, with the rule it generalises to.
 
-The accepted composable attack-damage rules are recorded in [ADR-0040](0040-composable-attack-damage.md),
+The accepted composable attack-damage rules are recorded in [ADR-0041](0041-composable-attack-damage.md),
 which supersedes ADR-0036's selective-critical proposal.
 
 Read that instead of this directory. Thirty-plus ADRs is a large context load and


### PR DESCRIPTION
Two PRs merged on the same day both claimed **ADR-0040**: #1147 (`0040-atlas-carries-render-layout.md`) and #1146 (`0040-composable-attack-damage.md`). `scripts/check-decisions.sh` now fails on `main` — every open PR shows a red `docs-decisions` job (first seen on #1151).

#1147 landed first, so the attack-damage ADR becomes **0041**. Changed: the file name and title, `docs/adr/README.md`'s pointer, ADR-0036's "Superseded by" note, and the `DECISIONS.md` entry. No content changes. `check-decisions.sh`: 42/42 green.

Docs only; no module directory touched, so the auto-tagger has nothing to tag.

— asset-pipeline agent, on behalf of KirkDiggler