### PR TITLE
session: Afford — what a member can still declare this turn (#1138)

### DIFF
--- a/docs/adr/0042-afford-answers-in-declarations-not-currencies.md
+++ b/docs/adr/0042-afford-answers-in-declarations-not-currencies.md
@@ -1,0 +1,176 @@
+# ADR-0042: Afford Answers in Declarations, Not Remaining Currencies
+
+**Date:** 2026-08-22
+**Status:** Accepted (Kirk, 2026-08-22 — "oh I like B a lot. backend tells
+dumb client what it can do.")
+
+## Context
+
+`session/v0.17.0` made the action economy real: a second swing in a turn
+that bought only one is refused with `ErrCannotAfford`, and the sentinel
+carefully names the currency that ran out — "action: 1 needed, 0 left" —
+because "a refusal a client cannot explain is a refusal that reads as a
+bug." All of that is about the refusal. Nothing on the seam reports the
+budget *before* it.
+
+There is no read for what a member can still afford. `Turn` returns
+`{Clock, Active, Round, Order}`. `Status` is `{Open, Outcome}`. `View`
+reports perception. A client building a turn UI has exactly two options:
+offer every action and let the server refuse it — the button that fails,
+fine for a debug harness and not for a game — or re-derive the economy
+client-side: know that a level-1 fighter gets one attack, that Extra
+Attack lands at level 5, that a bonus action is not an action. That is a
+D&D rule living in the client, the Boundary Rule violation this whole seam
+exists to prevent. Filed as rpg-toolkit#1138, and the shape it names in
+passing ("What a client needs to render is closer to *what can I still
+declare* than *how many points do I have*") is what this ADR settles.
+
+## Options considered
+
+1. **Remaining currencies.** `{action: 0, bonus: 1}` — the ledger, read
+   back. Cheapest to build: it is `combat.SpendProfile`'s own vocabulary
+   with nothing translated. Rejected on inspection: a client reading it
+   still has to know that a swing *costs* an action and that Extra Attack
+   *banks* capacity to turn those numbers into "can I swing" — the rule
+   would leak through the very read meant to keep it server-side. The
+   D&D-in-the-client problem does not go away; it moves one read earlier.
+
+2. **Declarations.** One entry per verb the seam prices — `{Verb, Slot,
+   Affordable, Shortfall}` — answering the client's actual question
+   (*can I do this*) rather than handing over the ledger and trusting the
+   client to derive the answer. `Slot` rides along so a client can still
+   light the action/bonus/reaction shapes it already draws, without
+   needing to know *why* — it is read off the same `SpendProfile.Slots`
+   the door prices, never a second table.
+
+3. **Both.** Declarations plus the raw remaining currencies, for a client
+   that wants more than can-or-cannot. Rejected for v1: nothing asking for
+   it exists yet, and shipping the currencies teaches every future client
+   that reading them is legitimate — the same "re-derive the rule" failure
+   mode option 1 has, just available as an opt-out rather than the only
+   path. Nothing forecloses adding a currency-shaped read later if a real
+   caller needs one; it is not this read's job to guess that caller into
+   existence.
+
+## Kirk's ruling
+
+> oh I like B a lot. backend tells dumb client what it can do. in our ui
+> we hand shapes for action, bonus and reaction that lined up with the
+> various things we could do. that was really nice
+
+Option 2, verbatim. The `Slot` field exists because of the second half of
+the quote: a UI that already draws three shapes (action / bonus /
+reaction) needs to know which one a declaration would spend, without the
+seam handing over the currency ledger to compute it from.
+
+## What this read does NOT decide
+
+**Whose turn it is.** `Attack` does not check whose turn it currently is —
+nothing on this seam does yet, `EndTurn` aside (verified by reading
+`attack.go`: no consult of `ClockOfOutput.Active` anywhere in the
+verb) — so `Afford` does not either. Folding "not your turn" into a
+`Declaration.Shortfall` would answer a question this read was never asked,
+in a currency it does not price: that is `Turn`'s question, and a future
+turn gate belongs beside `Turn`'s own `Active` field rather than inside a
+declaration meant to describe the economy alone.
+
+**Weapon compilation.** `Afford` prices what `priceSwing` prices — the
+turn's economy — and `priceSwing` never touches `resolution.AttackProfile`
+or a weapon at all; that half of `Attack`'s compilation
+(`compileAttack` → `resolution.AttackFromCharacter`) is a different
+refusal (`ErrBadAttack`) about a different fact. Deciding whether an
+unarmed or weaponless member's `Declaration` should say so is left for the
+caller that needs it — v1's only caller is a client asking about its own
+authenticated member, who has a weapon or does not swing at all.
+
+## Decision
+
+`Manager.Afford(ctx, *AffordInput) (*AffordOutput, error)`, in the spirit
+of `Where`: a caller-scoped singular read, the host binding `Member` to the
+authenticated caller exactly as `Where` requires.
+
+```go
+type AffordOutput struct {
+    Clock        ClockKind      // ClockWorld: the economy does not apply; Declarations is empty and that IS the answer
+    Declarations []Declaration  // one per verb the seam prices; v1: Attack only
+}
+
+type Declaration struct {
+    Verb       Verb    // VerbAttack in v1
+    Slot       Slot    // SlotAction | SlotBonus | SlotReaction | SlotNone — read off SpendProfile.Slots
+    Affordable bool    // no omitempty; false is an answer
+    Shortfall  string  // empty when Affordable; otherwise the SAME text the refusal carries
+}
+```
+
+### The load-bearing invariant, and how it is kept true by construction
+
+`Afford` must never become a second copy of what `Attack` already prices,
+because two copies is exactly the shape that drifts. It is not: `Afford`
+calls the identical `priceSwing` a real swing compiles from — the same
+function, refactored to take an `*encounter.Encounter` rather than a
+`*writeScope` so a read verb can call it too — and then charges that price
+through `combat.Pay`, the SAME gate function `resolution`'s door pays a
+real swing through. The sheet it charges is loaded fresh for the call and
+handed to nobody: never adopted into the scope, never passed to
+`saveDirty`, never reaching a repository. Charging it is therefore both
+safe (nothing persists) and honest (it is the real gate, not a
+read-only twin of it) — a payment that succeeds sets `Affordable`; one
+that fails hands back `Pay`'s own error text as `Shortfall`, verbatim.
+
+This was checked against an alternative — adding a read-only
+`combat.Explain(Ledger, *SpendProfile) error` next to `CanPay`, wrapping
+the same private `check` — and calling `Pay` on the throwaway sheet was
+preferred: `combat` is a *different Go module* from `session`
+(`rulebooks/dnd5e` vs. `rulebooks/dnd5e/session`), pinned by version in
+`session/go.mod`, and this repo's own history sequences a lower-module
+change and the session-side change that consumes it as separate PRs
+(e.g. `9a6d1bb` / `e1f8ba7`'s "take the X correction" commits) rather than
+landing both in one. `Pay` is already exported, already the exact function
+the door calls, and calling it on a copy nobody saves needs no new export
+and no cross-module version bump to ship this as one PR.
+
+Proven by test as well as by construction (`afford_test.go`):
+`TestAffordableMeansAttackWillNotRefuse`,
+`TestUnaffordableMeansAttackRefusesWithTheSameShortfall`, walking the
+level-1 fighter's second swing and Extra Attack's second and third swings
+from `economy_test.go`'s own fixtures, plus `TestFreeRoamAffordsNothing`
+and `TestAffordSavesNothing` (the no-persistence half, mirroring
+`TestARefusedSwingWritesNothing`).
+
+## Consequences
+
+### Positive
+- A turn UI can grey a button honestly instead of offering one the server
+  will refuse, without knowing a single 5e rule.
+- The rule stays server-side. A client that wanted to bypass `Declaration`
+  and compute affordability itself has no currencies to read — there is
+  nothing to re-derive from.
+- `priceSwing`'s signature change (`*writeScope` → `*encounter.Encounter`)
+  is a pure widening: `Attack` passes `scope.enc` and is otherwise
+  unchanged, and the function's only real dependency was ever the
+  encounter, not the write machinery around it.
+
+### Negative
+- `Declaration` carries no field for "why can't this verb even be
+  attempted" reasons outside the economy (not your turn, no weapon,
+  member is downed). A client that wants those has to call the verb and
+  read the refusal, same as before this ADR.
+- Calling `combat.Pay` (a mutating function) on a throwaway sheet to get a
+  read-only answer is a slightly unusual use of an exported API — the
+  alternative (`combat.Explain`) is cleaner in isolation but was rejected
+  above for the cross-module reason. Worth revisiting if `combat` ever
+  needs its own reason-returning read for another caller.
+
+### Neutral
+- v1 has exactly one verb to declare, so `Declarations` is always
+  length-0-or-1 today. The shape does not change when a second verb (Dash,
+  Dodge) is priced; it grows another entry.
+
+## Rule
+
+**A read that could leak a rule by handing over the ledger instead answers
+the caller's actual question.** When a client's real question is
+can-or-cannot, reporting the numbers behind the answer is not a more
+complete version of the same read — it is a second, unofficial API for
+deriving the rule the first one was built to keep server-side.

--- a/docs/adr/DECISIONS.md
+++ b/docs/adr/DECISIONS.md
@@ -142,6 +142,16 @@ because this directory's `README.md` index silently drifted to listing 7 of 37.
   unmarshals a payload itself. *Rule: a rule a client cannot read off the
   wire gets re-derived by experiment, once per client — the same argument
   ADR-0040 already made about Atlas.Layout.*
+- **0042** — **`Afford` answers in declarations, not remaining currencies**:
+  `Manager.Afford` reports one `Declaration{Verb, Slot, Affordable,
+  Shortfall}` per verb the seam prices (v1: Attack only) rather than the raw
+  ledger, so a client never has to know that a swing costs an action or that
+  Extra Attack banks capacity to answer "can I do this". It prices through the
+  identical `priceSwing` -> `combat.Pay` path `Attack`'s door pays, on a sheet
+  loaded fresh and never saved — never a second copy of the arithmetic. Kirk:
+  "backend tells dumb client what it can do." *Rule: a read that could leak a
+  rule by handing over the ledger instead answers the caller's actual
+  question.*
 
 ---
 

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -1,0 +1,255 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"context"
+	"fmt"
+
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// AffordInput asks what one member can still declare this turn.
+type AffordInput struct {
+	// Session is the session to look inside.
+	Session string
+
+	// Member is whose budget is being asked about. Required.
+	//
+	// THE HOST MUST BIND THIS TO THE AUTHENTICATED CALLER, exactly as
+	// [Manager.Where] requires and for the same reason: this package cannot
+	// tell who is asking, and a client-supplied ID wired through unchecked
+	// turns a caller-scoped budget read into one that answers about anybody.
+	Member string
+}
+
+// Verb names a seam action [Manager.Afford] can price.
+//
+// A closed enum owned here rather than a reuse of the rulebook's own action
+// vocabulary — a declaration is a question about what THIS SEAM lets a member
+// declare, not the currency the rulebook happens to price it in. v1 has
+// exactly one entry because v1 has exactly one gated verb.
+type Verb string
+
+const (
+	// VerbAttack is [Manager.Attack]: swinging a weapon at another member.
+	VerbAttack Verb = "attack"
+)
+
+// Slot names which of a turn's three economy shapes a [Declaration] draws
+// from, mirroring the vocabulary a UI already has buttons for — the same four
+// values character.EconomySlot carries (action_economy_types.go), spelled
+// here rather than imported across the seam (S2).
+//
+// It answers a narrower question than "what does this cost." A declaration
+// that lights none of the three shapes is not thereby free — see SlotNone.
+type Slot string
+
+const (
+	// SlotNone is a declaration that draws no per-turn slot: nothing to light
+	// on an action, bonus action or reaction shape. NOT the same claim as
+	// "costs nothing" — Extra Attack's second swing spends a banked attack
+	// and lights no shape at all, and Affordable can still be false for it
+	// once that bank runs out.
+	SlotNone Slot = ""
+	// SlotAction draws the standard action.
+	SlotAction Slot = "action"
+	// SlotBonus draws the bonus action.
+	SlotBonus Slot = "bonus"
+	// SlotReaction draws the reaction.
+	SlotReaction Slot = "reaction"
+)
+
+// Declaration is one verb this member could still declare this turn, and
+// whether they can pay for it.
+//
+// DECLARATIONS, NOT REMAINING CURRENCIES — Kirk's ruling on rpg-toolkit#1138:
+// "backend tells dumb client what it can do." A read that answered
+// {action:0, bonus:1} would still hand a client the raw ledger and trust it to
+// know that a swing costs an action and that Extra Attack banks capacity —
+// which is the D&D-in-the-client violation the economy exists to prevent, only
+// moved one read earlier. A Declaration answers the question a client actually
+// has, CAN I DO THIS, and keeps the arithmetic where it has always lived:
+// server-side, behind [combat.SpendProfile]. See
+// docs/adr/0042-afford-answers-in-declarations-not-currencies.md.
+type Declaration struct {
+	// Verb is which seam action this prices.
+	Verb Verb `json:"verb"`
+
+	// Slot is which economy shape this declaration would spend, or SlotNone.
+	// Read off the SAME SpendProfile the door would charge — never a second
+	// table asserting what a verb "usually" costs — so a class table changing
+	// what an action buys changes this automatically.
+	Slot Slot `json:"slot"`
+
+	// Affordable is whether the member could pay for this verb right now.
+	//
+	// NO OMITEMPTY. False is an ANSWER, not an absence — the same
+	// false-vs-absent law every other bool at this seam keeps (types.go).
+	// Absence of information is instead Declarations being empty, on the
+	// world clock, where the question does not apply at all.
+	Affordable bool `json:"affordable"`
+
+	// Shortfall names what ran out, in the SAME words a refused Attack would
+	// use — "action: 1 needed, 0 left" — because a client that cannot repeat
+	// a refusal in the player's own words has been handed a boolean and
+	// nothing else. Empty when Affordable.
+	Shortfall string `json:"shortfall,omitempty"`
+}
+
+// AffordOutput is what one member can still declare this turn.
+type AffordOutput struct {
+	// Clock is which kind of time the member is in. ClockWorld means the
+	// action economy does not apply to them at all: Declarations is empty,
+	// and that IS the answer rather than a shorter way of asking again.
+	Clock ClockKind `json:"clock"`
+
+	// Declarations is one entry per verb the seam prices, empty on the world
+	// clock. v1 prices Attack alone.
+	Declarations []Declaration `json:"declarations,omitempty"`
+}
+
+// Afford reports what one member can still declare this turn: which of the
+// seam's gated verbs they could pay for right now, and — when they cannot —
+// the same currency-naming text a refused [Manager.Attack] would carry.
+//
+// # The gap this closes
+//
+// Attack refuses a swing nobody can pay for with [ErrCannotAfford], and the
+// refusal is careful to name the currency that ran out. Nothing on the seam
+// said so BEFORE the refusal. A turn UI built against that has exactly two
+// options: offer the button and let the server say no, or re-derive 5e's
+// economy client-side — a level-1 fighter gets one swing, Extra Attack lands
+// at level 5 — which is the Boundary Rule violation this whole seam exists to
+// prevent. See rpg-toolkit#1138.
+//
+// # A declaration, not the remaining currencies
+//
+// Kirk's ruling: "backend tells dumb client what it can do." Reporting
+// {action:0, bonus:1} would still make the client know a swing costs an
+// action and that Extra Attack banks capacity — the rule would have leaked
+// through the very read meant to keep it server-side. So this returns
+// [Declaration]s — can-or-cannot, per verb — carrying [Slot] so a client can
+// light the action/bonus/reaction shapes it already draws without knowing WHY
+// any of them are lit. See docs/adr/0042-afford-answers-in-declarations-not-currencies.md.
+//
+// # The same price Attack pays, never a second copy of it
+//
+// This does not reprice the swing by a second route. It calls the identical
+// [Manager.priceSwing] a real swing compiles from, then charges that price
+// through [combat.Pay] — the SAME gate [Manager.Attack]'s door pays through —
+// against a [character.Character] loaded fresh for this call and never saved.
+// A payment that succeeds answers Affordable; one that fails hands back the
+// exact text a refused Attack's door would have produced, because it IS that
+// text: nothing here reimplements what a currency needs or what ran out. If
+// Attack and Afford could ever disagree, one of them would be pricing wrong,
+// and routing both through one gate call is what makes that impossible by
+// construction rather than merely tested for.
+//
+// # The economy's answer, not the turn's
+//
+// Attack does not check whose turn it currently is — nothing on this seam
+// does yet, [Manager.EndTurn] aside — so this does not either. Whether a swing
+// would ALSO be refused for arriving out of turn is [Manager.Turn]'s question:
+// folding "not your turn" into a Shortfall here would answer a question this
+// read was never asked, in a currency it does not price. A future turn gate
+// belongs beside Turn's own Active field, not inside a Declaration.
+//
+// # Reads, and reads only
+//
+// No new state, no new gate. [Manager.priceSwing] "readies" a cold sheet's
+// turn as a side effect of pricing it — see its own doc — and here that
+// mutation lands on a character this call loaded for itself and hands to
+// nobody: never adopted, never passed to [Manager.saveDirty], never reaching a
+// repository. A save happens exactly as often from this verb as from any
+// other read: never. TestAffordSavesNothing pins it the way
+// TestARefusedSwingWritesNothing pins the same claim for a refused swing.
+//
+// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
+// ErrNoEncounter, or ErrNoMember if the member is not in this encounter.
+// Returns ErrNoCharacter or ErrBadCharacter if the member is on the turn clock
+// and has no loadable sheet — reachable for a monster or a malformed record,
+// since a character already in a fight has one by construction. Returns
+// ErrBadCost if the rulebook cannot compile this member's own price, which
+// [Manager.Attack] would also refuse the same way.
+func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("afford: %w", ErrNilInput)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("afford: %w", ErrNoMemberID)
+	}
+
+	enc, err := m.open(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("afford: %w", err)
+	}
+
+	clock, err := enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(in.Member)})
+	if err != nil {
+		return nil, fmt.Errorf("afford: %w", translate(err))
+	}
+	if ClockKind(clock.Kind) != ClockTurn {
+		return &AffordOutput{Clock: ClockWorld}, nil
+	}
+
+	data, err := m.fetchCharacterData(ctx, "member", in.Member)
+	if err != nil {
+		return nil, fmt.Errorf("afford: %w", err)
+	}
+	// Bus-free, the same loader priceSwing's own caller (compileAttack) reads
+	// the economy through: the action economy is plain sheet data in v1, not
+	// condition-driven, so nothing here needs the conditions a bus-attached
+	// reconstitution would bring. See compileAttack's own comment.
+	sheet, err := character.Load(ctx, data)
+	if err != nil {
+		return nil, fmt.Errorf("member %q: %w: %v", in.Member, ErrBadCharacter, err)
+	}
+
+	price, err := m.priceSwing(ctx, enc, in.Member, sheet)
+	if err != nil {
+		return nil, fmt.Errorf("afford: %w", err)
+	}
+
+	// price.cost is never nil here: priceSwing returns a nil cost only when
+	// the member is on the world clock, already ruled out above.
+	decl := Declaration{Verb: VerbAttack, Slot: slotOf(price.cost.Profile)}
+
+	// Charged against the sheet THIS CALL loaded, which is handed to nobody
+	// else and never saved (see the doc comment above). combat.Pay is the
+	// SAME gate the door pays a real swing through, so a payment that
+	// succeeds or fails here answers exactly as Attack's would.
+	if payErr := combat.Pay(sheet, price.cost.Profile); payErr != nil {
+		decl.Shortfall = payErr.Error()
+	} else {
+		decl.Affordable = true
+	}
+
+	return &AffordOutput{Clock: ClockTurn, Declarations: []Declaration{decl}}, nil
+}
+
+// slotOf reads which of a turn's three slots a compiled price draws from, if
+// any — the same map [combat.Pay] would charge, never a second table
+// asserting what a verb "usually" costs. A profile with none of the three
+// keys a turn holds answers SlotNone: it may still draw capacity (a banked
+// swing Extra Attack already bought) without lighting a shape a client draws
+// for action, bonus or reaction.
+func slotOf(p *combat.SpendProfile) Slot {
+	if p == nil {
+		return SlotNone
+	}
+	switch {
+	case p.Slots[coreCombat.ActionStandard] > 0:
+		return SlotAction
+	case p.Slots[coreCombat.ActionBonus] > 0:
+		return SlotBonus
+	case p.Slots[coreCombat.ActionReaction] > 0:
+		return SlotReaction
+	default:
+		return SlotNone
+	}
+}

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -98,7 +98,12 @@ type Declaration struct {
 	// use — "action: 1 needed, 0 left" — because a client that cannot repeat
 	// a refusal in the player's own words has been handed a boolean and
 	// nothing else. Empty when Affordable.
-	Shortfall string `json:"shortfall,omitempty"`
+	//
+	// NO OMITEMPTY, for the same reason Affordable has none: an empty string
+	// beside affordable:true is itself the answer ("nothing ran out"), not
+	// the absence of one, and a non-Go client reading a missing key cannot
+	// tell that from "the server didn't say".
+	Shortfall string `json:"shortfall"`
 }
 
 // AffordOutput is what one member can still declare this turn.
