### PR TITLE
resolution: thread the required TurnDriver capability through (#1162)

### DIFF
--- a/rulebooks/dnd5e/resolution/character_attack_test.go
+++ b/rulebooks/dnd5e/resolution/character_attack_test.go
@@ -121,9 +121,10 @@ func (s *CharacterAttackTestSuite) mainHand() *CharacterAttackInput {
 // world puts the hero next to the wolf. Adjacency matters only to prone's
 // range predicate, which nobody here triggers.
 func (s *CharacterAttackTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
@@ -139,7 +140,7 @@ func (s *CharacterAttackTestSuite) world() encounter.EncounterData {
 func (s *CharacterAttackTestSuite) swingAt(
 	hero *character.Data, profile AttackProfile, roller *sequenceRoller,
 ) (*Output, error) {
-	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: roller,
+	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: roller,
 		World: s.world(),
 		Participants: []Participant{
 			{Character: hero},

--- a/rulebooks/dnd5e/resolution/contest_test.go
+++ b/rulebooks/dnd5e/resolution/contest_test.go
@@ -67,9 +67,10 @@ func (s *ContestTestSuite) wolfsKnockdown() *saves.SaveGate {
 }
 
 func (s *ContestTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
@@ -145,7 +146,7 @@ func (s *ContestTestSuite) contest(gate *saves.SaveGate, roller *scriptedRoller)
 }
 
 func (s *ContestTestSuite) resolve(hero *character.Data, machine Machine) *Output {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: hero}, {Monster: s.wolfData()}},
 		Machine:      machine,
@@ -252,14 +253,14 @@ func (s *ContestTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
 		return &scriptedRoller{single: straightRoll, pair: []int{straightRoll, straightRoll}}
 	}
 
-	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.hero(s.raging())}, {Monster: s.wolfData()}},
 		Machine:      s.contest(s.wolfsKnockdown(), roller()),
 	})
 	s.Require().NoError(err)
 
-	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Monster: s.wolfData()}, {Character: s.hero(s.raging())}},
 		Machine:      s.contest(s.wolfsKnockdown(), roller()),
