### PR TITLE
fix(session)!: take the (x, z) axial basis; pin the wire's drawing promise (#1150)

### DIFF
--- a/rulebooks/dnd5e/session/atlas_basis_test.go
+++ b/rulebooks/dnd5e/session/atlas_basis_test.go
@@ -1,0 +1,41 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"math"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+)
+
+// TestAtlasCellsDrawTheAuthoredShape is ADR-0040's promise, checked at the
+// wire it was made for (rpg-toolkit#1150): a client that takes Atlas.Cells as
+// axial (q, r), reads Atlas.Layout, and applies the STANDARD pixel formula for
+// that layout gets the authored picture — with no private knowledge of the
+// toolkit.
+//
+// hexWorld is two 6x6 chambers side by side, authored pointy-top: 12 columns
+// by 6 rows. An external reference (the formula), not a round-trip — the only
+// kind of test that could see the basis this seam used to hand out.
+func (s *ReadTestSuite) TestAtlasCellsDrawTheAuthoredShape() {
+	s.startWith(hexWorld(s.T()))
+	atlas, err := s.mgr.Atlas(context.Background(), &session.AtlasInput{Session: "sess"})
+	s.Require().NoError(err)
+	s.Require().Equal(session.HexLayoutPointyTop, atlas.Layout)
+
+	minX, maxX := math.Inf(1), math.Inf(-1)
+	minY, maxY := math.Inf(1), math.Inf(-1)
+	for _, c := range atlas.Cells {
+		// Pointy-top, circumradius 1: x = √3·(q + r/2), y = 1.5·r.
+		x := math.Sqrt(3) * (c.X + c.Y/2)
+		y := 1.5 * c.Y
+		minX, maxX = math.Min(minX, x), math.Max(maxX, x)
+		minY, maxY = math.Min(minY, y), math.Max(maxY, y)
+	}
+
+	const cols, rows = 12, 6
+	s.InDelta(math.Sqrt(3)*(cols-1+0.5), maxX-minX, 1e-9, "12 authored columns across")
+	s.InDelta(1.5*(rows-1), maxY-minY, 1e-9, "6 authored rows down")
+}

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,9 +9,9 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.27.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,12 +18,12 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0 h1:w+QHwNV8h2WCkF0fNtDQSyVCNFzVGXi8av9sQcOWNQw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.27.0 h1:fLD8SiJ6voh0aDGTYQ2cNQEnru/8h8rMoRW5C7BRvC8=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.27.0/go.mod h1:Fqd/JDv0wXdPqdP0Tf5QBWd3Fu/tSgUU10yh5Hdbjoc=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0 h1:2ElsBctjQGavG+EhUCkEcNBcsCJI2GbgBH0CMU7AOzY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0 h1:ZBHWR+o9pwpTRSEEnkFPDsj+h5htLa8N8Ywhspglc44=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0/go.mod h1:wANmNP7YRPCvm2Qj/EpT0026fSX6TkqLk1xvkkNHF80=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0 h1:FqMCjTNi/M/brqwlJvBc70eDx+PqWZ6mZLoJOxxOHJw=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.10.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=


### PR DESCRIPTION
Third toolkit link of rpg-toolkit#1150, on #1151 (spatial v0.11.0) and #1153 (encounter v0.28.0).

## What
- Pin `rulebooks/dnd5e/encounter` v0.27.0 → **v0.28.0** (lifts `tools/spatial` to v0.11.0). **No code change**: `regionCells` loops and calls `HexCellAt`, so the correction flowed through and the existing suite is green unchanged — the same thing that happened at #1145, for the same reason (a copy that asks, not decides).
- `atlas_basis_test.go` — the promise ADR-0040 made, checked at the wire it was made for: hexWorld's two 6×6 chambers, taken as axial `(q, r)` with `Atlas.Layout` and the **standard** pointy-top formula, measure 12 columns × 6 rows. An external reference, not a round-trip.

## Evidence
- The new test **fails against encounter v0.27.0** (old basis: the chambers draw as a band) and passes against v0.28.0 — verified by temporarily re-pinning, then restoring.
- `go test -count=1 ./...` — session and session-workbench ok. go.mod carries no replace.

## Next
rpg-api: `sessionworld`'s tomb entrance literal `(0,−3)` → `(0,3)` on the pin bump (the projection is borrowed, so only the literal moves) → rpg-dnd5e-web recaptures `referenceTombCells.json`, un-skips the held test, and the tomb draws as three chambers from the wire alone.

— asset-pipeline agent, on behalf of KirkDiggler