@@ -109,8 +114,12 @@ type AffordOutput struct {
 	Clock ClockKind `json:"clock"`
 
 	// Declarations is one entry per verb the seam prices, empty on the world
-	// clock. v1 prices Attack alone.
-	Declarations []Declaration `json:"declarations,omitempty"`
+	// clock — where empty IS the answer rather than a shorter way of asking
+	// again, so it is never omitted from the wire either: the same
+	// false-vs-absent law types.go keeps for every bool at this seam applies
+	// here to the list itself. A non-Go client must read "declarations": [],
+	// not a missing key that reads as "the server didn't say".
+	Declarations []Declaration `json:"declarations"`
 }
 
 // Afford reports what one member can still declare this turn: which of the
@@ -194,7 +203,10 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 		return nil, fmt.Errorf("afford: %w", translate(err))
 	}
 	if ClockKind(clock.Kind) != ClockTurn {
-		return &AffordOutput{Clock: ClockWorld}, nil
+		// A non-nil, empty slice: the world clock's Declarations marshals as
+		// "[]", never "null" — the same reason above applies to the wire
+		// shape as much as the tag.
+		return &AffordOutput{Clock: ClockWorld, Declarations: []Declaration{}}, nil
 	}
 
 	data, err := m.fetchCharacterData(ctx, "member", in.Member)
