### PR TITLE
session: Sighting/Report carry typed Seen.Position (ADR-0041, #1157)

### DIFF
--- a/docs/adr/0041-sighting-carries-typed-channel-knowledge.md
+++ b/docs/adr/0041-sighting-carries-typed-channel-knowledge.md
@@ -1,0 +1,116 @@
+# ADR-0041: A sighting carries what its channel knows, typed per channel
+
+Date: 2026-08-22
+
+## Status
+
+Accepted
+
+## Context
+
+`session.Sighting` (and `Report`, the first-contact form of the same fact) hands
+a host `Payload []byte`: "what the observer knows about it, encoded by the
+composition." Today the only channel is `sight`, and the composition
+(`rulebooks/dnd5e/encounter`) encodes `SightPayload{X, Y}` — the sighted
+member's dungeon-absolute cell — as JSON. Session hands the bytes through
+unread (pinned in `onemap_test.go`: intel's testimony is the composition's
+encoding, not session's), and intel stores them opaquely and carries no
+version (`encounter/data.go`, the room-local scar of #1044).
+
+The first real client of `View` on the new stack (rpg-dnd5e-web#762, the 3D
+route) needs the skeleton's position to draw it. The position is on the wire,
+but only as bytes whose shape is a private agreement between one composition
+and whoever reverse-engineers it. That is the situation ADR-0040
+(atlas-carries-render-layout) already ruled on: *a rule a client cannot read
+off the wire gets re-derived by experiment, once per client.* The proposed
+shortcut — decode the JSON in the client behind one function and file the
+proper change later — was rejected on the same grounds: a client dependency on
+a non-contract is drag, and the session SDK's seams exist to stay honest.
+
+More channels are coming (hearing, tremorsense, memory of a last sighting,
+lit vs darkvision distinctions inside sight itself). Each tells the observer a
+different *kind* of thing. Loose optional fields on `Sighting` would not say
+which channel produced them; a single typed `Position` would say nothing about
+why it is there or what else that channel knew.
+
+## Decision
+
+`Sighting` and `Report` gain a typed, channel-keyed sub-struct for each channel
+the session SDK commits to, starting with sight:
+
+```go
+// Seen is what the sight channel knows about a subject. Present exactly when
+// the sighting was produced by sight; nil for every other channel. A memory
+// (CurrentVia empty) keeps the Seen it last had — that is the last-known cell
+// a client draws a faded marker on.
+type Seen struct {
+    Position spatial.Position // dungeon-absolute; one map, no room
+}
+
+type Sighting struct {
+    Subject    string
+    Seen       *Seen   // sight channel's knowledge, typed
+    Payload    []byte  // retained for channels the SDK has not typed
+    Channel    string
+    At         uint64
+    CurrentVia []string
+    Status     string
+}
+```
+
+`Report` carries `Seen` the same way, so first contact and a held sighting
+are the same fact in the same shape.
+
+Mechanics follow ADR-0040 and rule S2: the **composition decodes its own
+encoding** — `encounter` exposes its perception typed (its own view type
+carrying `Position spatial.Position`), and session's projection copies it into
+`Seen`. Session never unmarshals payload bytes; intel stays opaque storage.
+`spatial.Position` is the existing allow-listed value type, so no inner type
+crosses the boundary.
+
+Future channels add their own sub-struct (`Heard`, `Felt`, …) with the facts
+that channel actually conveys. Sight-specific facts that arrive later
+(lighting, distance band, partial cover) go inside `Seen`, not on `Sighting`.
+
+The wire mirrors this: protos add `Seen seen` to `Sighting` and `Report`;
+rpg-api transcribes; clients render from `seen` and never read `payload`.
+
+## Consequences
+
+### Positive
+- The skeleton's cell is a contract, not an experiment. Every client of `View`
+  reads the same typed fact.
+- Channel provenance is in the type: a nil `Seen` on a `sight` sighting is a
+  defect the projection test catches, not a client guess.
+- Room for growth without churn: new channels and new sight facts have a home
+  that does not touch existing fields.
+- Session's passthrough pin survives unchanged; intel's opacity and
+  no-version rule are untouched because the composition does the decoding.
+
+### Negative
+- One more projected field to keep complete (`convert_test.go`'s projected-pairs
+  audit must list `Seen` and justify `Payload`'s retention).
+- Three repos move in sequence (toolkit → protos → rpg-api → web) before the
+  3D route can draw a monster.
+
+### Neutral
+- `Payload` remains on the wire for untyped channels. When every channel has a
+  typed sub-struct it becomes baggage and is removed — no back-compat ceremony
+  (Kirk's 2026-08-15 ruling).
+- The `Sight` capability (range, line of sight, later lighting) is unaffected:
+  this ADR is about how knowledge is *reported*, not how it is *gained*.
+
+## Example
+
+A fighter walks through the entrance-hall doorway; the composition's refresh
+sees `skeleton-1` at (10,3):
+
+```go
+v, _ := mgr.View(ctx, session.ViewInput{Session: s, Member: fighter})
+v.Sightings[0].Subject      // "skeleton-1"
+v.Sightings[0].Channel      // "sight"
+v.Sightings[0].Seen.Position // spatial.Position{X: 10, Y: 3}
+```
+
+A hearing channel, when it exists, would leave `Seen` nil and populate
+`Heard{Direction, Loudness}` — the client draws a sound cue, not a figure.

--- a/docs/adr/0041-sighting-carries-typed-channel-knowledge.md
+++ b/docs/adr/0041-sighting-carries-typed-channel-knowledge.md
@@ -61,12 +61,31 @@ type Sighting struct {
 `Report` carries `Seen` the same way, so first contact and a held sighting
 are the same fact in the same shape.
 
+> **Implementation note, added during #1157/PR #1159 (Copilot review):**
+> `Sighting.Seen` gates on real channel provenance — `intel.Holding` carries a
+> `Channel` field, so `Seen` is nil for anything that is not literally
+> sight-channel testimony. `Report.Seen` cannot do the same today:
+> `intel.Report`/`intel.SurveilOutput` carry no channel of their own — a
+> `Surveil` call is scoped to one channel, but that channel is not threaded
+> onto each `Report` it returns — so `Report.Seen` is populated by decoding
+> the payload and checking whether it parses as a sight payload, not by
+> asking what channel produced it. That is equivalent to the real check only
+> because sight is the only channel any composition in this codebase calls
+> `Surveil` with today. Closing the gap needs `SurveilOutput` (or the percept
+> it is built from) to carry its own channel — a `play/intel` change outside
+> this PR's scope, tracked as a known limitation rather than silently
+> papered over.
+
 Mechanics follow ADR-0040 and rule S2: the **composition decodes its own
-encoding** — `encounter` exposes its perception typed (its own view type
-carrying `Position spatial.Position`), and session's projection copies it into
-`Seen`. Session never unmarshals payload bytes; intel stays opaque storage.
-`spatial.Position` is the existing allow-listed value type, so no inner type
-crosses the boundary.
+encoding** — `encounter` exposes its perception typed, and session's
+projection copies it into `Seen`. Session never unmarshals payload bytes;
+intel stays opaque storage. `spatial.Position` is the existing allow-listed
+value type, so no inner type crosses the boundary.
+
+> *(Shipped as `encounter.DecodeSightPayload(payload []byte) (spatial.Position,
+> bool)` rather than a retyped `View` return — smaller, and `View` keeps
+> returning `[]intel.Holding` unchanged. Either satisfies "the composition
+> decodes its own encoding"; this is the one PR #1158 built.)*
 
 Future channels add their own sub-struct (`Heard`, `Felt`, …) with the facts
 that channel actually conveys. Sight-specific facts that arrive later

--- a/docs/adr/DECISIONS.md
+++ b/docs/adr/DECISIONS.md
@@ -133,6 +133,15 @@ because this directory's `README.md` index silently drifted to listing 7 of 37.
   sharing its name — a client drew the tomb as a staircase because the two
   questions shared one word. *Rule: a wire field is named for the question the
   receiver asks, not the one the author answered.*
+- **[0041-sighting-carries-typed-channel-knowledge.md](0041-sighting-carries-typed-channel-knowledge.md)**
+  (number shared — see Numbering hazards below) — **A sighting carries what
+  its channel knows, typed per channel**: `Sighting`/`Report` gain a typed
+  `Seen{Position spatial.Position}`, present exactly when the channel is
+  sight and nil otherwise; a memory keeps its last `Seen`. The composition
+  decodes its own encoding (`encounter.DecodeSightPayload`) — session never
+  unmarshals a payload itself. *Rule: a rule a client cannot read off the
+  wire gets re-derived by experiment, once per client — the same argument
+  ADR-0040 already made about Atlas.Layout.*
 
 ---
 
@@ -162,6 +171,10 @@ The corpus has collisions. When citing a number, cite the **filename**:
 - **0019 twice** — `0019-environment-orchestrator.md` and
   `0019_dnd5e_module_registry_system.md`, and the second is *titled* "ADR-0014"
   internally.
+- **0041 twice** — `0041-composable-attack-damage.md` (combat) and
+  `0041-sighting-carries-typed-channel-knowledge.md` (session SDK): two
+  unrelated decisions landed in overlapping PR windows and both claimed the
+  next free number before either merged.
 - **0010 is missing.** Never written.
 
 ## Status fields are unreliable

--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -218,6 +218,7 @@ func projectSightings(in []intel.Holding) []Sighting {
 		}
 		out = append(out, Sighting{
 			Subject:    string(h.Subject),
+			Seen:       projectSeen(h.Channel, h.Payload),
 			Payload:    append([]byte(nil), h.Payload...),
 			Channel:    string(h.Channel),
 			At:         h.At,
@@ -226,6 +227,28 @@ func projectSightings(in []intel.Holding) []Sighting {
 		})
 	}
 	return out
+}
+
+// projectSeen copies the sight channel's typed knowledge into Seen (ADR-0041).
+// It is nil for every channel but sight, and nil if a sight-channel payload
+// somehow fails to decode — an impossible state today (the composition is the
+// only writer of sight payloads) that a wrong Position would be worse than
+// admitting to.
+//
+// The decode itself happens in encounter.DecodeSightPayload, not here: this
+// package never calls encoding/json on a payload. h.Channel is intel's own
+// provenance field — a holding's last accepted testimony — so a held memory
+// (CurrentVia empty) still carries the channel and payload that produced it,
+// and still gets a Seen: "a memory keeps its last Seen" (the ADR's words).
+func projectSeen(channel intel.Channel, payload []byte) *Seen {
+	if channel != intel.Sight {
+		return nil
+	}
+	pos, ok := encounter.DecodeSightPayload(payload)
+	if !ok {
+		return nil
+	}
+	return &Seen{Position: pos}
 }
 
 // projectStory drops each entry's audience roster deliberately.
@@ -346,6 +369,7 @@ func projectDiscovery(in *intel.SurveilOutput) Discovery {
 	for _, r := range in.FirstContact {
 		out.FirstContact = append(out.FirstContact, Report{
 			Subject: string(r.Subject),
+			Seen:    projectReportSeen(r.Payload),
 			Payload: append([]byte(nil), r.Payload...),
 		})
 	}
@@ -356,4 +380,29 @@ func projectDiscovery(in *intel.SurveilOutput) Discovery {
 		out.Faded = append(out.Faded, string(s))
 	}
 	return out
+}
+
+// projectReportSeen decodes first-contact's Seen the same way projectSeen
+// does, but cannot gate on channel the way projectSeen does: intel.Report
+// carries no Channel of its own — a SurveilOutput is scoped to the one
+// Channel its Surveil call used, but that channel is not threaded back onto
+// each Report inside it. So this is decode-and-see rather than a channel
+// check.
+//
+// That is equivalent to projectSeen's guard ONLY as long as sight is the only
+// channel any composition surveils with — true today, since rebuildPercepts
+// (encounter.go, refreshSight) is the sole Surveil call site in this
+// codebase and always passes intel.Sight. The day a second channel starts
+// calling Surveil, an undecodable payload here stops meaning "not sight" and
+// starts meaning "channel this SDK has not typed yet OR truly bad bytes" —
+// indistinguishable from here. TestReportSeenIsNilForAPayloadDecodeWouldEatQuietly
+// below documents the risk rather than closing it: closing it needs
+// SurveilOutput (or the percept it is built from) to carry its own channel,
+// which is a play/intel change outside this PR's scope.
+func projectReportSeen(payload []byte) *Seen {
+	pos, ok := encounter.DecodeSightPayload(payload)
+	if !ok {
+		return nil
+	}
+	return &Seen{Position: pos}
 }

--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -395,10 +395,11 @@ func projectDiscovery(in *intel.SurveilOutput) Discovery {
 // codebase and always passes intel.Sight. The day a second channel starts
 // calling Surveil, an undecodable payload here stops meaning "not sight" and
 // starts meaning "channel this SDK has not typed yet OR truly bad bytes" —
-// indistinguishable from here. TestReportSeenIsNilForAPayloadDecodeWouldEatQuietly
-// below documents the risk rather than closing it: closing it needs
-// SurveilOutput (or the percept it is built from) to carry its own channel,
-// which is a play/intel change outside this PR's scope.
+// indistinguishable from here.
+// TestProjectReportSeenCannotDistinguishSightFromALookalikePayload
+// (seen_internal_test.go) documents the risk rather than closing it: closing
+// it needs SurveilOutput (or the percept it is built from) to carry its own
+// channel, which is a play/intel change outside this PR's scope.
 func projectReportSeen(payload []byte) *Seen {
 	pos, ok := encounter.DecodeSightPayload(payload)
 	if !ok {

--- a/rulebooks/dnd5e/session/convert_test.go
+++ b/rulebooks/dnd5e/session/convert_test.go
@@ -159,6 +159,27 @@ func (s *ConvertTestSuite) TestEveryInnerFieldIsCarriedOrJustified() {
 	}
 }
 
+// TestSeenIsProjectedFromPayloadOnBothSightingAndReport pins ADR-0041's shape
+// outside the generic inner-field audit above, because Seen is not a
+// same-named passthrough of an intel field the way every other projected
+// field is: it is a SECOND projection of Payload, decoded by the
+// composition's own encounter.DecodeSightPayload rather than renamed from or
+// dropped in favour of it. The generic audit above already requires Payload
+// itself to survive unchanged (matched by name on intel.Holding and
+// intel.Report — see the "Sighting" pair); this states the derived half
+// explicitly, so a future reviewer does not mistake Seen's absence from the
+// renamed/omitted maps above for an oversight.
+func (s *ConvertTestSuite) TestSeenIsProjectedFromPayloadOnBothSightingAndReport() {
+	s.Contains(fieldNames(session.Sighting{}), "Seen",
+		"Sighting must carry the sight channel's typed knowledge (ADR-0041)")
+	s.Contains(fieldNames(session.Report{}), "Seen",
+		"Report must carry it too — first contact and a held sighting are the same fact")
+	s.Contains(fieldNames(session.Sighting{}), "Payload",
+		"retained for channels the SDK has not typed")
+	s.Contains(fieldNames(session.Report{}), "Payload",
+		"retained for channels the SDK has not typed")
+}
+
 // TestOmissionsStillApply keeps the exception list from outliving its reasons.
 //
 // A justified omission for a field that no longer exists is a stale comment

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,8 +18,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0 h1:2ElsBctjQGavG+EhUCkEcNBcsCJI2GbgBH0CMU7AOzY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.28.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0 h1:YyKFsJqczz3Ip18utScZdYZrukcwF8Cu+6Pem76xKwM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0 h1:zYz6ikMy5o/i5VBJvxwScLhCLtv2iGGrjDMjDjnwewQ=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0/go.mod h1:RPfATHgAUVDWhORJqDzuyyeIekh9AGSag+9nu8eQVIk=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/session/seen_internal_test.go
+++ b/rulebooks/dnd5e/session/seen_internal_test.go
@@ -1,0 +1,117 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// seen_internal_test.go pins ADR-0041's projection: Seen is present exactly
+// when the sighting was produced by sight, and a held memory keeps its last
+// Seen (rpg-toolkit#1157).
+
+func sightPayloadBytes(t *testing.T, x, y float64) []byte {
+	t.Helper()
+	b, err := json.Marshal(encounter.SightPayload{X: x, Y: y})
+	require.NoError(t, err)
+	return b
+}
+
+// TestProjectSightingsSightChannelGetsASeen is the ordinary case: a
+// sight-channel holding decodes into Seen.Position.
+func TestProjectSightingsSightChannelGetsASeen(t *testing.T) {
+	holdings := []intel.Holding{{
+		Subject:    intel.Subject("skeleton-1"),
+		Payload:    sightPayloadBytes(t, 10, 3),
+		Channel:    intel.Sight,
+		At:         5,
+		CurrentVia: []intel.Channel{intel.Sight},
+		Status:     intel.Current,
+	}}
+
+	out := projectSightings(holdings)
+	require.Len(t, out, 1)
+	require.NotNil(t, out[0].Seen, "a sight-channel holding must carry Seen")
+	require.Equal(t, spatial.Position{X: 10, Y: 3}, out[0].Seen.Position)
+}
+
+// TestProjectSightingsNonSightChannelGetsNoSeen pins the other half: a
+// holding whose provenance channel is not sight gets no Seen, even though the
+// payload happens to be a valid SightPayload — Channel is what decides,
+// consistent with the ADR's "present exactly when the sighting was produced
+// by sight".
+func TestProjectSightingsNonSightChannelGetsNoSeen(t *testing.T) {
+	holdings := []intel.Holding{{
+		Subject:    intel.Subject("goblin-1"),
+		Payload:    sightPayloadBytes(t, 4, 4),
+		Channel:    intel.Channel("hearing"),
+		At:         5,
+		CurrentVia: []intel.Channel{intel.Channel("hearing")},
+		Status:     intel.Current,
+	}}
+
+	out := projectSightings(holdings)
+	require.Len(t, out, 1)
+	require.Nil(t, out[0].Seen, "a non-sight channel must not carry Seen, however the payload happens to decode")
+}
+
+// TestProjectSightingsHeldMemoryKeepsItsLastSeen is the ADR's own case: a
+// subject whose CurrentVia has gone empty (Status == Held, a ghost) still
+// carries the Channel and Payload of the last accepted testimony, so it still
+// gets a Seen — the last-known cell a client draws a faded marker on.
+func TestProjectSightingsHeldMemoryKeepsItsLastSeen(t *testing.T) {
+	holdings := []intel.Holding{{
+		Subject:    intel.Subject("goblin-1"),
+		Payload:    sightPayloadBytes(t, 6, 10),
+		Channel:    intel.Sight,
+		At:         3,
+		CurrentVia: nil, // faded: no channel currently sustains it
+		Status:     intel.Held,
+	}}
+
+	out := projectSightings(holdings)
+	require.Len(t, out, 1)
+	require.NotNil(t, out[0].Seen, "a held memory must keep its last Seen")
+	require.Equal(t, spatial.Position{X: 6, Y: 10}, out[0].Seen.Position)
+}
+
+// TestProjectSeenIsNilWhenASightPayloadFailsToDecode is the defensive arm: an
+// impossible state today (the composition is the only writer of sight
+// payloads), pinned so a future regression that corrupts a sight payload
+// fails loudly as a missing Seen rather than a wrong Position.
+func TestProjectSeenIsNilWhenASightPayloadFailsToDecode(t *testing.T) {
+	got := projectSeen(intel.Sight, []byte("not json"))
+	require.Nil(t, got)
+}
+
+// TestProjectReportSeenCannotDistinguishSightFromALookalikePayload documents
+// the one soft spot in this PR, named in projectReportSeen's own comment:
+// intel.Report carries no Channel of its own, so projectReportSeen decodes
+// and checks rather than gating on Channel the way projectSeen does. That is
+// equivalent to a real channel check ONLY because sight is the only channel
+// any composition in this codebase surveils with today (rebuildPercepts is
+// the sole Surveil call site, always intel.Sight).
+//
+// This test proves the gap rather than hiding it: a payload that merely
+// LOOKS like a SightPayload — decodable as {x,y} — gets a Seen from
+// projectReportSeen with no way to ask "but was this really sight?", because
+// nothing here has a channel to ask about. The day a second channel starts
+// calling Surveil, this stops being a hypothetical and starts being a wrong
+// answer; closing it needs SurveilOutput (or the percept it is built from) to
+// carry its own channel, which is a play/intel change outside this PR.
+func TestProjectReportSeenCannotDistinguishSightFromALookalikePayload(t *testing.T) {
+	lookalike := sightPayloadBytes(t, 1, 2) // could be any future channel's bytes that
+	// happen to parse as {x,y}; today it can only actually be sight.
+
+	got := projectReportSeen(lookalike)
+	require.NotNil(t, got, "documents the gap: any {x,y}-shaped payload decodes, whatever channel actually produced it")
+	require.Equal(t, spatial.Position{X: 1, Y: 2}, got.Position)
+}

--- a/rulebooks/dnd5e/session/seen_test.go
+++ b/rulebooks/dnd5e/session/seen_test.go
@@ -1,0 +1,203 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// seen_test.go is #1157's end-to-end case: after a walker crosses a doorway,
+// View reports the monster on the far side with Seen.Position equal to where
+// that monster actually stands — the whole projection, exercised through the
+// real SDK verbs rather than a synthetic intel.Holding.
+//
+// authoredTomb() (example_session_test.go) is this package's usual reference
+// world, but it is one bare room: no doorway, no monster. Reusing it here
+// would mean adding wall/doorway geometry to a fixture every other test in
+// this file depends on staying simple, or duplicating the reference tomb's
+// own wall math (canvas_test.go's tombField, in the encounter package) at
+// this seam — a second hand-written copy of exactly the coordinate class of
+// bug ADR-0040/#1140 was about. So this builds its own small two-room world,
+// the same way onemap_test.go's offsetWorld and read_test.go's hexWorld do:
+// a seam wall with a doorway-row gap (squareSeamWalls, mirroring
+// hexSeamWalls in testprops_test.go and squareSeamWall in the encounter
+// package's own tests), so sight is genuinely gated by the doorway rather
+// than open across the whole shared edge.
+
+type SeenTestSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	mgr        *session.Manager
+}
+
+func TestSeenTestSuite(t *testing.T) {
+	suite.Run(t, new(SeenTestSuite))
+}
+
+func (s *SeenTestSuite) SetupTest() {
+	s.sessions = newFakeSessions()
+	s.encounters = newFakeEncounters()
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+		Sessions: s.sessions, Encounters: s.encounters, Characters: testCharacters(),
+		Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+	s.mgr = mgr
+}
+
+// squareSeamWalls is entrance's east wall, open only at doorRow — the square
+// analogue of hexSeamWalls (testprops_test.go), and the same construction as
+// the encounter package's own squareSeamWall/tombSeamWall test helpers.
+func squareSeamWalls(atX, rows, doorRow int) []spatial.Boundary {
+	out := make([]spatial.Boundary, 0, rows*3)
+	for y := 0; y < rows; y++ {
+		for _, dy := range []int{-1, 0, 1} {
+			to := y + dy
+			if to < 0 || to >= rows {
+				continue
+			}
+			if dy == 0 && y == doorRow {
+				continue // the doorway itself
+			}
+			out = append(out, spatial.Boundary{
+				From:              spatial.Position{X: float64(atX), Y: float64(y)},
+				To:                spatial.Position{X: float64(atX + 1), Y: float64(to)},
+				BlocksMovement:    true,
+				BlocksLineOfSight: true,
+			})
+		}
+	}
+	return out
+}
+
+// skeletonBehindADoor is a two-room world: entrance (0,0) and hall (6,0),
+// each 6x6, joined by one doorway on row 2 with a solid wall everywhere else
+// along the shared edge. skeleton-1 stands well inside hall at local (3,3) —
+// absolute (9,3) — where nothing but the doorway can put it in sight.
+func skeletonBehindADoor(t fataler) *encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms: []encounter.RoomInput{
+				{ID: "entrance", Width: 6, Height: 6, Boundaries: squareSeamWalls(5, 6, 2)},
+				{ID: "hall", Width: 6, Height: 6, Origin: spatial.Position{X: 6, Y: 0}},
+			},
+			Connections: []encounter.ConnectionInput{{
+				ID: "door1", From: "entrance", To: "hall",
+				FromPosition: spatial.Position{X: 5, Y: 2},
+				ToPosition:   spatial.Position{X: 0, Y: 2},
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "fighter", Kind: encounter.KindPlayer, Room: "entrance", Position: spatial.Position{X: 5, Y: 0}},
+			{ID: "skeleton-1", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 3, Y: 3}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	if err != nil {
+		t.Fatalf("building skeletonBehindADoor: %v", err)
+	}
+	data := enc.ToData()
+	return &data
+}
+
+// TestSeenIsPopulatedAfterCrossingTheDoorway is #1157's headline case: the
+// fighter cannot see skeleton-1 from behind the wall, walks through the one
+// doorway, and View then reports skeleton-1 with a Seen.Position equal to
+// where the skeleton actually stands — read independently via Where, not
+// the local literal used to place it, so the assertion cannot pass by both
+// sides sharing the same typo.
+func (s *SeenTestSuite) TestSeenIsPopulatedAfterCrossingTheDoorway() {
+	ctx := context.Background()
+	_, err := s.mgr.StartSession(ctx, &session.StartSessionInput{
+		Session: "sess", Encounter: "skeleton-behind-a-door", World: skeletonBehindADoor(s.T()),
+	})
+	s.Require().NoError(err)
+
+	// Before: the wall genuinely blocks it. Asserted first so a fixture that
+	// accidentally puts the skeleton in the open cannot make the "after"
+	// assertion trivially true.
+	before, err := s.mgr.View(ctx, &session.ViewInput{Session: "sess", Member: "fighter"})
+	s.Require().NoError(err)
+	for _, sight := range before {
+		s.NotEqual("skeleton-1", sight.Subject, "the wall must actually block sight before the walk")
+	}
+
+	// The fighter walks down to the doorway row and through it. The walk may
+	// stop short of the full requested path: reaching the doorway's own gap
+	// cell (5,2) already opens sight to skeleton-1 across it, and a sighting
+	// between a player and a monster starts a fight, which is news the walk
+	// reports rather than something it walks through (session/doc.go — the
+	// composition detects contact wherever sight changes and stops the walker
+	// there). That is itself part of what this test proves: sight opened
+	// exactly because the walk reached the doorway, not before.
+	out, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "fighter",
+		Path: []spatial.Position{{X: 5, Y: 1}, {X: 5, Y: 2}, {X: 6, Y: 2}},
+	})
+	s.Require().NoError(err)
+	s.Require().NotEmpty(out.Steps, "the fighter must have moved at all")
+	s.Require().NotNil(out.Formed, "seeing the skeleton must have started the fight")
+
+	where, err := s.mgr.Where(ctx, &session.WhereInput{Session: "sess", Member: "skeleton-1"})
+	s.Require().NoError(err)
+
+	after, err := s.mgr.View(ctx, &session.ViewInput{Session: "sess", Member: "fighter"})
+	s.Require().NoError(err)
+
+	var skeleton *session.Sighting
+	for i := range after {
+		if after[i].Subject == "skeleton-1" {
+			skeleton = &after[i]
+		}
+	}
+	s.Require().NotNil(skeleton, "the fighter must see the skeleton once through the doorway")
+	s.Require().NotNil(skeleton.Seen, "a sight-channel sighting must carry Seen")
+	s.Equal(where.Position, skeleton.Seen.Position,
+		"Seen.Position must equal the skeleton's own reported placement, read independently via Where")
+}
+
+// TestDiscoveredAlsoCarriesSeen pins the other producer of Report: MoveOutput
+// .Discovered's FirstContact list, which the walk above already populates the
+// moment the skeleton first comes into view. Discovery is proportional (S6):
+// this asserts against out.Discovered directly rather than repeating the walk.
+func (s *SeenTestSuite) TestDiscoveredAlsoCarriesSeen() {
+	ctx := context.Background()
+	_, err := s.mgr.StartSession(ctx, &session.StartSessionInput{
+		Session: "sess", Encounter: "skeleton-behind-a-door", World: skeletonBehindADoor(s.T()),
+	})
+	s.Require().NoError(err)
+
+	out, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "fighter",
+		Path: []spatial.Position{{X: 5, Y: 1}, {X: 5, Y: 2}, {X: 6, Y: 2}},
+	})
+	s.Require().NoError(err)
+
+	where, err := s.mgr.Where(ctx, &session.WhereInput{Session: "sess", Member: "skeleton-1"})
+	s.Require().NoError(err)
+
+	discovery, ok := out.Discovered["fighter"]
+	s.Require().True(ok, "the fighter's own perception must have changed on this walk")
+
+	var report *session.Report
+	for i := range discovery.FirstContact {
+		if discovery.FirstContact[i].Subject == "skeleton-1" {
+			report = &discovery.FirstContact[i]
+		}
+	}
+	s.Require().NotNil(report, "skeleton-1 must be first contact — the fighter never held it before")
+	s.Require().NotNil(report.Seen)
+	s.Equal(where.Position, report.Seen.Position)
+}

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -263,10 +263,15 @@ type MemberOutcome struct {
 // Seen is what the sight channel knows about a subject: the cell it occupies,
 // dungeon-absolute — the same frame every other position on this seam speaks.
 //
-// On [Sighting], present exactly when the sighting was produced by sight;
-// nil for every other channel, gated on Holding.Channel. A memory (CurrentVia
-// empty) keeps the Seen it last had — the last-known cell a client draws a
-// faded marker on.
+// On [Sighting], present when BOTH hold: the sighting was produced by sight
+// (gated on Holding.Channel) AND the composition's payload actually decodes
+// as a sight payload (encounter.DecodeSightPayload succeeds). Nil for every
+// other channel — that is the ordinary, expected case. Nil on a sight-channel
+// holding whose payload fails to decode is NOT a legal state a caller should
+// plan for; it means the composition wrote something projectSeen cannot
+// read, which is a defect in that layer, not a case this seam is choosing to
+// represent as "no sighting". A memory (CurrentVia empty) keeps the Seen it
+// last had — the last-known cell a client draws a faded marker on.
 //
 // On [Report] this is weaker (Copilot review, PR #1159): intel.Report carries
 // no Channel of its own, so a Report's Seen is inferred by decoding its

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -260,12 +260,36 @@ type MemberOutcome struct {
 	Position spatial.Position `json:"position"`
 }
 
+// Seen is what the sight channel knows about a subject: the cell it occupies,
+// dungeon-absolute — the same frame every other position on this seam speaks.
+//
+// Present exactly when the sighting that carries it was produced by sight;
+// nil for every other channel. A memory (CurrentVia empty) keeps the Seen it
+// last had — the last-known cell a client draws a faded marker on.
+//
+// ADR-0041: channel-keyed typed sub-structs on Sighting/Report. A future
+// channel (hearing, tremorsense) gets its own sub-struct with the facts that
+// channel actually conveys; a sight-specific fact that arrives later
+// (lighting, distance band) belongs inside Seen, not as a new field on
+// Sighting.
+type Seen struct {
+	// Position is the sighted subject's cell, dungeon-absolute.
+	Position spatial.Position `json:"position"`
+}
+
 // Sighting is one thing an observer currently perceives.
 type Sighting struct {
 	// Subject names what is perceived.
 	Subject string `json:"subject"`
 
+	// Seen is the sight channel's own typed knowledge; see [Seen]. Decoded by
+	// the composition, not by this package — session never unmarshals
+	// Payload itself.
+	Seen *Seen `json:"seen,omitempty"`
+
 	// Payload is what the observer knows about it, encoded by the composition.
+	// Retained for channels the SDK has not typed; sight itself is typed
+	// through Seen above rather than asking a client to decode this.
 	Payload []byte `json:"payload,omitempty"`
 
 	// Channel is how it was perceived.
@@ -647,6 +671,12 @@ type Report struct {
 	// Subject names what was perceived.
 	Subject string `json:"subject"`
 
+	// Seen is the sight channel's own typed knowledge, carried the same way
+	// [Sighting.Seen] is — first contact and a held sighting are the same
+	// fact in the same shape.
+	Seen *Seen `json:"seen,omitempty"`
+
 	// Payload is what the observer learned, encoded by the composition.
+	// Retained for channels the SDK has not typed.
 	Payload []byte `json:"payload,omitempty"`
 }

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -263,9 +263,17 @@ type MemberOutcome struct {
 // Seen is what the sight channel knows about a subject: the cell it occupies,
 // dungeon-absolute — the same frame every other position on this seam speaks.
 //
-// Present exactly when the sighting that carries it was produced by sight;
-// nil for every other channel. A memory (CurrentVia empty) keeps the Seen it
-// last had — the last-known cell a client draws a faded marker on.
+// On [Sighting], present exactly when the sighting was produced by sight;
+// nil for every other channel, gated on Holding.Channel. A memory (CurrentVia
+// empty) keeps the Seen it last had — the last-known cell a client draws a
+// faded marker on.
+//
+// On [Report] this is weaker (Copilot review, PR #1159): intel.Report carries
+// no Channel of its own, so a Report's Seen is inferred by decoding its
+// payload rather than gated on provenance — see projectReportSeen's own
+// comment in convert.go. It is not yet an authoritative "this was sight"
+// discriminator on a Report the way it is on a Sighting; do not treat it as
+// one until a second channel exists to prove the distinction matters.
 //
 // ADR-0041: channel-keyed typed sub-structs on Sighting/Report. A future
 // channel (hearing, tremorsense) gets its own sub-struct with the facts that
@@ -674,6 +682,14 @@ type Report struct {
 	// Seen is the sight channel's own typed knowledge, carried the same way
 	// [Sighting.Seen] is — first contact and a held sighting are the same
 	// fact in the same shape.
+	//
+	// UNLIKE Sighting.Seen, this is not gated on channel provenance: Report
+	// (unlike Holding) carries no Channel field, so this is populated by
+	// decoding the payload and checking whether it parses, not by asking
+	// what channel produced it. See [Seen]'s own doc and projectReportSeen
+	// in convert.go. Do not read a non-nil Seen here as proof the report
+	// came from sight — today it always does, because sight is the only
+	// channel this codebase surveils with, not because this field checked.
 	Seen *Seen `json:"seen,omitempty"`
 
 	// Payload is what the observer learned, encoded by the composition.


### PR DESCRIPTION
## What

ADR-0041 (added here, verbatim from the pre-approved decision text — with one added implementation-note addendum below, clearly marked): `Sighting`/`Report` gain `Seen{Position spatial.Position}`, present exactly when the channel is sight and nil otherwise; a held memory (CurrentVia empty) keeps its last `Seen`. The composition decodes its own encoding — `encounter.DecodeSightPayload` (PR #1158, merged) — and `projectSightings`/`projectDiscovery` copy the typed position across. This package still never `json.Unmarshal`s a payload itself; `onemap_test.go`'s passthrough pin (`TestASightingIsReportedOnTheMap`) is unchanged and still passes.

Closes #1157

## Testable cases (from #1157)

- [x] Projection: sight-channel holding → `Seen.Position == (10,3)`; non-sight holding → `Seen == nil`; a held memory keeps its `Seen`. (`TestProjectSightingsSightChannelGetsASeen`, `TestProjectSightingsNonSightChannelGetsNoSeen`, `TestProjectSightingsHeldMemoryKeepsItsLastSeen`)
- [x] `convert_test.go`'s projected-pairs audit lists `Seen` on both `Sighting` and `Report`, and pins `Payload`'s retention on both. (`TestSeenIsProjectedFromPayloadOnBothSightingAndReport` — a dedicated test rather than an entry in the `renamed`/`omitted` maps, since `Seen` is a *second* projection of `Payload`, not a rename or a drop of it; the generic inner-field audit above it already requires `Payload` itself to survive by name.)
- [x] onemap pin: no "room" in a sighting still holds — unchanged, still passing.
- [x] End-to-end: a fighter behind a doorway cannot see a monster (`skeleton-1`) through the wall, walks toward the doorway, and once sight opens `View` reports `skeleton-1` with `Seen.Position` equal to the skeleton's own placement (read independently via `Where`, not the fixture literal). `MoveOutput.Discovered`'s `FirstContact` carries the same fact. (`seen_test.go`, `TestSeenIsPopulatedAfterCrossingTheDoorway`, `TestDiscoveredAlsoCarriesSeen`)
- [x] `encounter` view test: the typed decode agrees with what a caller would get unmarshalling `View()`'s own raw payload — landed in PR #1158, since that's where the decode function lives.

## One soft spot (flagged as asked)

`projectSeen` (for `Sighting`) gates explicitly on `Holding.Channel == intel.Sight`, matching the ADR's "present exactly when sight" precisely. `projectReportSeen` (for `Report`, used by `Discovery.FirstContact`) **cannot** do that: `intel.Report` carries no `Channel` field of its own — a `SurveilOutput` is scoped to the one channel its `Surveil` call used, but that channel isn't threaded onto each `Report` inside it. So `projectReportSeen` decodes-and-checks instead: any payload that parses as a `SightPayload` gets a `Seen`, whatever channel actually produced it.

That is equivalent to a real channel check *only* because sight is the only channel any composition in this codebase calls `Surveil` with today (`rebuildPercepts` in `encounter.go` is the sole call site, always `intel.Sight`). `TestProjectReportSeenCannotDistinguishSightFromALookalikePayload` proves the gap rather than hiding it — it asserts the current (accepted) false-positive behavior on a payload that merely looks like `{x,y}`. Closing it properly needs `SurveilOutput`/the percept it's built from to carry its own channel, which is a `play/intel` change outside this PR's scope. `Seen`'s doc comment and `Report.Seen`'s own field doc (Copilot review) now say this explicitly, as does an added note in the ADR itself.

## World-fixture note

`authoredTomb()` (this package's usual reference world) is one bare room — no doorway, no monster — so the end-to-end case needed its own small fixture (`skeletonBehindADoor`, `seen_test.go`) rather than reusing it. Built the same way `onemap_test.go`'s `offsetWorld` and `read_test.go`'s `hexWorld` already do (a hand-built `encounter.EncounterData`), with a seam wall gapped at the doorway row (`squareSeamWalls`, the square analogue of `hexSeamWalls` in `testprops_test.go`) rather than reusing the encounter package's own `tombField()` reference-tomb fixture, which isn't reachable from this module (unexported, different package). Also worth naming: the walk doesn't complete the full requested path — reaching the doorway's own gap cell already opens sight to the skeleton, and player↔monster contact starts a fight (`session/doc.go`), which is exactly when `Formed`/`Discovered` populate. The test asserts on that (`out.Formed != nil`, not step count) rather than fighting the architecture.

## Sequencing (PR B of two — A merged)

PR #1158 (encounter) merged and auto-tagged `rulebooks/dnd5e/encounter/v0.29.0`. `session/go.mod` now pins the real tag (was a provisional pin to the same version number while A was in flight — turned out to be the correct guess). `go mod tidy` produced a two-line `go.sum` diff only (the h1 content hash moved; the `/go.mod` hash is unchanged, since encounter's own `go.mod` file is byte-identical between v0.28.0 and v0.29.0 — no dependency requirements changed, only exported surface).

Final verification, run normally (no `GOWORK` override needed anymore):

- `go build ./...` — clean
- `go test ./...` — PASS (`session`, `session/cmd/session-workbench`)
- `go test -race ./...` — PASS
- `go vet ./...` — clean
- `gofmt -l .` — clean
- `golangci-lint run ./...` — 0 issues
- `./scripts/check-decisions.sh` — 43/43 ADRs summarised
- Full pre-commit hook — passed normally (no `--no-verify` on this commit)

## Numbering note

`0041-sighting-carries-typed-channel-knowledge.md` collides in number with the already-merged `0041-composable-attack-damage.md` (combat). Both are now cited by filename in `docs/adr/DECISIONS.md` per `check-decisions.sh`'s own rule for a shared number, and the collision is recorded in the Numbering hazards section (a third entry alongside the existing 0006/0019 collisions).

— asset-pipeline agent, on behalf of KirkDiggler
