### PR TITLE
fix(encounter)!: hex cells in the (x, z) axial basis — delegate to spatial, hexRuns asks instead of decides (#1150)

### DIFF
--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -132,7 +132,7 @@ func bruteForceLocalCells(shape spatial.GridShape, width, height int) []spatial.
 			for row := 0; row < height; row++ {
 				cube := spatial.OffsetCoordinateToCubeWithOrientation(
 					spatial.Position{X: float64(col), Y: float64(row)}, spatial.HexOrientationPointyTop)
-				cells = append(cells, spatial.Position{X: float64(cube.X), Y: float64(cube.Y)})
+				cells = append(cells, cube.ToAxial())
 			}
 		}
 

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -246,8 +246,7 @@ func (p *continuityProjector) locate(member, verb string, absolute spatial.Posit
 // sharing a mistake. What it may borrow is tools/spatial's conversion, which
 // belongs to neither side of that comparison.
 func hexOffsetOfCell(cell spatial.Position) (col, row int) {
-	q, r := int(cell.X), int(cell.Y)
-	offset := spatial.CubeCoordinate{X: q, Y: r, Z: -q - r}.
+	offset := spatial.AxialToCube(cell).
 		ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
 	return int(offset.X), int(offset.Y)
 }
@@ -432,29 +431,31 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	// boundary is invisible in world space.
 	require.Equal(t, []string{
 		// EVERY ABSOLUTE HERE MOVED when rpg-toolkit#1141 corrected the hex
-		// offset schemes, and every AUTHORED one stayed put -- corridor(6,5)
-		// is still corridor(6,5). That split is the reassuring part: the scene
+		// offset schemes, and again when rpg-toolkit#1150 corrected the axial
+		// basis itself (Q is cube X, R is cube Z, not cube Y) -- every
+		// AUTHORED cell stayed put throughout both fixes: corridor(6,5) is
+		// still corridor(6,5). That split is the reassuring part: the scene
 		// plays out identically and only the projection underneath it changed.
 		//
 		// The continuity this test is named for still holds and is still what
 		// the comparison enforces: one authored cell projects to ONE absolute
-		// cell everywhere in the story. corridor(9,5) is absolute(7,-12) for
-		// alice and for the goblin; vault(0,5) is absolute(8,-13) at both
+		// cell everywhere in the story. corridor(9,5) is absolute(7,5) for
+		// alice and for the goblin; vault(0,5) is absolute(8,5) at both
 		// arrivals and at the goblin's outcome; vault(0,6) survives a reload
 		// unchanged.
-		"alice start: corridor(6,5) -> absolute(4,-9)",
-		"goblin start: corridor(9,4) -> absolute(7,-11)",
-		"alice move: corridor(7,5) -> absolute(5,-10)",
-		"alice move: corridor(8,5) -> absolute(6,-11)",
-		"alice move: corridor(9,5) -> absolute(7,-12)",
-		"alice arrive via gate: vault(0,5) -> absolute(8,-13)",
-		"alice move: vault(0,6) -> absolute(7,-13)",
-		"alice reload checkpoint: vault(0,6) -> absolute(7,-13)",
-		"goblin move: corridor(9,5) -> absolute(7,-12)",
-		"goblin arrive via gate: vault(0,5) -> absolute(8,-13)",
-		"alice move: vault(1,6) -> absolute(8,-14)",
-		"alice move: vault(2,6) -> absolute(9,-15)",
-		"alice outcome: vault(2,6) -> absolute(9,-15)",
-		"goblin outcome: vault(0,5) -> absolute(8,-13)",
+		"alice start: corridor(6,5) -> absolute(4,5)",
+		"goblin start: corridor(9,4) -> absolute(7,4)",
+		"alice move: corridor(7,5) -> absolute(5,5)",
+		"alice move: corridor(8,5) -> absolute(6,5)",
+		"alice move: corridor(9,5) -> absolute(7,5)",
+		"alice arrive via gate: vault(0,5) -> absolute(8,5)",
+		"alice move: vault(0,6) -> absolute(7,6)",
+		"alice reload checkpoint: vault(0,6) -> absolute(7,6)",
+		"goblin move: corridor(9,5) -> absolute(7,5)",
+		"goblin arrive via gate: vault(0,5) -> absolute(8,5)",
+		"alice move: vault(1,6) -> absolute(8,6)",
+		"alice move: vault(2,6) -> absolute(9,6)",
+		"alice outcome: vault(2,6) -> absolute(9,6)",
+		"goblin outcome: vault(0,5) -> absolute(8,5)",
 	}, proj.transcript, "the story IS the projected continuity, told in order")
 }

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -126,7 +126,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 	// because sight stopped at a room boundary. That makes the golden strictly
 	// richer: it is the one place the bubbles array and intel's holdings are
 	// pinned as exact bytes.
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTMsInkiOjZ9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotNSwieSI6LTJ9","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"opaque","orientation":"pointy"},"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","props":[{"ref":"test:props:rubble","at":{"x":1,"y":2},"blocks_movement":true,"blocks_line_of_sight":true}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-2,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":7,"y":3},"to_position":{"x":0,"y":3}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-5,"y":-2}},{"id":"p1","kind":"player","cell":{"x":-13,"y":6}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTMsInkiOjd9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotNSwieSI6N30=","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":4,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"opaque","orientation":"pointy"},"rooms":[{"id":"crypt","width":8,"height":8,"grid":"hex","props":[{"ref":"test:props:rubble","at":{"x":1,"y":2},"blocks_movement":true,"blocks_line_of_sight":true}],"boundaries":[{"from":{"x":2,"y":2},"to":{"x":2,"y":3},"blocks_movement":true,"blocks_line_of_sight":true}],"origin":{"x":-10,"y":7}},{"id":"hall","width":6,"height":6,"grid":"hex","origin":{"x":-2,"y":7}}],"connections":[{"id":"door1","from":"crypt","to":"hall","from_position":{"x":7,"y":3},"to_position":{"x":0,"y":3}}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-5,"y":7}},{"id":"p1","kind":"player","cell":{"x":-13,"y":7}}],"endings":[{"key":"guarded","kind":"reached_position","room":"crypt","position":{"x":3,"y":3},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
 	s.Equal(expected, string(bs))
 }
 
@@ -1908,20 +1908,26 @@ func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 	})
 
 	s.Run("its far corner accepted", func() {
-		// authored [3,2] — the last column of the last row
-		s.Require().NoError(load(encounter.PositionData{X: 3, Y: -4}))
+		// authored [3,2] — the last column of the last row. Moved again with
+		// rpg-toolkit#1150 (axial R is cube Z, not cube Y).
+		s.Require().NoError(load(encounter.PositionData{X: 2, Y: 2}))
 	})
 