@@ -207,7 +219,7 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 	// reconstitution would bring. See compileAttack's own comment.
 	sheet, err := character.Load(ctx, data)
 	if err != nil {
-		return nil, fmt.Errorf("member %q: %w: %v", in.Member, ErrBadCharacter, err)
+		return nil, fmt.Errorf("afford: member %q: %w: %v", in.Member, ErrBadCharacter, err)
 	}
 
 	price, err := m.priceSwing(ctx, enc, in.Member, sheet)

--- a/rulebooks/dnd5e/session/afford_test.go
+++ b/rulebooks/dnd5e/session/afford_test.go
@@ -1,0 +1,239 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+)
+
+// afford_test.go pins rpg-toolkit#1138: the affordability read
+// [session.Manager.Afford] and the invariant its own doc promises — it answers
+// from the SAME price and the SAME gate a real swing pays through, never a
+// second copy of the arithmetic, so the two structurally cannot disagree.
+//
+// It reuses aFight and armedFighter from economy_test.go / attack_test.go
+// rather than building a fixture of its own: a scene built only for Afford
+// could quietly stop being the scene Attack's own economy runs through, which
+// is exactly the drift the invariant exists to rule out.
+type AffordSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	characters *fakeCharacters
+	mgr        *session.Manager
+}
+
+func TestAffordSuite(t *testing.T) { suite.Run(t, new(AffordSuite)) }
+
+// fightScene is economy_test.go's own, reused rather than copied so the two
+// suites are driving the identical scene.
+func (s *AffordSuite) fightScene(level int, rolls ...int) {
+	alice := armedFighter("alice")
+	alice.Level = level
+
+	s.mgr, s.sessions, s.encounters, s.characters = aFight(s.T(), alice, rolls)
+}
+
+func (s *AffordSuite) afford() *session.AffordOutput {
+	s.T().Helper()
+	out, err := s.mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	return out
+}
+
+func (s *AffordSuite) swing() (*session.AttackOutput, error) {
+	return s.mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "skeleton",
+	})
+}
+
+// nextTurn is economy_test.go's own: both ends of the round are ended
+// deliberately, since a round only advances when the order comes back around.
+func (s *AffordSuite) nextTurn() {
+	s.T().Helper()
+	ctx := context.Background()
+
+	for _, who := range []string{"alice", "skeleton"} {
+		_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: who})
+		s.Require().NoError(err, "ending %s's turn", who)
+	}
+}
+
+// storedEconomy reads alice's persisted action economy, the same read
+// economy_test.go's own TestARefusedSwingWritesNothing checks against.
+func (s *AffordSuite) storedEconomy() *character.ActionEconomyData {
+	s.T().Helper()
+	stored, ok := s.characters.byID["alice"]
+	s.Require().True(ok, "alice must be in the repository")
+	return stored.ActionEconomy
+}
+
+// TestAffordableMeansAttackWillNotRefuse is half the load-bearing invariant:
+// Affordable == true implies a following Attack in the same state is NOT
+// refused with ErrCannotAfford.
+//
+// A fresh turn's first swing is the case: nothing has been spent yet, so
+// there is nothing for either verb to disagree about.
+func (s *AffordSuite) TestAffordableMeansAttackWillNotRefuse() {
+	s.fightScene(1, 15, 5, 1, 1)
+
+	out := s.afford()
+	s.Equal(session.ClockTurn, out.Clock)
+	s.Require().Len(out.Declarations, 1)
+
+	decl := out.Declarations[0]
+	s.Equal(session.VerbAttack, decl.Verb)
+	s.True(decl.Affordable, "a fresh turn can still buy its first swing")
+	s.Empty(decl.Shortfall, "affordable carries no shortfall")
+	s.Equal(session.SlotAction, decl.Slot, "the first swing of a turn lights the action shape")
+
+	_, err := s.swing()
+	s.Require().NoError(err, "Afford said yes, so Attack must not refuse with ErrCannotAfford")
+}
+
+// TestUnaffordableMeansAttackRefusesWithTheSameShortfall is the other half:
+// Affordable == false implies a following Attack IS refused with
+// ErrCannotAfford, and Shortfall is the same currency text inside that
+// refusal — not a paraphrase of it.
+func (s *AffordSuite) TestUnaffordableMeansAttackRefusesWithTheSameShortfall() {
+	s.fightScene(1, 15, 5, 1, 1)
+
+	first, err := s.swing()
+	s.Require().NoError(err, "the Attack action buys the first swing")
+	s.Require().True(first.Hit)
+
+	out := s.afford()
+	s.Require().Len(out.Declarations, 1)
+	decl := out.Declarations[0]
+	s.False(decl.Affordable, "nothing left to buy a second swing")
+	s.NotEmpty(decl.Shortfall, "false carries a reason")
+	s.Equal(session.SlotAction, decl.Slot, "the currency that ran out is the action slot")
+
+	_, err = s.swing()
+	s.Require().Error(err, "and there is nothing left to buy a second")
+	s.ErrorIs(err, session.ErrCannotAfford)
+	s.Contains(err.Error(), decl.Shortfall,
+		"Afford's Shortfall must be the SAME currency text the refusal carries, not a second copy of it")
+}
+
+// TestBankedSwingIsAffordableAndLightsNoSlot walks Extra Attack's second
+// swing (the brief's own required fixture): affordable, and Slot is SlotNone
+// because a banked swing spends only capacity, never a per-turn slot.
+func (s *AffordSuite) TestBankedSwingIsAffordableAndLightsNoSlot() {
+	s.fightScene(5, 1, 1, 1, 1)
+
+	_, err := s.swing()
+	s.Require().NoError(err, "swing 1, bought by the Attack action")
+
+	out := s.afford()
+	decl := out.Declarations[0]
+	s.True(decl.Affordable, "extra attack banked a second swing")
+	s.Empty(decl.Shortfall)
+	s.Equal(session.SlotNone, decl.Slot,
+		"a banked swing spends capacity alone — nothing lights the action/bonus/reaction shapes")
+
+	_, err = s.swing()
+	s.Require().NoError(err, "Afford said yes, so Attack must not refuse")
+}
+
+// TestExtraAttacksThirdSwingIsUnaffordable is the same scene's other end: once
+// the bank Extra Attack granted is spent, the action itself has also already
+// been spent, and Afford must say so.
+func (s *AffordSuite) TestExtraAttacksThirdSwingIsUnaffordable() {
+	s.fightScene(5, 1, 1, 1, 1, 1, 1)
+
+	_, err := s.swing()
+	s.Require().NoError(err, "swing 1")
+	_, err = s.swing()
+	s.Require().NoError(err, "swing 2, bought by Extra Attack")
+
+	out := s.afford()
+	decl := out.Declarations[0]
+	s.False(decl.Affordable, "the bank Extra Attack granted is spent")
+	s.Contains(decl.Shortfall, "action",
+		"the action itself ran out too — it was spent buying the bank on swing 1")
+
+	_, err = s.swing()
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrCannotAfford)
+	s.Contains(err.Error(), decl.Shortfall)
+}
+
+// TestANewTurnRefillsWhatAffordSees is TestANewTurnRefillsTheBank's own claim,
+// asked through Afford instead of inferred from a swing succeeding: a bank
+// that is charged and never refilled would make Afford permanently say no
+// after the first turn.
+func (s *AffordSuite) TestANewTurnRefillsWhatAffordSees() {
+	s.fightScene(1, 1, 1, 1, 1)
+
+	_, err := s.swing()
+	s.Require().NoError(err)
+	s.False(s.afford().Declarations[0].Affordable, "spent, on turn one")
+
+	s.nextTurn()
+
+	out := s.afford()
+	s.Require().Len(out.Declarations, 1)
+	s.True(out.Declarations[0].Affordable, "a new turn buys a new swing")
+	s.Equal(session.SlotAction, out.Declarations[0].Slot)
+}
+
+// TestFreeRoamAffordsNothing is TestFreeRoamChargesNothing's own claim, asked
+// of Afford: a member with no bubble has no economy to report, and the answer
+// is EMPTY, not a Declaration reporting Affordable:true for a free action —
+// the two would look identical on a boolean and mean different things about
+// why nothing is spent.
+func (s *AffordSuite) TestFreeRoamAffordsNothing() {
+	sessions, encounters := newFakeSessions(), newFakeEncounters()
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, Sessions: sessions, Encounters: encounters,
+		Characters: testCharacters(), Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: offsetWorld(s.T()),
+	})
+	s.Require().NoError(err)
+
+	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal(session.ClockWorld, out.Clock)
+	s.Empty(out.Declarations, "empty, not zero — the economy does not apply on the world clock at all")
+}
+
+// TestAffordSavesNothing is TestARefusedSwingWritesNothing's own claim, asked
+// of a read that has no refusal to hide behind: Afford prices a turn by
+// readying it exactly as priceSwing does for a real swing, and that readying
+// must land on a sheet nobody saves.
+//
+// Both states are checked: a cold sheet Afford must not light and persist on
+// its own, and a sheet a real swing already lit and spent, which a second ask
+// must not touch any further.
+func (s *AffordSuite) TestAffordSavesNothing() {
+	s.fightScene(1, 15, 5, 1, 1)
+
+	s.Nil(s.storedEconomy(), "a stored sheet starts cold: no economy at all")
+
+	before := s.afford()
+	s.True(before.Declarations[0].Affordable)
+	s.Nil(s.storedEconomy(),
+		"asking what alice can afford must not light and persist her turn — a read that ignited "+
+			"the ledger on the way to answering would make asking indistinguishable from swinging")
+
+	_, err := s.swing()
+	s.Require().NoError(err, "the real swing lights and spends the economy")
+	afterSwing := *s.storedEconomy()
+
+	s.afford()
+	s.Equal(afterSwing, *s.storedEconomy(),
+		"asking again must not touch the sheet the real swing already wrote")
+}

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -195,7 +195,7 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 	// actor's swing costs — which is a question about a sheet, and this is where
 	// the sheets are. Nothing persistent or wire-shaped assumed attacks were
 	// free, and nothing had to migrate.
