### PR TITLE
feat(encounter): decode sight payloads into typed positions (ADR-0041, #1157)

### DIFF
--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -31,6 +31,25 @@ type SightPayload struct {
 	Y float64 `json:"y"`
 }
 
+// DecodeSightPayload decodes a sight channel's payload into the dungeon-
+// absolute position it encodes. ok is false when payload does not parse as a
+// SightPayload — the caller is holding testimony from some other channel, or
+// bytes this composition did not produce.
+//
+// This is the seam ADR-0041 asks for: the composition decodes its own
+// encoding rather than handing a caller bytes it would otherwise have to
+// unmarshal itself, re-deriving a shape that was never a contract
+// (rpg-toolkit#1157, and the same argument ADR-0040 already made about
+// Atlas.Layout). session calls this and copies the result into its own Seen;
+// it never reaches into payload with encoding/json on its own.
+func DecodeSightPayload(payload []byte) (spatial.Position, bool) {
+	var p SightPayload
+	if err := json.Unmarshal(payload, &p); err != nil {
+		return spatial.Position{}, false
+	}
+	return spatial.Position{X: p.X, Y: p.Y}, true
+}
+
 // declaredEnding pairs an ending key with its trigger, in Setup order, plus
 // the canvas cell a positional trigger was compiled to.
 //

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -4,6 +4,7 @@
 package encounter
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -42,12 +43,40 @@ type SightPayload struct {
 // (rpg-toolkit#1157, and the same argument ADR-0040 already made about
 // Atlas.Layout). session calls this and copies the result into its own Seen;
 // it never reaches into payload with encoding/json on its own.
+//
+// STRICT on purpose (Copilot review, PR #1158). A plain json.Unmarshal into
+// SightPayload would accept "null" and "{}" as the zero-value position —
+// silently reporting "sight at the origin" for testimony that named no
+// position at all — and would accept the pre-#1044 room-bearing dialect
+// (data.go's refuseRoomLocalSightings), whose extra "room" key
+// encoding/json ignores by default while still parsing x and y as if they
+// were already dungeon-absolute. Both are wrong answers to hand back rather
+// than refuse, so X and Y must both be PRESENT — not merely zero-valued
+// after a no-op decode of "null" or "{}" — and no field beside them, known
+// or not, may appear.
 func DecodeSightPayload(payload []byte) (spatial.Position, bool) {
-	var p SightPayload
-	if err := json.Unmarshal(payload, &p); err != nil {
+	if len(payload) == 0 {
 		return spatial.Position{}, false
 	}
-	return spatial.Position{X: p.X, Y: p.Y}, true
+
+	dec := json.NewDecoder(bytes.NewReader(payload))
+	dec.DisallowUnknownFields()
+
+	var p struct {
+		X *float64 `json:"x"`
+		Y *float64 `json:"y"`
+	}
+	if err := dec.Decode(&p); err != nil {
+		return spatial.Position{}, false
+	}
+	if p.X == nil || p.Y == nil {
+		return spatial.Position{}, false
+	}
+	if dec.More() {
+		return spatial.Position{}, false // trailing data after the one object
+	}
+
+	return spatial.Position{X: *p.X, Y: *p.Y}, true
 }
 
 // declaredEnding pairs an ending key with its trigger, in Setup order, plus

--- a/rulebooks/dnd5e/encounter/sightdecode_test.go
+++ b/rulebooks/dnd5e/encounter/sightdecode_test.go
@@ -42,6 +42,39 @@ func TestDecodeSightPayloadRefusesWhatItDidNotEncode(t *testing.T) {
 	require.False(t, ok)
 }
 
+// TestDecodeSightPayloadRefusesValidJSONThatIsNotASightPayload is the case
+// Copilot's review of this PR named directly: a plain json.Unmarshal into
+// SightPayload treats "null" and "{}" as a no-op, leaving the zero-value
+// position and no error — which reads as "sight at the origin", the exact
+// failure mode DecodeSightPayload exists to prevent. Both must refuse.
+func TestDecodeSightPayloadRefusesValidJSONThatIsNotASightPayload(t *testing.T) {
+	_, ok := encounter.DecodeSightPayload([]byte("null"))
+	require.False(t, ok, `"null" must not decode as (0,0)`)
+
+	_, ok = encounter.DecodeSightPayload([]byte("{}"))
+	require.False(t, ok, `"{}" must not decode as (0,0)`)
+
+	_, ok = encounter.DecodeSightPayload([]byte(`{"x":1}`))
+	require.False(t, ok, "a payload naming only x must not decode with y defaulted to 0")
+
+	_, ok = encounter.DecodeSightPayload([]byte(`{"y":1}`))
+	require.False(t, ok, "a payload naming only y must not decode with x defaulted to 0")
+}
+
+// TestDecodeSightPayloadRefusesTheRoomBearingDialect is the other case
+// Copilot's review named: a sight payload written in the dialect
+// rpg-toolkit#1044 replaced — room-local coordinates alongside a "room" key
+// — must not be reinterpreted as dungeon-absolute just because x and y
+// happen to parse. data.go's refuseRoomLocalSightings refuses this same
+// dialect at load; this function must refuse it too, on the same grounds
+// (Kirk's ruling, 2026-08-17: fail loudly, no migration).
+func TestDecodeSightPayloadRefusesTheRoomBearingDialect(t *testing.T) {
+	legacy := []byte(`{"room":"hall","x":2,"y":5}`)
+
+	_, ok := encounter.DecodeSightPayload(legacy)
+	require.False(t, ok, "an unknown field beside x/y must refuse the whole payload, not decode around it")
+}
+
 // TestDecodeSightPayloadAgreesWithAViewsOwnPayload is item 5 of #1157's
 // testable cases: the typed decode and the raw payload a caller could
 // unmarshal itself must name the same cell, on a real percept the

--- a/rulebooks/dnd5e/encounter/sightdecode_test.go
+++ b/rulebooks/dnd5e/encounter/sightdecode_test.go
@@ -1,0 +1,85 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// sightdecode_test.go is ADR-0041's own half of this module: the composition
+// decodes its own encoding rather than handing session (or any other caller)
+// bytes to unmarshal itself (rpg-toolkit#1157).
+
+// TestDecodeSightPayloadRoundTripsASightPayload pins the ordinary case: bytes
+// this package itself produced decode back to the position they encoded.
+func TestDecodeSightPayloadRoundTripsASightPayload(t *testing.T) {
+	encoded, err := json.Marshal(encounter.SightPayload{X: 10, Y: 3})
+	require.NoError(t, err)
+
+	pos, ok := encounter.DecodeSightPayload(encoded)
+	require.True(t, ok, "a payload this package encoded must decode")
+	require.Equal(t, spatial.Position{X: 10, Y: 3}, pos)
+}
+
+// TestDecodeSightPayloadRefusesWhatItDidNotEncode pins the failure case:
+// bytes that are not a SightPayload come back refused rather than
+// zero-valued and silently accepted, which would let a caller mistake "not
+// sight" for "sight at the origin".
+func TestDecodeSightPayloadRefusesWhatItDidNotEncode(t *testing.T) {
+	_, ok := encounter.DecodeSightPayload([]byte("not a sight payload"))
+	require.False(t, ok)
+
+	_, ok = encounter.DecodeSightPayload(nil)
+	require.False(t, ok)
+}
+
+// TestDecodeSightPayloadAgreesWithAViewsOwnPayload is item 5 of #1157's
+// testable cases: the typed decode and the raw payload a caller could
+// unmarshal itself must name the same cell, on a real percept the
+// composition produced from geometry rather than a literal this test
+// invented.
+func TestDecodeSightPayloadAgreesWithAViewsOwnPayload(t *testing.T) {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: core.EntityID("skeleton-1"), Kind: encounter.KindMonster, Room: "hall",
+				Position: spatial.Position{X: 5, Y: 6}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	require.NoError(t, err)
+
+	view, err := enc.View(&encounter.ViewInput{Member: alice})
+	require.NoError(t, err)
+
+	var holding *intel.Holding
+	for i := range view {
+		if view[i].Subject == intel.Subject("skeleton-1") {
+			holding = &view[i]
+		}
+	}
+	require.NotNil(t, holding, "alice must hold a sighting of the skeleton to test against")
+
+	var raw encounter.SightPayload
+	require.NoError(t, json.Unmarshal(holding.Payload, &raw))
+
+	pos, ok := encounter.DecodeSightPayload(holding.Payload)
+	require.True(t, ok)
+	require.Equal(t, spatial.Position{X: raw.X, Y: raw.Y}, pos,
+		"the typed decode must name the same cell as the raw payload")
+	require.Equal(t, spatial.Position{X: 5, Y: 6}, pos, "and that cell is really where the skeleton stands")
+}


### PR DESCRIPTION
## What

`encounter.DecodeSightPayload(payload []byte) (spatial.Position, bool)` — the composition decodes its own sight-channel encoding, so a caller (session, or any other host) never has to `json.Unmarshal` `SightPayload` bytes itself. This is the first half of ADR-0041 (full ADR + DECISIONS entry land in the session PR, since that is where `Seen` itself lands): `Sighting`/`Report` gain a typed `Seen{Position spatial.Position}`, present exactly when the channel is sight, and the composition — not session — is the one that decodes the bytes into it.

Chose "export a decode function" over retyping `Encounter.View`'s return: smaller, less invasive, and `View` keeps returning `[]intel.Holding` unchanged.

## Testable cases (from #1157)

- [x] `DecodeSightPayload` round-trips a `SightPayload` this package encodes.
- [x] `DecodeSightPayload` refuses bytes it did not encode (garbage, nil) rather than returning a zero-valued position that reads as "sight at the origin".
- [x] The typed decode agrees with what a caller would get unmarshalling `View()`'s raw payload itself, on a real percept (not a literal) — item 5 of #1157's testable cases.

## Evidence

- `go build ./... && go vet ./... && go test ./...` — PASS (`rulebooks/dnd5e/encounter`, its `dungeonspec` and `cmd/freeroam-workbench` subpackages).
- `golangci-lint run ./...` — 0 issues.
- `gofmt -l .` — clean; `go mod tidy` — no diff.
- Full pre-commit hook (format, mod tidy, lint, test) — passed on commit.

Additive, exported-surface-only change: expected `gorelease` verdict is compatible.

## Sequenced with

This is PR A of two for #1157. PR B (`rulebooks/dnd5e/session`) adds `Seen` and wires this decode into `projectSightings`/`projectDiscovery`, and closes #1157; it depends on whatever version this tags as on merge (auto-tag), so B's `go.mod`/CI will be red until this merges — noted in B's own PR body.

Part of #1157

— asset-pipeline agent, on behalf of KirkDiggler