-	s.Run("a negative R inside it accepted", func() {
-		// authored [0,2]. A negative absolute coordinate is ordinary: the
+	s.Run("a negative Q inside it accepted", func() {
+		// authored [0,2]. Renamed from "a negative R" (rpg-toolkit#1150): for
+		// pointy-top under the fixed basis R IS the authored row exactly, so
+		// nothing in a room anchored at row 0 can ever produce a negative R —
+		// it is Q that staggers negative instead. The point survives the
+		// rename unchanged: a negative absolute coordinate is ordinary, the
 		// conversion from offset to axial produces them for almost every
-		// chamber, and the reference tomb's own R values run -21 to 0.
-		s.Require().NoError(load(encounter.PositionData{X: 0, Y: -2}))
+		// chamber, and the reference tomb's own Q values run negative too.
+		s.Require().NoError(load(encounter.PositionData{X: -1, Y: 2}))
 	})
 
 	s.Run("one column past the last rejected", func() {
-		// authored [4,0], which the 4-wide rectangle does not hold
-		err := load(encounter.PositionData{X: 4, Y: -2})
+		// authored [4,0], which the 4-wide rectangle does not hold. Moved
+		// with rpg-toolkit#1150.
+		err := load(encounter.PositionData{X: 4, Y: 0})
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().Contains(err.Error(), "owned by no region")
 	})
@@ -1935,8 +1941,8 @@ func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 	})
 
 	s.Run("one row past the last rejected", func() {
-		// authored [0,3]
-		err := load(encounter.PositionData{X: 0, Y: -3})
+		// authored [0,3]. Moved with rpg-toolkit#1150.
+		err := load(encounter.PositionData{X: -1, Y: 3})
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().Contains(err.Error(), "owned by no region")
 	})