-	price, err := m.priceSwing(ctx, scope, in.Attacker, sheet)
+	price, err := m.priceSwing(ctx, scope.enc, in.Attacker, sheet)
 	if err != nil {
 		return nil, fmt.Errorf("attack: %w", err)
 	}

--- a/rulebooks/dnd5e/session/economy.go
+++ b/rulebooks/dnd5e/session/economy.go
@@ -84,12 +84,16 @@ type swingPrice struct {
 // is above this seam — and it must not be discovered then. It is named here
 // rather than left to be found.
 //
+// It takes the encounter rather than a *writeScope so a read verb can call it
+// too ([Manager.Afford] does): pricing a swing commits nothing on its own, and
+// a signature that could only be handed a write scope would say otherwise.
+//
 // Returns ErrNoMember, ErrNoCharacter, ErrBadCharacter, ErrBadRepository, or
 // ErrBadCost.
 func (m *Manager) priceSwing(
-	ctx context.Context, scope *writeScope, attacker string, sheet *character.Character,
+	ctx context.Context, enc *encounter.Encounter, attacker string, sheet *character.Character,
 ) (*swingPrice, error) {
-	clock, err := scope.enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(attacker)})
+	clock, err := enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(attacker)})
 	if err != nil {
 		return nil, translate(err)
 	}

