### PR TITLE
test(session): pin aggregate strike recording

### DIFF
--- a/rulebooks/dnd5e/session/attack_internal_test.go
+++ b/rulebooks/dnd5e/session/attack_internal_test.go
@@ -16,21 +16,80 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
 )
 
-// TestRecordUsesAggregateFromTypedStrikeOutcome pins the session boundary:
-// resolution may retain typed damage evidence, but session recording writes
-// only the aggregate amount into encounter history.
+type aggregateRecordOrderAsGiven struct{}
+
+func (aggregateRecordOrderAsGiven) RollInitiative(
+	members []encounter.MemberID,
+) ([]encounter.MemberID, error) {
+	return members, nil
+}
+
+type aggregateRecordEveryoneStanding struct{}
+
+func (aggregateRecordEveryoneStanding) Standing(
+	_ []encounter.MemberID,
+) ([]encounter.MemberID, error) {
+	return nil, nil
+}
+
+type aggregateRecordEveryoneSees struct{}
+
+func (aggregateRecordEveryoneSees) Sight(
+	members []encounter.MemberID,
+) (map[encounter.MemberID]int, error) {
+	out := make(map[encounter.MemberID]int, len(members))
+	for _, member := range members {
+		out[member] = 1_000_000
+	}
+	return out, nil
+}
+
+// TestRecordUsesAggregateFromTypedStrikeOutcome pins the session boundary at
+// the real encounter recording seam: resolution may retain typed damage
+// evidence, but the story stores only the aggregate amount.
 func TestRecordUsesAggregateFromTypedStrikeOutcome(t *testing.T) {
 	struck := resolution.StrikeOutcome{
-		Hit:    true,
-		Damage: 9,
+		Roll:     15,
+		Total:    20,
+		TargetAC: 12,
+		Hit:      true,
+		Damage:   9,
 		DamageInstances: []damage.Instance{
 			{Amount: 5, Type: damage.Slashing},
 			{Amount: 4, Type: damage.Fire},
 		},
 	}
 
-	record := recordFor(&AttackInput{Attacker: "alice", Target: "bob"}, struck)
-	require.Equal(t, 9, record.Values[encounter.ValueAmount])
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight:      aggregateRecordEveryoneSees{},
+		Standing:   aggregateRecordEveryoneStanding{},
+		Initiative: aggregateRecordOrderAsGiven{},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 4, Height: 4}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall"},
+			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall"},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	require.NoError(t, err)
+
+	recorded, err := enc.Record(recordFor(
+		&AttackInput{Attacker: "alice", Target: "bob"}, struck,
+	))
+	require.NoError(t, err)
+	require.NotZero(t, recorded.Seq)
+
+	story, err := enc.Story(&encounter.StoryInput{Audience: "bob"})
+	require.NoError(t, err)
+	require.NotEmpty(t, story)
+	require.JSONEq(t,
+		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":9}`,
+		string(story[len(story)-1].Payload),
+		"the persisted encounter record carries the aggregate and no typed damage collection",
+	)
 }
 
 // halfBrokenCharacters writes the first sheet and refuses the second.

--- a/rulebooks/dnd5e/session/attack_internal_test.go
+++ b/rulebooks/dnd5e/session/attack_internal_test.go
@@ -11,8 +11,27 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
 )
+
+// TestRecordUsesAggregateFromTypedStrikeOutcome pins the session boundary:
+// resolution may retain typed damage evidence, but session recording writes
+// only the aggregate amount into encounter history.
+func TestRecordUsesAggregateFromTypedStrikeOutcome(t *testing.T) {
+	struck := resolution.StrikeOutcome{
+		Hit:    true,
+		Damage: 9,
+		DamageInstances: []damage.Instance{
+			{Amount: 5, Type: damage.Slashing},
+			{Amount: 4, Type: damage.Fire},
+		},
+	}
+
+	record := recordFor(&AttackInput{Attacker: "alice", Target: "bob"}, struck)
+	require.Equal(t, 9, record.Values[encounter.ValueAmount])
+}
 
 // halfBrokenCharacters writes the first sheet and refuses the second.
 type halfBrokenCharacters struct {

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -16,12 +16,12 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0 h1:w+QHwNV8h2WCkF0fNtDQSyVCNFzVGXi8av9sQcOWNQw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.96.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0 h1:2ElsBctjQGavG+EhUCkEcNBcsCJI2GbgBH0CMU7AOzY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0 h1:ZBHWR+o9pwpTRSEEnkFPDsj+h5htLa8N8Ywhspglc44=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.10.0/go.mod h1:wANmNP7YRPCvm2Qj/EpT0026fSX6TkqLk1xvkkNHF80=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0 h1:zYz6ikMy5o/i5VBJvxwScLhCLtv2iGGrjDMjDjnwewQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0/go.mod h1:RPfATHgAUVDWhORJqDzuyyeIekh9AGSag+9nu8eQVIk=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## Summary

- pin session to released D&D provider `v0.97.0` and resolution `v0.11.0`
- prove a typed `StrikeOutcome` crosses the session boundary while encounter history persists only aggregate damage
- exercise the real encounter `Record` → `Story` path and assert the exact aggregate JSON payload

## Boundary

Resolution retains typed `DamageInstances` for downstream consumers. Session intentionally stores only `encounter.ValueAmount = struck.Damage`; it does not persist a parallel typed damage collection. No production session APIs changed.

This PR changes only `rulebooks/dnd5e/session/**`, with no local replace or workspace directives. The frozen top-level `encounter/` module remains unchanged.

## Verification

- compile-only session suite
- focused aggregate persistence test with mutation proof
- `go test -count=1 ./...`
- `go test -race ./...`
- `go vet ./...`
- golangci-lint v2.3.1: `0 issues`
- `go mod tidy -diff`
- session-only scope and diff checks