@@ -1964,7 +1970,7 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 			}},
 		},
 		Members: []encounter.MemberData{
-			{ID: "p1", Kind: encounter.KindPlayer, Cell: &encounter.PositionData{X: 1, Y: -2}}, /*ROOM:"hex-a" authored [1,1]*/
+			{ID: "p1", Kind: encounter.KindPlayer, Cell: &encounter.PositionData{X: 1, Y: 1}}, /*ROOM:"hex-a" authored [1,1], moved with rpg-toolkit#1150*/
 		},
 		Endings:     []encounter.EndingData{{Key: "done", Kind: "external"}},
 		EverMembers: []encounter.MemberID{"p1"},
@@ -2585,10 +2591,18 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 	nearSide := atlas.Doorways[0].FromCell
 	farSide := atlas.Doorways[0].ToCell
 
-	// Still worth asserting the compile did something: the absolute cells are
-	// not the authored pairs.
-	s.NotEqual(spatial.Position{X: 9, Y: 1}, nearSide, "authored [9,1] is not its own absolute cell")
-	s.NotEqual(spatial.Position{X: 0, Y: 4}, farSide, "authored [0,4] is not its own absolute cell")
+	// Still worth asserting the compile did something, but NOT by pinning
+	// "the absolute cell differs from the authored pair": rpg-toolkit#1150
+	// found that check coincidentally true under the old, buggy axial basis
+	// and coincidentally FALSE under the fixed one for this exact fixture (row
+	// 1 has zero stagger for pointy-top, so [9,1] compiles to itself) — the
+	// same fragility this test's own comment above warns hardcoded literals
+	// have, just wearing a negative assertion. Adjacency is what a compiled
+	// doorway actually promises (W3) and is basis-invariant, so that is what
+	// this checks instead.
+	canvas, cerr := enc1.Canvas()
+	s.Require().NoError(cerr)
+	s.Equal(1.0, canvas.GetGrid().Distance(nearSide, farSide), "a compiled doorway's two sides are exactly one step apart")
 
 	out1, err := enc1.Step(&encounter.StepInput{Member: "p1", To: farSide})
 	s.Require().NoError(err, "the original encounter accepts the step through the gate")

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -948,12 +948,15 @@ func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 	})
 
 	s.Run("integral negative axial target accepted", func() {
-		// Absolute cells are axial and a negative R is entirely ordinary —
-		// the reference tomb's own run from -21 to 0. What changed in
-		// rpg-toolkit#1127 is which cells a chamber HOLDS, so this names one
-		// it does: the chamber's authored column 2, row 5, which lands on
-		// axial (2,-6).
-		_, err := enc.Step(&encounter.StepInput{Member: "p1", To: spatial.Position{X: 2, Y: -6}})
+		// Absolute cells are axial and a negative Q is entirely ordinary —
+		// the reference tomb's own run includes negative Q throughout. What
+		// changed in rpg-toolkit#1127 is which cells a chamber HOLDS, so this
+		// names one it does: the chamber's authored column 0, row 5, which
+		// lands on axial (-2,5) (rpg-toolkit#1150: for pointy-top R is the
+		// authored row exactly, so a room anchored at row 0 can only ever
+		// produce a negative Q, never a negative R — the axis this test
+		// exercises moved with the basis fix, the point it makes did not).
+		_, err := enc.Step(&encounter.StepInput{Member: "p1", To: spatial.Position{X: -2, Y: 5}})
 		s.Require().NoError(err)
 	})
 }
@@ -985,12 +988,14 @@ func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 	})
 
 	s.Run("integral negative axial position accepted", func() {
-		// The chamber's authored column 0, row 7 — axial (0,-7). See the
-		// Move counterpart for why a negative R is unremarkable.
+		// The chamber's authored column 0, row 7 — axial (-3,7)
+		// (rpg-toolkit#1150 moved this from (0,-7)). See the Move
+		// counterpart for why a negative Q, not R, is what a room anchored
+		// at row 0 can produce, and why that is unremarkable.
 		_, err := enc.Join(&encounter.JoinInput{
 			Member: "p3",
 			Kind:   encounter.KindPlayer,
-			Cell:   spatial.Position{X: 0, Y: -7},
+			Cell:   spatial.Position{X: -3, Y: 7},
 		})
 		s.Require().NoError(err)
 	})