--- a/rulebooks/dnd5e/session/wirecontract_test.go
+++ b/rulebooks/dnd5e/session/wirecontract_test.go
@@ -67,3 +67,25 @@ func TestFalseIsAnAnswerOnTheWire(t *testing.T) {
 		require.Equal(t, "false", string(wire.Walls[0][field]))
 	}
 }
+
+// TestEmptyDeclarationsIsAnAnswerOnTheWire is TestFalseIsAnAnswerOnTheWire's
+// own claim asked of a LIST rather than a bool: on the world clock,
+// AffordOutput.Declarations is empty because the economy does not apply, not
+// because nobody set the field. `omitempty` on a slice drops the key on nil
+// exactly the way it drops a bool on false, and a non-Go client reading a
+// missing "declarations" key cannot tell "the world clock, honestly empty"
+// from "an older server that never had this field" or "a bug that forgot to
+// set it". So the empty case still marshals the key, as "[]" rather than a
+// missing entry or "null".
+func TestEmptyDeclarationsIsAnAnswerOnTheWire(t *testing.T) {
+	out := session.AffordOutput{Clock: session.ClockWorld, Declarations: []session.Declaration{}}
+
+	raw, err := json.Marshal(out)
+	require.NoError(t, err)
+
+	var wire map[string]json.RawMessage
+	require.NoError(t, json.Unmarshal(raw, &wire))
+	require.Contains(t, wire, "declarations",
+		"the world clock's empty answer must still be a key on the wire: %s", raw)
+	require.JSONEq(t, "[]", string(wire["declarations"]))
+}