@@ -311,7 +312,7 @@ func (s *ContestTestSuite) TestTheDCComesFromTheGate() {
 		Recurrence: saves.RecurrenceNone,
 	}
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.hero()}, {Monster: s.wolfData()}},
 		Machine: NewContest(&ContestInput{
@@ -334,7 +335,7 @@ func (s *ContestTestSuite) TestARecurringGateIsRefused() {
 	gate := saves.NewSaveGate(abilities.STR, 11)
 	gate.Recurrence = saves.RecurrenceEndOfTurn
 
-	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.hero()}, {Monster: s.wolfData()}},
 		Machine:      s.contest(gate, &scriptedRoller{single: straightRoll}),
@@ -347,7 +348,7 @@ func (s *ContestTestSuite) TestARecurringGateIsRefused() {
 
 func (s *ContestTestSuite) TestRefusesAContestItCannotRun() {
 	s.Run("no gate", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.hero()}},
 			Machine: NewContest(&ContestInput{
@@ -359,7 +360,7 @@ func (s *ContestTestSuite) TestRefusesAContestItCannotRun() {
 	})
 
 	s.Run("an invalid gate", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.hero()}},
 			Machine: NewContest(&ContestInput{
@@ -372,7 +373,7 @@ func (s *ContestTestSuite) TestRefusesAContestItCannotRun() {
 	})
 
 	s.Run("no consequence", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.hero()}},
 			Machine:      NewContest(&ContestInput{Gate: s.wolfsKnockdown(), SaverID: heroID}),
@@ -381,7 +382,7 @@ func (s *ContestTestSuite) TestRefusesAContestItCannotRun() {
 	})
 
 	s.Run("a saver who is not a participant", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.hero()}},
 			Machine: NewContest(&ContestInput{
@@ -425,7 +426,7 @@ func (s *ContestTestSuite) TestTheImpositionStepSaysWhatItDoes() {
 // contest rolls anything — rather than a description reading "unknown" and a
 // contest that imposes something nobody can name.
 func (s *ContestTestSuite) TestAConsequenceWithNoRefIsRefused() {
-	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.hero()}, {Monster: s.wolfData()}},
 		Machine: NewContest(&ContestInput{

--- a/rulebooks/dnd5e/resolution/cost_test.go
+++ b/rulebooks/dnd5e/resolution/cost_test.go
@@ -134,9 +134,10 @@ func (s *CostTestSuite) strikeCost(data *character.Data) *combat.SpendProfile {
 }
 
 func (s *CostTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
@@ -207,7 +208,7 @@ func (s *CostTestSuite) swing(
 		Roller:     roller,
 	})}
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: hero}, {Monster: monsters.NewWolf(wolfID).ToData()}},
 		Machine:      machine,
@@ -223,7 +224,7 @@ func (s *CostTestSuite) swing(
 // ErrNoMachine's own doc blesses the form ("distinct from a machine that
 // finishes immediately, which is legal").
 func (s *CostTestSuite) declare(hero *character.Data, cost *Cost) (*Output, error) {
-	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: hero}, {Monster: monsters.NewWolf(wolfID).ToData()}},
 		Machine:      &captureMachine{},
@@ -473,7 +474,7 @@ func (s *CostTestSuite) TestACostKeyedToACurrencyNoLedgerHoldsIsRefused() {
 func (s *CostTestSuite) TestAMalformedCostIsRefusedBeforeTheWorldIsLoaded() {
 	hero := s.hero(s.economy(firstTurn, 1, bankedAttacks))
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        encounter.EncounterData{},
 		Participants: []Participant{{Character: hero}},
 		Machine:      &captureMachine{},
@@ -581,7 +582,7 @@ func (s *CostTestSuite) TestARefusedPaymentLeavesNothingOnTheBus() {
 	hero := s.hero(s.economy(firstTurn, 1, 0))
 	hero.Conditions = []json.RawMessage{s.raging()}
 
-	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: hero}, {Monster: monsters.NewWolf(wolfID).ToData()}},
 		Machine:      &captureMachine{},

--- a/rulebooks/dnd5e/resolution/damage_custody_test.go
+++ b/rulebooks/dnd5e/resolution/damage_custody_test.go
@@ -62,7 +62,7 @@ func (s *DamageCustodyTestSuite) biteOnBus(
 	attack, err := AttackFromMonsterAction(data.Actions[0])
 	s.Require().NoError(err)
 
-	return resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	return resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.roomWith(encounter.MemberID(wolfID), encounter.MemberID(target.ID)),
 		Participants: []Participant{{Monster: data}, {Monster: target}},
 		Machine: NewStrike(&StrikeInput{
@@ -166,7 +166,7 @@ func (s *DamageCustodyTestSuite) TestTypedOutcomePreservesMixedVulnerabilityAndI
 		damage.Damage{Dice: "1d6", Type: damage.Acid},
 	)
 	target := monsters.NewWolf(secondWolfID).ToData()
-	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.roomWith(encounter.MemberID(wolfID), encounter.MemberID(target.ID)),
 		Participants: []Participant{{Monster: monsters.NewWolf(wolfID).ToData()}, {Monster: target}},
 		Machine: NewStrike(&StrikeInput{
@@ -194,9 +194,10 @@ func (s *DamageCustodyTestSuite) TestTypedOutcomePreservesMixedVulnerabilityAndI
 // Real content, and the case a synthetic subscriber cannot pin: a raging
 // barbarian takes half from the wolf's piercing bite.
 func (s *DamageCustodyTestSuite) TestARagingTargetsResistanceReadsTheEventsDamageType() {
-	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
@@ -218,7 +219,7 @@ func (s *DamageCustodyTestSuite) TestARagingTargetsResistanceReadsTheEventsDamag
 	}).ToJSON()
 	s.Require().NoError(err)
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: world.ToData(),
 		Participants: []Participant{
 			{Character: s.ragingHero(raging)},
@@ -325,9 +326,10 @@ func (s *DamageCustodyTestSuite) addFlatOnBus(bus events.EventBus, amount int, t
 // it keeps a character's AC chain out of the arithmetic under test, and the
 // damage fold is the same fold whoever is swinging.
 func (s *DamageCustodyTestSuite) roomWith(attacker, target encounter.MemberID) encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: attacker, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},

--- a/rulebooks/dnd5e/resolution/declared_consequence_test.go
+++ b/rulebooks/dnd5e/resolution/declared_consequence_test.go
@@ -63,9 +63,10 @@ func (s *DeclaredConsequenceTestSuite) biteProfile() AttackProfile {
 // world places the hero and the wolf three cells apart — far enough that
 // prone's range predicate stays out of these cases.
 func (s *DeclaredConsequenceTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
@@ -106,7 +107,7 @@ func (s *DeclaredConsequenceTestSuite) hero() *character.Data {
 }
 
 func (s *DeclaredConsequenceTestSuite) resolve(machine Machine) (*Output, error) {
-	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Character: s.hero()},

--- a/rulebooks/dnd5e/resolution/effective_ac_test.go
+++ b/rulebooks/dnd5e/resolution/effective_ac_test.go
@@ -98,9 +98,10 @@ func (s *EffectiveACTestSuite) defenseStyle() json.RawMessage {
 }
 
 func (s *EffectiveACTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
@@ -120,7 +121,7 @@ func (s *EffectiveACTestSuite) biteAt(hero *character.Data, roll int) StrikeOutc
 	attack, err := AttackFromMonsterAction(data.Actions[0])
 	s.Require().NoError(err)
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: hero}, {Monster: data}},
 		Machine: NewStrike(&StrikeInput{
@@ -188,9 +189,10 @@ func (s *EffectiveACTestSuite) TestAMonsterTargetStillReportsItsStatBlockAC() {
 	attack, err := AttackFromMonsterAction(data.Actions[0])
 	s.Require().NoError(err)
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
@@ -200,7 +202,7 @@ func (s *EffectiveACTestSuite) TestAMonsterTargetStillReportsItsStatBlockAC() {
 	})
 	s.Require().NoError(err)
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        enc.ToData(),
 		Participants: []Participant{{Monster: data}, {Monster: second}},
 		Machine: NewStrike(&StrikeInput{

--- a/rulebooks/dnd5e/resolution/errors.go
+++ b/rulebooks/dnd5e/resolution/errors.go
@@ -44,6 +44,21 @@ var (
 	// rule about light it cannot see (rpg-toolkit#1111, rpg-toolkit#1033).
 	ErrNoSight = errors.New("resolution: no sight capability")
 
+	// ErrNoTurnDriver indicates an interaction given no way to decide what an
+	// unplayed member does when a fight's clock lands on their turn. The
+	// composition requires one to load at all, the same way it requires an
+	// initiative roller, a standing capability and a sight capability
+	// (rpg-toolkit#1162).
+	//
+	// Nothing in this package consults it, for ErrNoStanding's reason: the
+	// world is loaded here, one interaction runs, and it is read back out as
+	// data — this package never calls EndTurn, Transfer or Exit, so the
+	// question this capability answers is never put. Carried rather than
+	// invented, because a package that answered "it passes" on the caller's
+	// behalf would be deciding a rule it cannot see, the same way ErrNoStanding
+	// and ErrNoSight already refuse to guess.
+	ErrNoTurnDriver = errors.New("resolution: no turn driver capability")
+
 	// ErrNoMachine indicates an interaction with nothing to resolve. Distinct
 	// from a machine that finishes immediately, which is legal.
 	ErrNoMachine = errors.New("resolution: no machine")

--- a/rulebooks/dnd5e/resolution/errors.go
+++ b/rulebooks/dnd5e/resolution/errors.go
@@ -52,7 +52,7 @@ var (
 	//
 	// Nothing in this package consults it, for ErrNoStanding's reason: the
 	// world is loaded here, one interaction runs, and it is read back out as
-	// data — this package never calls EndTurn, Transfer or Exit, so the
+	// data — this package never calls EndTurn, form, Transfer or Exit, so the
 	// question this capability answers is never put. Carried rather than
 	// invented, because a package that answered "it passes" on the caller's
 	// behalf would be deciding a rule it cannot see, the same way ErrNoStanding

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -7,8 +7,8 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.21.0
-	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0
+	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -18,10 +18,10 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.21.0 h1:gh43waX8aBfbs3GgZMwpdidelEqpnsrz36nZDxjcsNw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.21.0/go.mod h1:tQcF1xe+vxp2S+WRO/aIhq0f4TxRNyUOVO4hm8LWLGQ=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1 h1:NrXhgXVH5ozDLqi3iZk/p6YJI07kMIDA3WeXDQ69Uls=
-github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.9.1/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0 h1:BnDZ//xyK/vcFmhUyDV8mRd4KSnj6Ofrz5Kpxy0GH1o=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
+github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -141,6 +141,18 @@ type Input struct {
 	// fine. Validate has answered ErrNoRoller ever since; only this line had
 	// not caught up.
 	Roller dice.Roller
+
+	// TurnDriver decides what a member with no player does when a fight's
+	// clock lands on their turn. REQUIRED.
+	//
+	// Carried, never consulted — the same shape as Standing and Sight, and for
+	// the same reason: this package loads the world, runs one interaction, and
+	// reads it back out as data, so it never calls EndTurn, form, Transfer or
+	// Exit itself. The composition still refuses to load without one
+	// (rpg-toolkit#1162), and answering on the caller's behalf — "it passes" —
+	// would be this package deciding a rule it holds no opinion on. So it is
+	// handed over, the way Deciders, Initiative, Standing and Sight above are.
+	TurnDriver encounter.TurnDriver
 }
 
 // Validate reports whether this input describes a resolvable interaction.
@@ -168,6 +180,9 @@ func (in *Input) Validate() error {
 	}
 	if in.Sight == nil {
 		return ErrNoSight
+	}
+	if in.TurnDriver == nil {
+		return ErrNoTurnDriver
 	}
 	if in.Roller == nil {
 		return ErrNoRoller
@@ -277,6 +292,7 @@ func resolveOn(ctx context.Context, in *Input, surf *surface) (*Output, error) {
 		Initiative: in.Initiative,
 		Standing:   in.Standing,
 		Sight:      in.Sight,
+		TurnDriver: in.TurnDriver,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("resolution: load world: %w", err)

--- a/rulebooks/dnd5e/resolution/resolve_test.go
+++ b/rulebooks/dnd5e/resolution/resolve_test.go
@@ -596,6 +596,14 @@ func TestCapabilitiesAreSuppliedNeverDefaulted(t *testing.T) {
 		require.ErrorIs(t, err, ErrNoSight)
 	})
 
+	t.Run("no turn driver", func(t *testing.T) {
+		err := (&Input{
+			Machine: machine, Initiative: orderAsGiven{}, Standing: everyoneStanding{},
+			Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		}).Validate()
+		require.ErrorIs(t, err, ErrNoTurnDriver)
+	})
+
 	t.Run("no roller", func(t *testing.T) {
 		err := (&Input{
 			Machine: machine, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},

--- a/rulebooks/dnd5e/resolution/resolve_test.go
+++ b/rulebooks/dnd5e/resolution/resolve_test.go
@@ -69,9 +69,10 @@ func (s *ResolveTestSuite) SetupTest() {
 // world is a two-member encounter, already normalised by a load/save cycle so
 // that "unchanged" can be asserted literally.
 func (s *ResolveTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
@@ -215,7 +216,7 @@ func (s *ResolveTestSuite) outcomeOf(out *Output) SaveOutcome {
 // own predicate decided it applied. This single assertion is ADR-0038 end to
 // end.
 func (s *ResolveTestSuite) TestRagingBarbarianGetsAdvantageOnAStrengthSave() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian(s.raging())}},
 		Machine:      s.save(abilities.STR),
@@ -237,7 +238,7 @@ func (s *ResolveTestSuite) TestRagingBarbarianGetsAdvantageOnAStrengthSave() {
 // The control that makes the headline mean something: the same barbarian, the
 // same save, no condition — a straight roll.
 func (s *ResolveTestSuite) TestTheSameBarbarianWithoutRageRollsStraight() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian()}},
 		Machine:      s.save(abilities.STR),
@@ -252,7 +253,7 @@ func (s *ResolveTestSuite) TestTheSameBarbarianWithoutRageRollsStraight() {
 
 // The second effect, on a different chain, through the same machinery.
 func (s *ResolveTestSuite) TestDodgingGrantsAdvantageOnADexteritySave() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian(s.dodging())}},
 		Machine:      s.save(abilities.DEX),
@@ -267,7 +268,7 @@ func (s *ResolveTestSuite) TestDodgingGrantsAdvantageOnADexteritySave() {
 // Applicability is the effect's own predicate, never resolution's. Raging is
 // attached for a DEX save exactly as it is for a STR save, and declines.
 func (s *ResolveTestSuite) TestRagingDeclinesADexteritySaveOnItsOwn() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian(s.raging())}},
 		Machine:      s.save(abilities.DEX),
@@ -285,7 +286,7 @@ func (s *ResolveTestSuite) TestRagingDeclinesADexteritySaveOnItsOwn() {
 // R3. A participant nobody expected to matter is passed in, attaches, and folds
 // nothing. Pass-everyone-in costs correctness nothing.
 func (s *ResolveTestSuite) TestAnIrrelevantParticipantAttachesAndFoldsNothing() {
-	alone, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	alone, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian(s.raging())}},
 		Machine:      s.save(abilities.STR),
@@ -293,7 +294,7 @@ func (s *ResolveTestSuite) TestAnIrrelevantParticipantAttachesAndFoldsNothing() 
 	s.Require().NoError(err)
 
 	s.SetupTest()
-	together, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	together, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Character: s.barbarian(s.raging())},
@@ -315,7 +316,7 @@ func (s *ResolveTestSuite) TestAnIrrelevantParticipantAttachesAndFoldsNothing() 
 // caller happened to list participants in. Without this, a resumed suspension
 // could attach into a differently-ordered world.
 func (s *ResolveTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
-	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Character: s.barbarian(s.raging())},
@@ -326,7 +327,7 @@ func (s *ResolveTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
 	s.Require().NoError(err)
 
 	s.SetupTest()
-	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Monster: s.skeleton()},
@@ -347,7 +348,7 @@ func (s *ResolveTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
 func (s *ResolveTestSuite) TestNothingSurvivesTheCall() {
 	inner := events.NewEventBus()
 
-	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.barbarian(s.raging())}},
 		Machine:      s.save(abilities.STR),
@@ -378,7 +379,7 @@ func (s *ResolveTestSuite) TestTheWorldRoundTripsUnchanged() {
 	before, err := json.Marshal(world)
 	s.Require().NoError(err)
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        world,
 		Participants: []Participant{{Character: s.barbarian(s.raging())}},
 		Machine:      s.save(abilities.STR),
@@ -413,7 +414,7 @@ func (s *ResolveTestSuite) TestTheWorldRoundTripsUnchanged() {
 func (s *ResolveTestSuite) TestAMonstersActionsSurviveResolution() {
 	machine := &captureMachine{}
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Monster: s.skeleton()}},
 		Machine:      machine,
@@ -435,7 +436,7 @@ func (s *ResolveTestSuite) TestAMonstersActionsSurviveResolution() {
 // A save changes nobody, so nobody comes back dirty. The point is that dirty
 // means dirty rather than "was present".
 func (s *ResolveTestSuite) TestASaveLeavesNobodyDirty() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Character: s.barbarian(s.raging())},
@@ -458,13 +459,13 @@ func (s *ResolveTestSuite) TestNilInputRejected() {
 }
 
 func (s *ResolveTestSuite) TestMissingMachineRejected() {
-	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(), World: s.world()})
+	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(), World: s.world()})
 	s.Require().ErrorIs(err, ErrNoMachine)
 }
 
 func (s *ResolveTestSuite) TestBadParticipantsRejected() {
 	s.Run("empty", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{}},
 			Machine:      s.save(abilities.STR),
@@ -473,7 +474,7 @@ func (s *ResolveTestSuite) TestBadParticipantsRejected() {
 	})
 
 	s.Run("both a character and a monster", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.barbarian(), Monster: s.skeleton()}},
 			Machine:      s.save(abilities.STR),
@@ -482,7 +483,7 @@ func (s *ResolveTestSuite) TestBadParticipantsRejected() {
 	})
 
 	s.Run("the same id twice", func() {
-		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 			World:        s.world(),
 			Participants: []Participant{{Character: s.barbarian()}, {Character: s.barbarian(s.raging())}},
 			Machine:      s.save(abilities.STR),
@@ -494,7 +495,7 @@ func (s *ResolveTestSuite) TestBadParticipantsRejected() {
 // Rolling a save for someone who was not passed in would silently drop their
 // modifier and every effect they carry, and still return a plausible number.
 func (s *ResolveTestSuite) TestASaverWhoIsNotAParticipantIsRefused() {
-	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	_, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Monster: s.skeleton()}},
 		Machine:      NewSave(&SaveInput{SaverID: "nobody", Ability: abilities.STR, DC: saveDifficulty}),
@@ -505,7 +506,7 @@ func (s *ResolveTestSuite) TestASaverWhoIsNotAParticipantIsRefused() {
 func (s *ResolveTestSuite) TestAMonsterCanSucceedOnASavingThrow() {
 	s.roller.single = 11
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Monster: s.wolf()}},
 		Machine: NewSave(&SaveInput{
@@ -526,7 +527,7 @@ func (s *ResolveTestSuite) TestAMonsterCanSucceedOnASavingThrow() {
 func (s *ResolveTestSuite) TestAMonsterCanFailASavingThrowWithANegativeModifier() {
 	s.roller.single = 10
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Monster: s.wolf()}},
 		Machine: NewSave(&SaveInput{
@@ -584,20 +585,20 @@ func TestCapabilitiesAreSuppliedNeverDefaulted(t *testing.T) {
 	})
 
 	t.Run("no standing", func(t *testing.T) {
-		err := (&Input{Machine: machine, Initiative: orderAsGiven{}, Roller: dice.NewRoller()}).Validate()
+		err := (&Input{Machine: machine, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Roller: dice.NewRoller()}).Validate()
 		require.ErrorIs(t, err, ErrNoStanding)
 	})
 
 	t.Run("no sight", func(t *testing.T) {
 		err := (&Input{
-			Machine: machine, Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
+			Machine: machine, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Roller: dice.NewRoller(),
 		}).Validate()
 		require.ErrorIs(t, err, ErrNoSight)
 	})
 
 	t.Run("no roller", func(t *testing.T) {
 		err := (&Input{
-			Machine: machine, Initiative: orderAsGiven{}, Standing: everyoneStanding{},
+			Machine: machine, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
 			Sight: everyoneSeesTheWholeMap{},
 		}).Validate()
 		require.ErrorIs(t, err, ErrNoRoller)
@@ -605,7 +606,7 @@ func TestCapabilitiesAreSuppliedNeverDefaulted(t *testing.T) {
 
 	t.Run("all supplied", func(t *testing.T) {
 		err := (&Input{
-			Machine: machine, Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+			Machine: machine, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		}).Validate()
 		require.NoError(t, err)
 	})
@@ -634,9 +635,10 @@ func (c *countingStanding) Standing(_ []encounter.MemberID) ([]encounter.MemberI
 // zero is how that stays a decision rather than a coincidence.
 func TestTheStandingCapabilityIsCarriedAndNeverAsked(t *testing.T) {
 	world, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
@@ -647,7 +649,7 @@ func TestTheStandingCapabilityIsCarriedAndNeverAsked(t *testing.T) {
 
 	counter := &countingStanding{}
 	out, err := Resolve(context.Background(), &Input{
-		Initiative: orderAsGiven{}, Standing: counter, Sight: everyoneSeesTheWholeMap{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: counter, Sight: everyoneSeesTheWholeMap{},
 		Roller: dice.NewRoller(),
 		World:  world.ToData(),
 		Participants: []Participant{{Character: &character.Data{
@@ -699,9 +701,10 @@ func (c *countingSight) Sight(members []encounter.MemberID) (map[encounter.Membe
 // darkvision it holds nothing of.
 func TestTheSightCapabilityIsCarriedAndNeverAsked(t *testing.T) {
 	world, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
@@ -712,7 +715,7 @@ func TestTheSightCapabilityIsCarriedAndNeverAsked(t *testing.T) {
 
 	counter := &countingSight{}
 	out, err := Resolve(context.Background(), &Input{
-		Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: counter,
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: counter,
 		Roller: dice.NewRoller(),
 		World:  world.ToData(),
 		Participants: []Participant{{Character: &character.Data{

--- a/rulebooks/dnd5e/resolution/strictness_test.go
+++ b/rulebooks/dnd5e/resolution/strictness_test.go
@@ -65,9 +65,10 @@ func (s *StrictnessTestSuite) SetupTest() {
 // world is a two-member encounter: the hero, and a second character whose sheet
 // is the corrupt one.
 func (s *StrictnessTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
@@ -131,7 +132,7 @@ func (s *StrictnessTestSuite) save() Machine {
 // error says which participant and which blob. The legacy path resolved it
 // happily, one effect short, and returned a sheet to persist in that state.
 func (s *StrictnessTestSuite) TestAnUnroutableConditionFailsTheResolution() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.sheet(heroID, unroutable)}},
 		Machine:      s.save(),
@@ -146,7 +147,7 @@ func (s *StrictnessTestSuite) TestAnUnroutableConditionFailsTheResolution() {
 // The control that makes the refusal mean something: the same sheet, the same
 // machine, a condition this build does know — and the resolution runs.
 func (s *StrictnessTestSuite) TestTheSameSheetWithAReadableConditionResolves() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.sheet(heroID, s.raging(heroID))}},
 		Machine:      s.save(),
@@ -167,7 +168,7 @@ func (s *StrictnessTestSuite) TestTheSameSheetWithAReadableConditionResolves() {
 func (s *StrictnessTestSuite) TestAFailedResolutionLeavesNothingOnTheBus() {
 	inner := events.NewEventBus()
 
-	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: s.world(),
 		Participants: []Participant{
 			{Character: s.sheet(heroID, s.raging(heroID))},
@@ -207,9 +208,10 @@ func (s *StrictnessTestSuite) TestAnUnroutableMonsterTraitFailsTheResolution() {
 		},
 	}
 
-	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
@@ -219,7 +221,7 @@ func (s *StrictnessTestSuite) TestAnUnroutableMonsterTraitFailsTheResolution() {
 	})
 	s.Require().NoError(err)
 
-	out, resolveErr := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, resolveErr := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: world.ToData(),
 		Participants: []Participant{
 			{Character: s.sheet(heroID)},
@@ -268,7 +270,7 @@ func (b *refusingBus) Publish(ctx context.Context, topic events.Topic, event any
 func (s *StrictnessTestSuite) TestAnAttachThatFailsFailsTheResolution() {
 	bus := &refusingBus{inner: events.NewEventBus(), failOn: 1}
 
-	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World:        s.world(),
 		Participants: []Participant{{Character: s.sheet(heroID, s.raging(heroID))}},
 		Machine:      s.save(),

--- a/rulebooks/dnd5e/resolution/strike_test.go
+++ b/rulebooks/dnd5e/resolution/strike_test.go
@@ -105,9 +105,10 @@ func (s *StrikeTestSuite) wolfBite() monster.ActionData {
 // hero; otherwise it stands three cells away — the two sides of prone's range
 // split.
 func (s *StrikeTestSuite) world(secondWolfAt spatial.Position) encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
@@ -195,7 +196,7 @@ func (s *StrikeTestSuite) strike(attacker string, roller *scriptedRoller) Machin
 func (s *StrikeTestSuite) resolve(
 	world encounter.EncounterData, hero *character.Data, machine Machine,
 ) (*Output, error) {
-	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	return Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: world,
 		Participants: []Participant{
 			{Character: hero},
@@ -329,7 +330,7 @@ func (s *StrikeTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
 		return &scriptedRoller{single: hitRoll, pair: []int{hitRoll, hitRoll}}
 	}
 
-	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	forward, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: world,
 		Participants: []Participant{
 			{Character: s.hero(s.raging())},
@@ -340,7 +341,7 @@ func (s *StrikeTestSuite) TestRegistrationsDoNotDependOnInputOrder() {
 	})
 	s.Require().NoError(err)
 
-	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	reversed, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: world,
 		Participants: []Participant{
 			{Monster: s.wolf(secondWolfID)},
@@ -366,7 +367,7 @@ func (s *StrikeTestSuite) TestTheStrikeRunsInPieces() {
 	surf := newSurface(events.NewEventBus())
 
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Data: world, Initiative: orderAsGiven{}, Standing: everyoneStanding{},
+		Data: world, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
 		Sight: everyoneSeesTheWholeMap{},
 	})
 	s.Require().NoError(err)
@@ -459,7 +460,7 @@ func (s *StrikeTestSuite) TestStrikePublishesPostAttackRollForSubscribers() {
 // strikeMachine.afterDamage: the topic is an instruction to one listener and a
 // notification to another, which is slice 2's classification to make.
 func (s *StrikeTestSuite) TestAMonsterTargetTakesItsDamageOnce() {
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: s.world(spatial.Position{X: 5, Y: 4}),
 		Participants: []Participant{
 			{Character: s.hero()},
@@ -550,7 +551,7 @@ func (s *StrikeTestSuite) resolveWith(
 		second = secondWolf[0]
 	}
 
-	return resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	return resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: world,
 		Participants: []Participant{
 			{Character: hero},
@@ -887,7 +888,7 @@ func (s *StrikeTestSuite) TestCanceledAdvantageRollsStraightAndDoesNotGrantSneak
 		}},
 	}
 	roller := scripted(15, 4)
-	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := resolveOn(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: s.world(spatial.Position{X: 8, Y: 5}),
 		Participants: []Participant{
 			{Character: s.hero(sneak)},
@@ -944,9 +945,10 @@ func (s *StrikeTestSuite) TestASkeletonSwingsItsShortsword() {
 	s.Require().NoError(err)
 	s.Require().Nil(attack.Gate, "a plain weapon declares no rider")
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
@@ -956,7 +958,7 @@ func (s *StrikeTestSuite) TestASkeletonSwingsItsShortsword() {
 	})
 	s.Require().NoError(err)
 
-	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+	out, err := Resolve(s.ctx, &Input{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
 		World: enc.ToData(),
 		Participants: []Participant{
 			{Character: s.hero()},
@@ -998,9 +1000,10 @@ const scoutID = "scout-1"
 // deciding a rule" (ADR-0038).
 func (s *StrikeTestSuite) spreadWorld(secondWolfRoom string, secondWolfAt spatial.Position) encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
 		Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-1", Width: 10, Height: 10},
 				{ID: "room-2", Width: 10, Height: 10, Origin: spatial.Position{X: 12}},
@@ -1050,7 +1053,7 @@ func (s *StrikeTestSuite) resolveSpread(
 	world encounter.EncounterData, hero *character.Data, machine Machine,
 ) (*Output, error) {
 	return Resolve(s.ctx, &Input{
-		Initiative: orderAsGiven{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
 		Sight:  everyoneSeesTheWholeMap{},
 		Roller: dice.NewRoller(),
 		World:  world,
@@ -1149,22 +1152,29 @@ func (s *StrikeTestSuite) TestAWolfInTheNextChamberIsSixtyFeetAwayNotOneCell() {
 //
 // So the field's grid family is not decoration here: it decides the rule.
 //
-// The first wolf stands at axial (-5,-5) for a second reason. A hex grid is
-// origin-CENTERED — a span of ten reaches [-5,4] on each axis — where a square
-// grid of the same width reaches [0,9]. So the two families need different span
-// arithmetic to hold the same field, and a member at the hex field's own corner
-// is the only thing that can tell a correct hex span from a square one applied
-// to a hex grid. (Mutation M8; nobody stood out there until it survived.)
+// The first wolf stands at the field's own opposite corner (9,9) for a second
+// reason. A hex ROOM's authored (room-local) span is zero-based — [0,Width) on
+// each axis, the same as square (localIsInRoom, orientation.go) — even though
+// the field's absolute frame is origin-centred axial once compiled; a member
+// at the room's own edge is the only thing that can tell that bounds check
+// from one that quietly clipped the corner. (Mutation M8; nobody stood out
+// there until it survived. Coordinates updated for rpg-project#227's
+// room-local/absolute reshape: authoring moved to zero-based room-local cells
+// after this test predated it — see localIsInRoom's own doc.)
 func (s *StrikeTestSuite) hexWorld() encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
 		Sight: everyoneSeesTheWholeMap{},
+		// Orientation is required for a hex field but arbitrary here: axial
+		// distance (what this test measures) is the same six neighbours either
+		// way (ADR-0040) — only rendering cares which way the hexes point.
 		Field: encounter.FieldInput{
-			Rooms: []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10, Grid: spatial.GridShapeHex}},
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesAreFlatTop()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10, Grid: spatial.GridShapeHex}},
 		},
 		Members: []encounter.MemberInput{
 			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 0, Y: 0}},
-			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: -5, Y: -5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 9, Y: 9}},
 			{ID: secondWolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},

--- a/rulebooks/dnd5e/resolution/testrollers_test.go
+++ b/rulebooks/dnd5e/resolution/testrollers_test.go
@@ -68,6 +68,18 @@ func (everyoneStanding) Standing(_ []encounter.MemberID) ([]encounter.MemberID, 
 	return nil, nil
 }
 
+// passDriver is the deterministic TurnDriver every fixture wires.
+//
+// The composition requires one to load at all (rpg-toolkit#1162), and this
+// package never consults it — it carries the caller's capability across a
+// round trip through the world, exactly like Standing and Sight above. So the
+// fixtures hand over the one answer that changes nothing.
+type passDriver struct{}
+
+func (passDriver) Act(encounter.MemberID) (encounter.TurnOutcome, error) {
+	return encounter.Pass{}, nil
+}
+
 // unlimitedSight is the range these fixtures hand out. Further than the longest
 // sightline any field in this package draws, because light is not this
 // package's subject — and stated as a number rather than left to a default,

--- a/rulebooks/dnd5e/resolution/world_test.go
+++ b/rulebooks/dnd5e/resolution/world_test.go
@@ -77,9 +77,10 @@ func walledWorld(t *testing.T) encounter.EncounterData {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
 		Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
 				{ID: "room-1", Width: 10, Height: 8, Boundaries: seam},
 				{ID: "room-2", Width: 10, Height: 8, Origin: spatial.Position{X: 10}},
@@ -110,7 +111,7 @@ func runProbe(t *testing.T, world encounter.EncounterData, participants []Partic
 
 	probe := &worldProbe{}
 	out, err := Resolve(context.Background(), &Input{
-		Initiative: orderAsGiven{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
 		Sight:        everyoneSeesTheWholeMap{},
 		Roller:       dice.NewRoller(),
 		World:        world,


### PR DESCRIPTION
## Why resolution needs this

`resolution.Resolve` calls `encounter.LoadEncounter` directly (`resolve.go`,
`resolveOn`) — it loads a world, runs one interaction, and reads the result
back as data. It never calls `EndTurn`, `form`, `Transfer` or `Exit` itself.
So when `encounter` gained a required `TurnDriver` capability
(rpg-toolkit#1162, encounter PR #1163, merged/tagged v0.30.0), this
package's own `LoadEncounter` call needed one too, or every resolution
started failing with `"no turn driver capability"`.

`Input.TurnDriver` joins `Initiative`/`Standing`/`Sight` — required, carried
across the round trip, never consulted — for the identical, already-stated
reason those three are ("Carried, never consulted... this package loads the
world and reads it back out as data"). No new design decision: this is a
downstream, mechanical propagation of ADR-0043 (encounter), following the
exact shape already established on this same `Input` struct.

## The unplanned part

Bumping `rulebooks/dnd5e/encounter` from resolution's prior pin (v0.21.0,
several versions stale) to v0.30.0 surfaced two unrelated, pre-existing gaps
this module's fixtures never caught up to:

- `FieldInput.Canvas.Void` became required (rpg-toolkit#1116) sometime
  after v0.21.0 — every fixture in the package was missing it (104 test
  failures, all the identical error, before the fix).
- A hex room's authored (room-local) position became zero-based
  (`[0,Width)`) rather than origin-centred, as part of the room-local/
  absolute reshape (rpg-project#227). One fixture
  (`strike_test.go`'s `hexWorld`) placed a member at the OLD convention's
  corner (-5,-5), now out of bounds; corrected to (9,9) — the new
  convention's equivalent corner — preserving the fixture's own documented
  intent (a member at the room's own edge, for mutation-testing coverage of
  the bounds check) rather than moving it somewhere merely convenient.

Both are mechanical, verified against the actual bounds-checking code
(`localIsInRoom`, `orientation.go`) rather than guessed.

## Evidence

`go test -race ./...`: clean. `golangci-lint run ./...` (auto-discovered
`rulebooks/dnd5e/.golangci.yml`): 0 issues. `gorelease -base=v0.11.0`:
additive/compatible, suggests v0.12.0 (left for auto-tag).
`scripts/check-decisions.sh`: passes (no new ADR needed — see above).

## Sequencing

Third module in the chain: encounter (merged, #1163) → **resolution
(this PR)** → session. `rulebooks/dnd5e/session` needs this module's next
tag before it can wire `TurnDriver` all the way through
`session.Attack`'s call into `resolution.Resolve` — that PR follows once
this merges and auto-tags.

— asset-pipeline agent, on behalf of KirkDiggler