--- a/rulebooks/dnd5e/encounter/go.mod
+++ b/rulebooks/dnd5e/encounter/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/clock v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/rulebooks/dnd5e/encounter/go.sum
+++ b/rulebooks/dnd5e/encounter/go.sum
@@ -10,8 +10,8 @@ github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0 h1:89nU27faMf80JrIJlQeVeYac
 github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0/go.mod h1:BlYgBeigB1mUum7FG8AUxWX32tgBrBLFg4/t//+tSvk=
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q+6k8n0krpcnka+lLyflk=
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0 h1:FqMCjTNi/M/brqwlJvBc70eDx+PqWZ6mZLoJOxxOHJw=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/rulebooks/dnd5e/encounter/hex_axial_basis_test.go
+++ b/rulebooks/dnd5e/encounter/hex_axial_basis_test.go
@@ -1,0 +1,106 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// hex_axial_basis_test.go is this module's own copy of spatial's
+// hex_axial_basis_test.go, aimed at [encounter.HexCellAt] rather than at
+// spatial's exported conversion directly (rpg-toolkit#1150).
+//
+// # Why this module needs its own copy of that test
+//
+// spatial pinning its OWN basis does not pin this module's reading of it.
+// rpg-toolkit#1150 happened exactly because [encounter.HexCellAt] used to
+// rebuild the cube-to-axial conversion by hand instead of calling
+// [spatial.CubeCoordinate.ToAxial] — a second definition of the same basis,
+// silently disagreeing with the first. Every test inside this module that
+// compared HexCellAt's output against ITSELF (round-trips, run-agrees-with-
+// enumeration, region-ownership) stayed green throughout, because a value
+// compared only against its own inverse cannot detect which basis produced
+// it — see TestOffsetAndAxialAgreeWithSpatial's doc comment for the same
+// argument made about spatial's internal consistency. The one thing that
+// can tell the two bases apart is a DRAWING, and only an EXTERNAL reference
+// — the standard pixel formula, not another conversion — counts as one.
+//
+// # What this measures
+//
+// An authored W x H room, projected cell-by-cell through HexCellAt, drawn
+// with the standard formula for its orientation (pointy: x = sqrt(3)*(q +
+// r/2), y = 1.5*r; flat: x = 1.5*q, y = sqrt(3)*(r + q/2)), must measure W
+// columns wide and H rows tall. Under the OLD, buggy basis (axial R read as
+// cube Y instead of cube Z) an authored rectangle draws as a diagonal band
+// instead — narrow and tall regardless of W and H — which is exactly the
+// failure mode #1150 and #1141 before it both produced and both survived
+// every round-trip test in this module. See spatial's
+// hex_axial_basis_test.go for the fuller argument; this file states the
+// same contract one layer up, at the function content actually calls.
+
+const hexBasisW, hexBasisH = 28, 8 // matches spatial's own fixture: the reference tomb's chain
+
+func pointyHexPixel(p spatial.Position) (float64, float64) {
+	return math.Sqrt(3) * (p.X + p.Y/2), 1.5 * p.Y
+}
+
+func flatHexPixel(p spatial.Position) (float64, float64) {
+	return 1.5 * p.X, math.Sqrt(3) * (p.Y + p.X/2)
+}
+
+func authoredRoomAsAxial(o encounter.Orientation) []spatial.Position {
+	out := make([]spatial.Position, 0, hexBasisW*hexBasisH)
+	for row := 0; row < hexBasisH; row++ {
+		for col := 0; col < hexBasisW; col++ {
+			out = append(out, encounter.HexCellAt(o, col, row))
+		}
+	}
+	return out
+}
+
+func hexBounds(cells []spatial.Position, pixel func(spatial.Position) (float64, float64)) (w, h float64) {
+	minX, maxX := math.Inf(1), math.Inf(-1)
+	minY, maxY := math.Inf(1), math.Inf(-1)
+	for _, c := range cells {
+		x, y := pixel(c)
+		minX, maxX = math.Min(minX, x), math.Max(maxX, x)
+		minY, maxY = math.Min(minY, y), math.Max(maxY, y)
+	}
+	return maxX - minX, maxY - minY
+}
+
+// TestHexCellAtDrawsTheAuthoredRoom_PointyTop is the discriminator: a room
+// this module compiled must measure as the rectangle its author drew, not as
+// the rhombus an internally-consistent-but-wrong basis would also draw
+// correctly by its own lights.
+func TestHexCellAtDrawsTheAuthoredRoom_PointyTop(t *testing.T) {
+	cells := authoredRoomAsAxial(encounter.HexesArePointyTop())
+	w, h := hexBounds(cells, pointyHexPixel)
+
+	// odd-r: columns are sqrt(3) apart, alternate rows stagger by half a
+	// column, rows are 1.5 apart.
+	require.InDelta(t, math.Sqrt(3)*(hexBasisW-1+0.5), w, 1e-9, "width must be the authored column count")
+	require.InDelta(t, 1.5*(hexBasisH-1), h, 1e-9, "height must be the authored row count")
+	require.Greater(t, w/h, 3.0, "a 28x8 room is wide, not a diagonal band")
+}
+
+// TestHexCellAtDrawsTheAuthoredRoom_FlatTop is the flat-top counterpart —
+// Kirk's ruling that both orientations are valid means both need the same
+// discriminator.
+func TestHexCellAtDrawsTheAuthoredRoom_FlatTop(t *testing.T) {
+	cells := authoredRoomAsAxial(encounter.HexesAreFlatTop())
+	w, h := hexBounds(cells, flatHexPixel)
+
+	// odd-q: columns are 1.5 apart, rows sqrt(3) apart, alternate columns
+	// stagger by half a row.
+	require.InDelta(t, 1.5*(hexBasisW-1), w, 1e-9, "width must be the authored column count")
+	require.InDelta(t, math.Sqrt(3)*(hexBasisH-1+0.5), h, 1e-9, "height must be the authored row count")
+	require.Greater(t, w/h, 2.5, "a 28x8 room is wide, not a diagonal band")
+}