### PR DESCRIPTION
## The gap

`Attack` refuses a swing the member can't pay for (`ErrCannotAfford`,
naming the currency that ran out). Nothing on the seam let a client ask
BEFORE swinging — a turn UI had to either offer the button and let the
server refuse it, or re-derive D&D's action economy client-side (the
Boundary Rule violation this seam exists to prevent). Closes #1138.

## Decision

`Manager.Afford(ctx, *AffordInput) (*AffordOutput, error)`, a caller-scoped
singular read in the spirit of `Where`. It answers in **declarations**,
not remaining currencies — Kirk's ruling: *"backend tells dumb client what
it can do."* `{action: 0, bonus: 1}` would still make a client know a
swing costs an action and that Extra Attack banks capacity; a
`Declaration{Verb, Slot, Affordable, Shortfall}` answers the client's
actual question (can I do this) and keeps the pricing server-side.

`Slot` is read off the same `SpendProfile.Slots` the door would charge —
never a second table — so a UI can light the action/bonus/reaction shapes
it already draws.

This read deliberately does **not** gate on whose turn it currently is
(verified: `Attack` doesn't check that either today) — that's `Turn`'s
question, not the economy's. See ADR-0042 for the full options
considered (currencies / declarations / both) and the reasoning.

## The invariant

`Afford` must answer from the SAME pricing path `Attack` pays through —
never a second copy of the arithmetic. It calls the identical
`priceSwing` a real swing compiles from (refactored to take the encounter
directly rather than a `*writeScope`, since pricing commits nothing), then
charges that price through `combat.Pay` — the same gate function
`resolution`'s door pays through — against a `character.Character` loaded
fresh for the call and handed to nobody: never adopted, never saved. A
payment that succeeds is `Affordable`; one that fails hands back `Pay`'s
own error text as `Shortfall`, verbatim.

## Evidence

```
=== RUN   TestAffordSuite
--- PASS: TestAffordSuite (0.01s)
    --- PASS: TestAffordSuite/TestANewTurnRefillsWhatAffordSees (0.00s)
    --- PASS: TestAffordSuite/TestAffordSavesNothing (0.00s)
    --- PASS: TestAffordSuite/TestAffordableMeansAttackWillNotRefuse (0.00s)
    --- PASS: TestAffordSuite/TestBankedSwingIsAffordableAndLightsNoSlot (0.00s)
    --- PASS: TestAffordSuite/TestExtraAttacksThirdSwingIsUnaffordable (0.00s)
    --- PASS: TestAffordSuite/TestFreeRoamAffordsNothing (0.00s)
    --- PASS: TestAffordSuite/TestUnaffordableMeansAttackRefusesWithTheSameShortfall (0.00s)
ok  	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session	1.506s (go test -race ./...)
```

Full `go test -race ./...` for `rulebooks/dnd5e/session` and
`rulebooks/dnd5e/combat` (combat untouched) both green.
`golangci-lint run ./...` (auto-discovered config,
`rulebooks/dnd5e/.golangci.yml`): 0 issues, in both modules.
`gorelease -base=v0.21.2`: all changes additive/compatible, suggests
v0.22.0 (left for auto-tag). `scripts/check-decisions.sh`: passes.
`TestBoundarySuite`: passes — no inner type crosses `Afford`'s exported
surface.

## ADR

docs/adr/0042-afford-answers-in-declarations-not-currencies.md — options
(currencies / declarations / both), Kirk's ruling, and what this read
deliberately leaves to `Turn` and to `Attack`'s own weapon compilation.

## Review round (f08e1ab)

Gate review (team-lead) caught that `Declarations` and `Shortfall` had
`omitempty` — breaking the package's own false-vs-absent law (types.go):
the world clock's empty `Declarations` and an affordable `Shortfall` of
`""` are both answers, not absences. Fixed: both tags dropped, the
world-clock branch now returns a non-nil `[]Declaration{}` so it marshals
as `[]` rather than `null`, and `TestEmptyDeclarationsIsAnAnswerOnTheWire`
pins it (`wirecontract_test.go`, sibling to `TestFalseIsAnAnswerOnTheWire`).

Copilot's one round (requested via GraphQL, verified via node query) came
back 🟢 approval recommended, one real finding: the `character.Load`
failure path in `Afford` was missing the `afford:` prefix every other
return in the method carries. Fixed in the same commit, replied in-thread.

All CI green: gorelease (session, encounter, play/clock, play/intel,
play/interrupt, play/record all pass — additive/compatible), docs-decisions,
test-changed (session). `go test -race ./...` and `golangci-lint run ./...`
(auto-discovered `rulebooks/dnd5e/.golangci.yml`, matching CI) both clean.

— asset-pipeline agent, on behalf of KirkDiggler