--- a/rulebooks/dnd5e/encounter/orientation.go
+++ b/rulebooks/dnd5e/encounter/orientation.go
@@ -202,23 +202,27 @@ func orientationName(o Orientation) string {
 // question get born. It is the same function [regionAt] runs backwards.
 //
 // The conversion itself is spatial's, not this module's: offset -> cube through
-// [spatial.OffsetCoordinateToCubeWithOrientation], then cube read as axial with
-// Q = X and R = Y, which is the reading [spatial.AxialHexGrid] uses (its
-// axialToCube derives Z = -Q-R, so the two agree by construction rather than by
-// coincidence — pinned by TestOffsetAndAxialAgreeWithSpatial).
+// [spatial.OffsetCoordinateToCubeWithOrientation], then [spatial.CubeCoordinate.ToAxial]
+// reads the cube as axial — Q is cube X and R is cube Z (rpg-toolkit#1150: the
+// pair every pixel formula and [spatial.AxialHexGrid] assume). This function
+// used to rebuild that reading by hand, X and Y rather than X and Z, which is
+// the bug #1150 fixed: two definitions of the same basis, silently disagreeing.
+// There is now exactly one, and this asks for it — pinned by
+// TestOffsetAndAxialAgreeWithSpatial.
 func HexCellAt(o Orientation, col, row int) spatial.Position {
 	cube := spatial.OffsetCoordinateToCubeWithOrientation(
 		spatial.Position{X: float64(col), Y: float64(row)}, o.spatial())
 
-	return spatial.Position{X: float64(cube.X), Y: float64(cube.Y)}
+	return cube.ToAxial()
 }
 
 // hexOffsetOf is HexCellAt run backwards: the authored [col,row] a
 // dungeon-absolute cell came from.
+//
+// Axial -> cube through [spatial.AxialToCube] — the same exported basis
+// [HexCellAt] reads, run in reverse, rather than a hand-built cube triple.
 func hexOffsetOf(o Orientation, cell spatial.Position) (col, row int) {
-	q, r := int(cell.X), int(cell.Y)
-	offset := spatial.CubeCoordinate{X: q, Y: r, Z: -q - r}.
-		ToOffsetCoordinateWithOrientation(o.spatial())
+	offset := spatial.AxialToCube(cell).ToOffsetCoordinateWithOrientation(o.spatial())
 
 	return int(offset.X), int(offset.Y)
 }
@@ -270,21 +274,28 @@ func footprintHolds(r RoomInput, o Orientation, grid spatial.Grid, cell spatial.
 // intervals intersect in O(1). So the whole disjointness question costs
 // O(Width) or O(Height) rather than O(Width x Height).
 //
-// The key is the coordinate that does NOT shear:
+// The key is the coordinate that does NOT shear — the one [HexCellAt] reports
+// unstaggered for this orientation, under spatial's axial basis (rpg-toolkit#1150:
+// axial Q is cube X, axial R is cube Z):
 //
-//   - FLAT-TOP is odd-q, so Q = col exactly and only R staggers. Key by Q;
-//     for a fixed column, R decreases by exactly one per row, so the run is
-//     [r(row=Height-1), r(row=0)].
-//   - POINTY-TOP is odd-r, so the authored ROW is recoverable as -(Q+R) and
-//     only Q staggers. Key by that; for a fixed row, Q increases by exactly one
-//     per column.
+//   - FLAT-TOP is odd-q, so Q = col exactly and only R staggers. Key by Q; for
+//     a fixed column, R climbs one-for-one with row.
+//   - POINTY-TOP is odd-r, so R = row EXACTLY — the authored row needs no
+//     formula to recover, it IS R — and only Q staggers. Key by R itself; for
+//     a fixed row, Q climbs one-for-one with column.
 //
-// Those two bullets USED TO NAME THE OTHER ORIENTATION, because spatial had the
-// schemes swapped (rpg-toolkit#1141). The arithmetic below is unchanged; which
-// orientation it belongs to is what moved.
+// Neither bullet assumes which DIRECTION an axis moves as its authored
+// coordinate grows; both ends of a run are read from [HexCellAt] and sorted,
+// not derived from a sign this file would otherwise have to predict. That is
+// deliberate: #1141 swapped which orientation these two facts named, and #1150
+// changed the pointy-top key outright (it used to be recovered as -(Q+R), the
+// reading spatial's OLD, buggy axial basis produced; under the fixed basis R
+// already IS the row). A copy of the direction, baked in as which end of
+// HexCellAt's output goes first, is exactly the kind of restatement that broke
+// last time — so this asks HexCellAt twice and orders the answer, rather than
+// deciding in advance which one is smaller.
 //
-// Both facts are read off spatial's own conversion rather than assumed, and
-// pinned by TestRunsAgreeWithEnumeration, which compares this against a full
+// Pinned by TestRunsAgreeWithEnumeration, which compares this against a full
 // cell-by-cell sweep over a spread of shapes and both orientations.
 func hexRuns(r RoomInput, o Orientation) map[int][2]int {
 	runs := make(map[int][2]int, max(r.Width, r.Height))
@@ -294,7 +305,11 @@ func hexRuns(r RoomInput, o Orientation) map[int][2]int {
 		for col := 0; col < r.Width; col++ {
 			top := HexCellAt(o, col+oc, or)
 			bottom := HexCellAt(o, col+oc, r.Height-1+or)
-			runs[int(top.X)] = [2]int{int(bottom.Y), int(top.Y)}
+			lo, hi := int(top.Y), int(bottom.Y)
+			if lo > hi {
+				lo, hi = hi, lo
+			}
+			runs[int(top.X)] = [2]int{lo, hi}
 		}
 
 		return runs
@@ -303,7 +318,11 @@ func hexRuns(r RoomInput, o Orientation) map[int][2]int {
 	for row := 0; row < r.Height; row++ {
 		left := HexCellAt(o, oc, row+or)
 		right := HexCellAt(o, r.Width-1+oc, row+or)
-		runs[-(int(left.X) + int(left.Y))] = [2]int{int(left.X), int(right.X)}
+		lo, hi := int(left.X), int(right.X)
+		if lo > hi {
+			lo, hi = hi, lo
+		}
+		runs[int(left.Y)] = [2]int{lo, hi}
 	}
 
 	return runs
@@ -316,12 +335,16 @@ func hexFootprintBounds(r RoomInput, o Orientation) (qMin, qMax, rMin, rMax int)
 	for key, run := range hexRuns(r, o) {
 		var q0, q1, r0, r1 int
 		if o.Kind() == OrientationFlatTop {
+			// key is the absolute column — Q, unstaggered; the run is R's
+			// interval for that column.
 			q0, q1, r0, r1 = key, key, run[0], run[1]
 		} else {
-			// key is the authored row; the run is a Q interval, and R is
-			// -Q-row on each end.
+			// key is the absolute row, which for pointy-top under the fixed
+			// basis (rpg-toolkit#1150) IS R directly — no formula needed, R
+			// does not vary along a pointy-top row at all. The run is Q's
+			// interval for that row.
 			q0, q1 = run[0], run[1]
-			r0, r1 = -run[1]-key, -run[0]-key
+			r0, r1 = key, key
 		}
 		if first {
 			qMin, qMax, rMin, rMax = q0, q1, r0, r1

--- a/rulebooks/dnd5e/encounter/orientation_internal_test.go
+++ b/rulebooks/dnd5e/encounter/orientation_internal_test.go
@@ -69,15 +69,18 @@ func spreadOfChambers() []RoomInput {
 }
 
 // TestOffsetAndAxialAgreeWithSpatial pins the reading [HexCellAt] takes of
-// spatial's own cube coordinate: Q is cube.X and R is cube.Y.
+// spatial's own cube coordinate: Q is cube.X and R is cube.Z
+// (rpg-toolkit#1150 — [spatial.CubeCoordinate.ToAxial]'s definition, the ONE
+// exported reading this file used to rebuild by hand and get wrong).
 //
 // That is not the only reading available — a cube triple has three components
 // and axial keeps two — and picking the wrong pair produces cells that look
 // plausible and are somewhere else. The check is that spatial's TWO directions
 // agree: the cube it derives from an offset pair must be the cube
-// [spatial.AxialHexGrid] derives from the axial pair this hands it (its
-// axialToCube sets Z = -Q-R). So the two are the same coordinate, by
-// construction rather than by coincidence.
+// [spatial.AxialToCube] derives from the axial pair this hands it. So the two
+// are the same coordinate, by construction rather than by coincidence — and by
+// calling spatial's exported functions on both sides rather than restating
+// either one.
 func TestOffsetAndAxialAgreeWithSpatial(t *testing.T) {
 	for _, o := range bothOrientations() {
 		t.Run(string(o.Kind()), func(t *testing.T) {
@@ -87,8 +90,7 @@ func TestOffsetAndAxialAgreeWithSpatial(t *testing.T) {
 						spatial.Position{X: float64(col), Y: float64(row)}, o.spatial())
 
 					axial := HexCellAt(o, col, row)
-					q, r := int(axial.X), int(axial.Y)
-					fromAxial := spatial.CubeCoordinate{X: q, Y: r, Z: -q - r}
+					fromAxial := spatial.AxialToCube(axial)
 
 					require.Equal(t, fromOffset, fromAxial,
 						"offset [%d,%d]: the cube spatial derives from the pair an author "+
@@ -134,12 +136,14 @@ func TestRunsAgreeWithEnumeration(t *testing.T) {
 				for key, run := range hexRuns(r, o) {
 					require.LessOrEqual(t, run[0], run[1], "a run's interval must be ordered")
 					for v := run[0]; v <= run[1]; v++ {
-						// Mirrors hexRuns' contract, which swapped orientations
-						// when rpg-toolkit#1141 corrected the offset schemes.
+						// Mirrors hexRuns' contract. rpg-toolkit#1141 swapped
+						// which orientation each bullet named; rpg-toolkit#1150
+						// changed the pointy-top key itself — under the fixed
+						// axial basis R IS the authored row, no -(Q+R) needed.
 						if o.Kind() == OrientationFlatTop {
 							expanded[[2]int{key, v}] = true // key is Q, run is R
 						} else {
-							expanded[[2]int{v, -v - key}] = true // key is the row, run is Q
+							expanded[[2]int{v, key}] = true // key is R (the row), run is Q
 						}
 					}
 				}

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -398,7 +398,7 @@ func (s *RegionSuite) TestRegionAtAnswersExactlyWhatTheAuthoredGridWould() {
 		for q := -10; q <= 10; q++ {
 			for r := -10; r <= 10; r++ {
 				cell := spatial.Position{X: float64(q), Y: float64(r)}
-				offset := spatial.CubeCoordinate{X: q, Y: r, Z: -q - r}.
+				offset := spatial.AxialToCube(cell).
 					ToOffsetCoordinateWithOrientation(spatial.HexOrientationPointyTop)
 				col, row := offset.X-origin.X, offset.Y-origin.Y
 				want := col >= 0 && col < 6 && row >= 0 && row < 4


### PR DESCRIPTION
Second link of rpg-toolkit#1150, on top of #1151 (`tools/spatial/v0.11.0`). Pin bumped to the published tag; no replace directives.

## What
- `HexCellAt` returns `cube.ToAxial()`; `hexOffsetOf` goes through `spatial.AxialToCube`. The module no longer restates the basis anywhere — `grep` for `cube.Y`-as-R / hand-built `CubeCoordinate{…}` is empty, including `dungeonspec/`.
- **`hexRuns` needed arithmetic, not just delegation.** Under the new basis `R` runs the other way for flat-top, so its `[bottom, top]` pairing came out reversed and broke the overlap test's ordering. It now asks `HexCellAt` for both ends of every run and sorts them — it cannot silently re-decide direction if the basis ever moves again. (#1143's lesson: a copy that *asks* costs one test; a copy that *decides* costs 148.)
- **Why nothing caught this before, precisely:** four test oracles (`orientation_internal_test`, `continuity_test`, `regions_test`, `atlas_test`) each hand-built `Cube{X:q, Y:r, Z:−q−r}` — comparing `HexCellAt` against a second copy of the same bug. They now call spatial's exported conversion. A pre-existing `dungeonspec` tomb-walk failure ("cannot be moved to position (11,−13)") resolved by itself once `HexCellAt` agreed with `AxialHexGrid.GetNeighbors` — the module had been self-consistent against the old basis and only spatial's own BFS could see the mismatch.
- Fixtures: literals that *are* the point of a test were moved to values measured from the fixed toolkit and say so; a hardcoded `NotEqual(authored, compiled)` sanity check that flipped by coincidence (row 1 has zero pointy stagger) was replaced with the basis-invariant promise a doorway actually makes (`Distance == 1`). Two subtests renamed "negative R" → "negative Q" because under the fixed basis a pointy room anchored at row 0 structurally cannot produce a negative `R`. Golden JSON and the vault-chase transcript updated byte-for-byte.
- Comment sweep: every "Q = X, R = Y" assertion rewritten to name the axis (R is cube Z, the row) and point at `ToAxial` as the one definition. The `S = −(Q+R)` comments in `field.go`/`encounter.go` are basis-agnostic identities and stay.
- New `hex_axial_basis_test.go` at the `HexCellAt` layer: an authored 28×8 room drawn with the standard pixel formula measures 28 wide × 8 tall in both orientations. Not a round-trip.

## Evidence
Against the **published** `tools/spatial v0.11.0`, no replace: `go build`, `go vet` clean; `go test -count=1 ./...` — `encounter`, `cmd/freeroam-workbench`, `dungeonspec` all ok; `golangci-lint` 0 issues. Independently re-verified by the coordinator before opening. Delivered by the `encounter-axial-basis` agent under coordinator review.

## Next
`session` (pin bump; `regionCells` only loops and calls `HexCellAt`, so expect one fixture) → rpg-api `sessionworld` literal `(0,−3)` → `(0,3)` → web recapture and un-skip.

— asset-pipeline agent, on behalf of KirkDiggler
