### PR TITLE
session: a monster's turn has a driver (#1162)

### DIFF
--- a/rulebooks/dnd5e/session/afford_test.go
+++ b/rulebooks/dnd5e/session/afford_test.go
@@ -194,7 +194,7 @@ func (s *AffordSuite) TestANewTurnRefillsWhatAffordSees() {
 func (s *AffordSuite) TestFreeRoamAffordsNothing() {
 	sessions, encounters := newFakeSessions(), newFakeEncounters()
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: sessions, Encounters: encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: sessions, Encounters: encounters,
 		Characters: testCharacters(), Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/afford_test.go
+++ b/rulebooks/dnd5e/session/afford_test.go
@@ -55,16 +55,16 @@ func (s *AffordSuite) swing() (*session.AttackOutput, error) {
 	})
 }
 
-// nextTurn is economy_test.go's own: both ends of the round are ended
-// deliberately, since a round only advances when the order comes back around.
+// nextTurn is economy_test.go's own: ONE end, not two — rpg-toolkit#1162.
+// The skeleton has no player, so ending alice's own turn drives the
+// skeleton's through in the same call; a second, explicit EndTurn for the
+// skeleton would be refused, since its turn already ended.
 func (s *AffordSuite) nextTurn() {
 	s.T().Helper()
 	ctx := context.Background()
 
-	for _, who := range []string{"alice", "skeleton"} {
-		_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: who})
-		s.Require().NoError(err, "ending %s's turn", who)
-	}
+	_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err, "ending alice's turn")
 }
 
 // storedEconomy reads alice's persisted action economy, the same read

--- a/rulebooks/dnd5e/session/atlasmap_test.go
+++ b/rulebooks/dnd5e/session/atlasmap_test.go
@@ -39,7 +39,7 @@ func TestAtlasMapSuite(t *testing.T) {
 // order pin written against it passes with the sorting deleted, which is
 // exactly what the first version of this file did.
 func backwardsWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -66,7 +66,7 @@ func backwardsWorld(t fataler) *encounter.EncounterData {
 
 func (s *AtlasMapSuite) SetupTest() {
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
 		Characters: testCharacters(), Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -214,6 +214,7 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		Initiative:   m.initiative,
 		Standing:     scope.standing,
 		Sight:        sightSeam{},
+		TurnDriver:   m.turnDriver,
 		Cost:         price.cost,
 		Machine: resolution.NewStrike(&resolution.StrikeInput{
 			AttackerID: in.Attacker,

--- a/rulebooks/dnd5e/session/attack_internal_test.go
+++ b/rulebooks/dnd5e/session/attack_internal_test.go
@@ -63,7 +63,7 @@ func TestRecordUsesAggregateFromTypedStrikeOutcome(t *testing.T) {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight:      aggregateRecordEveryoneSees{},
 		Standing:   aggregateRecordEveryoneStanding{},
-		Initiative: aggregateRecordOrderAsGiven{},
+		Initiative: aggregateRecordOrderAsGiven{}, TurnDriver: passDriver{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 4, Height: 4}},

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -88,9 +88,9 @@ const duelAC = 12
 // fixture drift cannot make the two suites disagree about what was swung at.
 func duelWorld(t fataler) *encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
-		Initiative: encOrderAsGiven{},
-		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
@@ -124,7 +124,7 @@ func (s *AttackTestSuite) breakableDuel(dice session.Roller) (*session.Manager, 
 	encounters := &failingEncounters{fakeEncounters: s.encounters}
 
 	mgr, err := session.NewManager(&session.Config{
-		Dice: dice, Sessions: s.sessions, Encounters: encounters,
+		Dice: dice, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: encounters,
 		Characters: s.characters, Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -343,15 +343,15 @@ func (s *AttackTestSuite) TestAMonsterAttackerIsRefused() {
 	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
 	s.characters = newFakeCharacters(armedFighter("alice"))
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: s.characters, Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
-		Initiative: encOrderAsGiven{},
-		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 			{ID: "ogre", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
@@ -409,15 +409,15 @@ func (s *AttackTestSuite) TestAnEmptyHandIsRefused() {
 	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
 	s.characters = newFakeCharacters(dwarfCharacter("alice"), armedFighter("bob"))
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: s.characters, Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
-		Initiative: encOrderAsGiven{},
-		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
@@ -448,15 +448,15 @@ func (s *AttackTestSuite) TestASheetlessTargetIsRefusedByName() {
 	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
 	s.characters = newFakeCharacters(armedFighter("alice"))
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: s.characters, Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
-		Initiative: encOrderAsGiven{},
-		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 			{ID: "ogre", Kind: encounter.KindMonster, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},
@@ -487,7 +487,7 @@ func (s *AttackTestSuite) duelAmong(members []string, sheets ...*character.Data)
 	s.characters = newFakeCharacters(sheets...)
 
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: s.characters, Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -500,12 +500,12 @@ func (s *AttackTestSuite) duelAmong(members []string, sheets ...*character.Data)
 		})
 	}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
-		Initiative: encOrderAsGiven{},
-		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
-		Members:    placed,
-		Endings:    []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
-		Retention:  encounter.RetentionUnbounded,
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing:  encEveryoneStanding{},
+		Field:     encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Members:   placed,
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
 	})
 	s.Require().NoError(err)
 	data := enc.ToData()

--- a/rulebooks/dnd5e/session/attackevents_test.go
+++ b/rulebooks/dnd5e/session/attackevents_test.go
@@ -39,7 +39,7 @@ func (s *AttackEventsTestSuite) duelWithStream(dice session.Roller) *session.Man
 	s.stream = &fakeStream{}
 
 	mgr, err := session.NewManager(&session.Config{
-		Dice: dice, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: dice, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: s.characters, Events: s.stream,
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -90,6 +90,16 @@ func (encOrderAsGiven) RollInitiative(m []encounter.MemberID) ([]encounter.Membe
 	return m, nil
 }
 
+// encPassDriver is this construction's TurnDriver: every unplayed member
+// passes. Matched to session.Pass, the workbench's own answer, for the same
+// reason encEveryoneStanding is matched to session's — the scene reads the
+// same however it is entered.
+type encPassDriver struct{}
+
+func (encPassDriver) Act(encounter.MemberID) (encounter.TurnOutcome, error) {
+	return encounter.Pass{}, nil
+}
+
 // memSessions is a SessionRepository over a map. Get-by-id and put-by-id is
 // the whole interface (S12), which is why this is six lines rather than a
 // schema.
@@ -191,6 +201,10 @@ func drive(out *bytes.Buffer) error {
 		Encounters: &memEncounters{byID: map[string]*encounter.EncounterData{}},
 		Characters: &memCharacters{byID: map[string]*character.Data{"bob": bobTheDwarf()}},
 		Events:     &printStream{out: out},
+		// The workbench demonstrates verbs a human drives; nothing in it
+		// gives a monster a real behavior yet, so an unplayed member simply
+		// passes (rpg-toolkit#1162).
+		TurnDriver: session.Pass{},
 	})
 	if err != nil {
 		return err
@@ -375,7 +389,7 @@ func drive(out *bytes.Buffer) error {
 // gate between them, anchored so the doorway's endpoints are adjacent in
 // absolute space.
 func authoredCrypt() (*encounter.EncounterData, error) {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
 		// Governs THIS construction only: once session loads the world it
 		// supplies its own sight seam, so the walk below runs on session's

--- a/rulebooks/dnd5e/session/conditions_test.go
+++ b/rulebooks/dnd5e/session/conditions_test.go
@@ -72,7 +72,7 @@ func (s *ConditionsTestSuite) SetupSubTest() { s.SetupTest() }
 func (s *ConditionsTestSuite) managerOverStores(
 	sessions *fakeSessions, encounters *fakeEncounters, characters *fakeCharacters,
 ) *session.Manager {
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: sessions, Encounters: encounters,
 		Characters: characters, Events: session.DiscardEvents{},
 	})

--- a/rulebooks/dnd5e/session/death_test.go
+++ b/rulebooks/dnd5e/session/death_test.go
@@ -67,7 +67,7 @@ func cryptWorld(t fataler) *encounter.EncounterData {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
-		Initiative: encOrderAsGiven{}, Standing: encEveryoneStanding{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{}, Standing: encEveryoneStanding{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: "crypt", Width: 10, Height: 10, Props: occludingProps(occluders...)},
 		}},
@@ -92,7 +92,7 @@ func (s *DeathTestSuite) SetupTest() {
 	s.stream = &fakeStream{}
 
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: s.characters, Events: s.stream,
 	})
 	s.Require().NoError(err)
@@ -478,7 +478,7 @@ func (s *DeathTestSuite) TestASwingThatCannotRecordStillNamesTheSheetItWrote() {
 		fakeCharacters: newFakeCharacters(armedFighter("alice"), armedFighter("bob")),
 	}
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: chars, Events: s.stream,
 	})
 	s.Require().NoError(err)
@@ -741,7 +741,7 @@ func (m *markedCharacters) GetCharacter(ctx context.Context, id string) (*charac
 func (s *DeathTestSuite) TestTheSeamReadsOnTheCallersContext() {
 	chars := &markedCharacters{fakeCharacters: newFakeCharacters(armedFighter("alice"), armedFighter("bob"))}
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: chars, Events: s.stream,
 	})
 	s.Require().NoError(err)
@@ -799,7 +799,7 @@ func (s *DeathTestSuite) TestAStoreThatCannotAnswerFailsTheVerb() {
 		broken:         "bob",
 	}
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: chars, Events: s.stream,
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/dissolve_test.go
+++ b/rulebooks/dnd5e/session/dissolve_test.go
@@ -164,7 +164,7 @@ func (s *DissolveTestSuite) TestTheEndingReachesClients() {
 
 	stream := &fakeStream{}
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: testCharacters(), Events: stream,
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/economy_test.go
+++ b/rulebooks/dnd5e/session/economy_test.go
@@ -155,17 +155,17 @@ func (s *EconomySuite) swing() (*session.AttackOutput, error) {
 
 // nextTurn takes the fight all the way round to alice again.
 //
-// Both ends are ended deliberately: a round advances when the order comes back
-// around, so ending only alice's turn leaves the round where it was and the
-// bank exactly as spent.
+// ONE END, NOT TWO — rpg-toolkit#1162. The skeleton has no player: ending
+// alice's own turn now drives the skeleton's through in the same call
+// (ADR-0043), so a second, explicit EndTurn for the skeleton is refused —
+// its turn already ended, and alice is active again by the time this
+// returns.
 func (s *EconomySuite) nextTurn() {
 	s.T().Helper()
 	ctx := context.Background()
 
-	for _, who := range []string{"alice", "skeleton"} {
-		_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: who})
-		s.Require().NoError(err, "ending %s's turn", who)
-	}
+	_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err, "ending alice's turn")
 
 	turn, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/economy_test.go
+++ b/rulebooks/dnd5e/session/economy_test.go
@@ -93,7 +93,7 @@ func aFight(
 	scripted := append(make([]int, initiativeRolls), rolls...)
 
 	mgr, err := session.NewManager(&session.Config{
-		Dice: &sequenceDice{rolls: scripted}, Sessions: sessions, Encounters: encounters,
+		Dice: &sequenceDice{rolls: scripted}, TurnDriver: session.Pass{}, Sessions: sessions, Encounters: encounters,
 		Characters: characters, Events: session.DiscardEvents{},
 	})
 	if err != nil {
@@ -101,9 +101,9 @@ func aFight(
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
-		Initiative: encOrderAsGiven{},
-		Standing:   encEveryoneStanding{},
-		Field:      encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{
 			{ID: encounter.MemberID(alice.ID), Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
 		},

--- a/rulebooks/dnd5e/session/entities_test.go
+++ b/rulebooks/dnd5e/session/entities_test.go
@@ -32,7 +32,7 @@ func (s *EntitiesTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
 	s.characters = testCharacters()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})
@@ -228,7 +228,7 @@ func (s *EntitiesTestSuite) TestEveryPlayerJoinConsultsTheRepository() {
 // violation rather than the absence: a store that returns (nil, nil) is broken,
 // and guessing in either direction is worse than saying so.
 func (s *EntitiesTestSuite) TestARepositoryReportingSuccessWithNoDataIsRejected() {
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: s.sessions, Encounters: s.encounters,
 		Characters: &nilDataCharacters{},
 		Events:     session.DiscardEvents{},
@@ -290,7 +290,7 @@ func (f benchFataler) Fatalf(format string, args ...any) { f.b.Fatalf(format, ar
 
 func benchManager(b *testing.B) *session.Manager {
 	b.Helper()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
 		Characters: testCharacters(), Events: session.DiscardEvents{},
 	})

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -361,4 +361,14 @@ var (
 	// unqualified failure either, because the difference determines whether a
 	// retry is safe.
 	ErrSaveFailed = errors.New("save failed")
+
+	// ErrBadTurnOutcome is returned when a TurnDriver's Act answers with a
+	// TurnOutcome the seam that translates it to the composition does not
+	// recognise.
+	//
+	// Reachable, not merely defensive: TurnOutcome is this package's own
+	// vocabulary, and the day it grows a second case, an internal adapter
+	// that has not been updated to translate it hits this rather than
+	// silently treating the new outcome as Pass.
+	ErrBadTurnOutcome = errors.New("turn driver returned an unrecognised outcome")
 )

--- a/rulebooks/dnd5e/session/events_test.go
+++ b/rulebooks/dnd5e/session/events_test.go
@@ -36,7 +36,7 @@ func (s *EventsTestSuite) SetupTest() {
 	s.encounters = newFakeEncounters()
 	s.characters = testCharacters()
 	s.stream = &fakeStream{}
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters, Events: s.stream,
 	})
 	s.Require().NoError(err)
@@ -46,7 +46,7 @@ func (s *EventsTestSuite) SetupTest() {
 // twoRoomParty puts alice and dave in the corridor and carol in the sealed
 // vault, so one member is genuinely unable to perceive what the others do.
 func twoRoomParty(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -153,7 +153,7 @@ func (s *EventsTestSuite) TestEventsAreAddressed() {
 func (s *EventsTestSuite) TestNothingIsPublishedWhenTheSaveFails() {
 	encounters := &failingEncounters{fakeEncounters: newFakeEncounters()}
 	stream := &fakeStream{}
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: newFakeSessions(), Encounters: encounters, Characters: testCharacters(), Events: stream,
 	})
 	s.Require().NoError(err)
@@ -181,7 +181,7 @@ func (s *EventsTestSuite) TestNothingIsPublishedWhenTheSaveFails() {
 // error the host has to interpret. The log is the truth and sequences are
 // gapless, so clients self-heal.
 func (s *EventsTestSuite) TestDeliveryFailureDoesNotFailTheVerb() {
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: &failingStream{err: errBroken},
 	})
@@ -215,7 +215,7 @@ func (s *EventsTestSuite) TestDeliveryFailureDoesNotFailTheVerb() {
 // did, and would make a genuinely silent run indistinguishable from a broken
 // one.
 func (s *EventsTestSuite) TestDiscardingEventsStillReportsHonestly() {
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})

--- a/rulebooks/dnd5e/session/example_session_test.go
+++ b/rulebooks/dnd5e/session/example_session_test.go
@@ -32,7 +32,7 @@ func Example_theSession() {
 	ctx := context.Background()
 
 	// The host's entire integration: two stores.
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions:   newFakeSessions(),
 		Encounters: newFakeEncounters(), Characters: testCharacters(),
 		Events: session.DiscardEvents{},
@@ -133,7 +133,7 @@ func Example_theSession() {
 // (rpg-toolkit#964), so what reaches the host is news rather than a question.
 func Example_theFightThatStartsItself() {
 	ctx := context.Background()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: newFakeSessions(), Encounters: newFakeEncounters(), Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
@@ -182,7 +182,7 @@ func (panicFataler) Fatalf(format string, args ...any) {
 // authoredTomb is content, not a live encounter: the blob a host would have
 // sitting in storage from an authoring pipeline.
 func authoredTomb() *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
 		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/session/fight_starts_test.go
+++ b/rulebooks/dnd5e/session/fight_starts_test.go
@@ -231,6 +231,44 @@ func (s *FightStartsTestSuite) TestTheDiceDecideTheOrder() {
 	}
 }
 
+// TestAnUnplayedMemberFirstInInitiativeIsAlreadyDrivenPastFightStart is
+// rpg-toolkit#1162's other headline case, at the session seam: if the roll
+// puts the ogre first, nobody has reached the fight's clock yet to end its
+// turn for them — the caller only just learned the fight exists — so the
+// drive has to have already happened by the time this Move call returns.
+//
+// The ogre wins initiative here on the dice alone (1 vs 20), the same
+// mechanism TestTheDiceDecideTheOrder pins, so this is not a different fight-
+// forming path: it is the ordinary one, with the roll that used to be able to
+// strand it.
+func (s *FightStartsTestSuite) TestAnUnplayedMemberFirstInInitiativeIsAlreadyDrivenPastFightStart() {
+	dice := &sequenceDice{rolls: []int{1, 20}} // alice, then ogre — alphabetical asking order
+	mgr, err := session.NewManager(&session.Config{
+		Dice: dice, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: ambushWorld(s.T()),
+	})
+	s.Require().NoError(err)
+
+	out, err := mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Formed)
+	s.Equal([]string{"ogre", "alice"}, out.Formed.Order, "control: the ogre really did win initiative")
+
+	turn, err := mgr.Turn(context.Background(), &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal("alice", turn.Active,
+		"the ogre's turn was driven through at formation; the caller sees a PLAYED member active "+
+			"in the very first read after Formed, with no EndTurn of its own required to reach it")
+	s.Equal(1, turn.Round, "driving the ogre through at formation does not itself wrap a round")
+}
+
 // TestADiceFailureAbortsTheFight pins that a host whose randomness is down gets
 // a refused verb rather than a wrong fight.
 //

--- a/rulebooks/dnd5e/session/fight_starts_test.go
+++ b/rulebooks/dnd5e/session/fight_starts_test.go
@@ -56,7 +56,7 @@ func managerOver(t fataler, sessions *fakeSessions, encounters *fakeEncounters) 
 func managerOverRepos(
 	t fataler, sessions session.SessionRepository, encounters session.EncounterRepository,
 ) *session.Manager {
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: sessions, Encounters: encounters, Characters: testCharacters(), Events: session.DiscardEvents{},
 	})
 	if err != nil {
@@ -107,7 +107,7 @@ func buildAmbush(t fataler, alice spatial.Position, extra ...encounter.MemberInp
 	}
 	members = append(members, extra...)
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 8, Height: 8, Props: occludingProps(occluders...)},
@@ -204,7 +204,7 @@ func (s *FightStartsTestSuite) TestTheDiceDecideTheOrder() {
 		sessions, encounters := newFakeSessions(), newFakeEncounters()
 		dice := &sequenceDice{rolls: []int{5, 18, 11}}
 		mgr, err := session.NewManager(&session.Config{
-			Dice: dice, Sessions: sessions, Encounters: encounters,
+			Dice: dice, TurnDriver: session.Pass{}, Sessions: sessions, Encounters: encounters,
 			Characters: testCharacters(), Events: session.DiscardEvents{},
 		})
 		s.Require().NoError(err)
@@ -240,7 +240,7 @@ func (s *FightStartsTestSuite) TestTheDiceDecideTheOrder() {
 // threw away, and a fight that cannot be ordered does not half-start.
 func (s *FightStartsTestSuite) TestADiceFailureAbortsTheFight() {
 	mgr, err := session.NewManager(&session.Config{
-		Dice: brokenDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: brokenDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: testCharacters(), Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,8 +18,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0 h1:YyKFsJqczz3Ip18utScZdYZrukcwF8Cu+6Pem76xKwM=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.29.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0 h1:BnDZ//xyK/vcFmhUyDV8mRd4KSnj6Ofrz5Kpxy0GH1o=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0 h1:zYz6ikMy5o/i5VBJvxwScLhCLtv2iGGrjDMjDjnwewQ=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0/go.mod h1:RPfATHgAUVDWhORJqDzuyyeIekh9AGSag+9nu8eQVIk=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0 h1:BnDZ//xyK/vcFmhUyDV8mRd4KSnj6Ofrz5Kpxy0GH1o=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0 h1:zYz6ikMy5o/i5VBJvxwScLhCLtv2iGGrjDMjDjnwewQ=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.0/go.mod h1:RPfATHgAUVDWhORJqDzuyyeIekh9AGSag+9nu8eQVIk=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1 h1:FCDHPx/vGzDmHIHopHCJQspyybr0HI/KL7z7i68a9Y4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/session/manager_test.go
+++ b/rulebooks/dnd5e/session/manager_test.go
@@ -215,28 +215,28 @@ func (s *ManagerTestSuite) TestEachRequirementIsCheckedByName() {
 	}{
 		{
 			name: "sessions absent",
-			config: &session.Config{Dice: testDice{}, Encounters: newFakeEncounters(),
+			config: &session.Config{Dice: testDice{}, TurnDriver: session.Pass{}, Encounters: newFakeEncounters(),
 				Characters: testCharacters(), Events: session.DiscardEvents{},
 			},
 			expect: "Sessions",
 		},
 		{
 			name: "encounters absent",
-			config: &session.Config{Dice: testDice{}, Sessions: newFakeSessions(),
+			config: &session.Config{Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: newFakeSessions(),
 				Characters: testCharacters(), Events: session.DiscardEvents{},
 			},
 			expect: "Encounters",
 		},
 		{
 			name: "characters absent",
-			config: &session.Config{Dice: testDice{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+			config: &session.Config{Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
 				Events: session.DiscardEvents{},
 			},
 			expect: "Characters",
 		},
 		{
 			name: "events absent",
-			config: &session.Config{Dice: testDice{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+			config: &session.Config{Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
 				Characters: testCharacters(),
 			},
 			expect: "Events",
@@ -252,6 +252,18 @@ func (s *ManagerTestSuite) TestEachRequirementIsCheckedByName() {
 				Characters: testCharacters(), Events: session.DiscardEvents{},
 			},
 			expect: "Dice",
+		},
+		{
+			// A fight can also form — or a turn can end — with the clock
+			// landing on a member nobody plays: a host that wired everything
+			// else and forgot this one would get a working session that
+			// stalled the first time initiative rolled a monster first, or a
+			// player ended their turn ahead of one (rpg-toolkit#1162).
+			name: "turndriver absent",
+			config: &session.Config{Dice: testDice{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+				Characters: testCharacters(), Events: session.DiscardEvents{},
+			},
+			expect: "TurnDriver",
 		},
 	}
 
@@ -289,7 +301,7 @@ func (s *ManagerTestSuite) TestMissingReportIsDeterministic() {
 // being a stated decision. A nil reads as an oversight; this reads as a choice,
 // and it greps.
 func (s *ManagerTestSuite) TestDiscardEventsIsAcceptedAsAStream() {
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions:   newFakeSessions(),
 		Encounters: newFakeEncounters(),
 		Characters: testCharacters(),
@@ -302,7 +314,7 @@ func (s *ManagerTestSuite) TestDiscardEventsIsAcceptedAsAStream() {
 // TestFullyWiredConstructs is the other positive control: a real stream,
 // which is what any actual game supplies.
 func (s *ManagerTestSuite) TestFullyWiredConstructs() {
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions:   newFakeSessions(),
 		Encounters: newFakeEncounters(),
 		Characters: testCharacters(),

--- a/rulebooks/dnd5e/session/move_internal_test.go
+++ b/rulebooks/dnd5e/session/move_internal_test.go
@@ -20,7 +20,7 @@ import (
 // identical either way, and only a test aimed at the reasoning can say why the
 // deletion was safe rather than lucky.
 
-// walkOrderAsGiven and walkEveryoneStanding are the two capabilities every
+// walkOrderAsGiven and walkEveryoneStanding are two of the capabilities every
 // encounter needs, in their most boring form. The external test package has its
 // own; these tests are internal and cannot see them.
 type walkOrderAsGiven struct{}
@@ -35,6 +35,16 @@ func (walkEveryoneStanding) Standing(_ []encounter.MemberID) ([]encounter.Member
 	return nil, nil
 }
 
+// passDriver is the third: every unplayed member always passes. Shared across
+// this package's internal test files (attack_internal_test.go included)
+// rather than "walk"-prefixed, since it answers the same boring question
+// regardless of which internal verb's test needs an encounter built.
+type passDriver struct{}
+
+func (passDriver) Act(encounter.MemberID) (encounter.TurnOutcome, error) {
+	return encounter.Pass{}, nil
+}
+
 // walkWorld is two rooms of DIFFERENT sizes, anchored away from the origin.
 // Different sizes on purpose: the grid this seam builds used to take the
 // walker's own room's span, so a fixture whose rooms agree could not tell a
@@ -43,7 +53,7 @@ func walkWorld(t *testing.T, family spatial.GridShape) *encounter.Encounter {
 	t.Helper()
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: sightSeam{},
-		Initiative: walkOrderAsGiven{}, Standing: walkEveryoneStanding{},
+		Initiative: walkOrderAsGiven{}, TurnDriver: passDriver{}, Standing: walkEveryoneStanding{},
 		Field: encounter.FieldInput{Canvas: canvasFor(family), Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 4, Height: 4, Grid: family, Origin: spatial.Position{X: 30, Y: 40}},
 			{ID: "annex", Width: 12, Height: 12, Grid: family, Origin: spatial.Position{X: 60, Y: 40}},

--- a/rulebooks/dnd5e/session/move_test.go
+++ b/rulebooks/dnd5e/session/move_test.go
@@ -31,7 +31,7 @@ func (s *MoveTestSuite) SetupTest() {
 	s.encounters = newFakeEncounters()
 	s.characters = testCharacters()
 	s.stream = &fakeStream{}
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: s.stream,
 	})
@@ -43,7 +43,7 @@ func (s *MoveTestSuite) SetupTest() {
 // three steps to her east — near enough to walk onto, far enough that a walk
 // can be interrupted before reaching it.
 func corridorWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
 		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
 		Members: []encounter.MemberInput{

--- a/rulebooks/dnd5e/session/onemap_test.go
+++ b/rulebooks/dnd5e/session/onemap_test.go
@@ -42,7 +42,7 @@ func TestOneMapSuite(t *testing.T) {
 // The doorway joins hall-local (5,2) — absolute (45,22) — to annex-local (0,2)
 // — absolute (46,22).
 func offsetWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -81,7 +81,7 @@ func offsetWorld(t fataler) *encounter.EncounterData {
 func (s *OneMapSuite) SetupTest() {
 	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: testCharacters(), Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -172,7 +172,7 @@ func (s *OneMapSuite) TestAWalkCrossesTheDoorway() {
 func (s *OneMapSuite) TestACrossingReachesClientsAsACrossing() {
 	stream := &fakeStream{}
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: testCharacters(), Events: stream,
 	})
 	s.Require().NoError(err)
@@ -358,8 +358,8 @@ func (s *OneMapSuite) TestASightingAndAPlacementAgree() {
 // the origin that its ABSOLUTE cells overlap its own room-local ones.
 func shallowAnchoredWorld(t fataler) *encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
-		Initiative: encOrderAsGiven{},
-		Standing:   encEveryoneStanding{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 10, Height: 10, Origin: spatial.Position{X: 2, Y: 3}},
 		}},
@@ -384,7 +384,7 @@ func shallowAnchoredWorld(t fataler) *encounter.EncounterData {
 func (s *OneMapSuite) shallowSession() *session.Manager {
 	sessions, encounters := newFakeSessions(), newFakeEncounters()
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: sessions, Encounters: encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: sessions, Encounters: encounters,
 		Characters: testCharacters(), Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -293,6 +293,7 @@ func (m *Manager) loadWorldWithBaseline(
 		Initiative: m.initiative,
 		Standing:   standing,
 		Sight:      sightSeam{},
+		TurnDriver: m.turnDriver,
 	})
 	if err != nil {
 		// The reason is kept as TEXT, not as a chain. A blob this seam cannot

--- a/rulebooks/dnd5e/session/read_test.go
+++ b/rulebooks/dnd5e/session/read_test.go
@@ -30,7 +30,7 @@ func (s *ReadTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
 	s.characters = testCharacters()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})
@@ -49,7 +49,7 @@ func (s *ReadTestSuite) startWith(world *encounter.EncounterData) {
 // hexWorld is a two-room hex field with a doorway, occluders and a wall — rich
 // enough that a projection dropping any one field is visible.
 func hexWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
@@ -185,7 +185,7 @@ func (s *ReadTestSuite) TestGridProjectionCoversBothFamilies() {
 
 	square := newFakeSessions()
 	squareEnc := newFakeEncounters()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, Sessions: square, Encounters: squareEnc, Characters: testCharacters(),
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: square, Encounters: squareEnc, Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -299,7 +299,7 @@ func (s *ReadTestSuite) TestTrimmedStoryUsesOurSentinelNotTheirs() {
 // trimmedWorld builds a world whose story log has already aged past its
 // retention window, so a resume from sequence 1 can no longer be honoured.
 func trimmedWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
 		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
@@ -349,7 +349,7 @@ func (s *ReadTestSuite) TestAtlasSaysWhichWayTheHexesPoint() {
 // for the same reason TestGridProjectionCoversBothFamilies does: a projection
 // hard-coded to pointy would pass every fixture in this file.
 func (s *ReadTestSuite) TestAtlasLayoutCoversBothHexLayouts() {
-	flat, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+	flat, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesAreFlatTop()},
 			Rooms: []encounter.RoomInput{{ID: "cell", Width: 4, Height: 4, Grid: spatial.GridShapeHex}},

--- a/rulebooks/dnd5e/session/seen_test.go
+++ b/rulebooks/dnd5e/session/seen_test.go
@@ -47,7 +47,7 @@ func TestSeenTestSuite(t *testing.T) {
 func (s *SeenTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: s.sessions, Encounters: s.encounters, Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
@@ -86,7 +86,7 @@ func squareSeamWalls(atX, rows, doorRow int) []spatial.Boundary {
 // absolute (9,3) — where nothing but the doorway can put it in sight.
 func skeletonBehindADoor(t fataler) *encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, Standing: encEveryoneStanding{},
+		Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{}, Standing: encEveryoneStanding{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{

--- a/rulebooks/dnd5e/session/sentinels_test.go
+++ b/rulebooks/dnd5e/session/sentinels_test.go
@@ -162,7 +162,7 @@ func TestSentinelSuite(t *testing.T) { suite.Run(t, new(SentinelSuite)) }
 func (s *SentinelSuite) SetupTest() {
 	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: testCharacters(), Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -214,7 +214,7 @@ func (s *SentinelSuite) refusedInOurVocabulary(err error, want error) {
 // the only part of a duel these refusals differ in.
 func (s *SentinelSuite) armedDuel(chars *fakeCharacters) *session.Manager {
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
 		Characters: chars, Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/session.go
+++ b/rulebooks/dnd5e/session/session.go
@@ -74,6 +74,17 @@ type Config struct {
 	// roller mandatory, and for the same reason: refuse at the door, never
 	// guard at the use site.
 	Dice Roller
+
+	// TurnDriver decides what a member with no player does when a fight's
+	// clock lands on their turn. Required.
+	//
+	// A fight can form — or a turn can end — with the clock landing on a
+	// member nobody plays: initiative rolled the monster first, or the human
+	// ahead of it just ended their own turn. What that member does is a game
+	// rule, so it is asked for rather than assumed, exactly as Dice is
+	// (rpg-toolkit#1162). Wire session.Pass{} for v1's whole behavior — every
+	// unplayed member's turn ends the moment the clock reaches it.
+	TurnDriver TurnDriver
 }
 
 // Manager is the host's single point of contact with the toolkit.
@@ -90,6 +101,7 @@ type Manager struct {
 	characters CharacterRepository
 	events     EventStream
 	initiative encounter.InitiativeRoller
+	turnDriver encounter.TurnDriver
 
 	// dice is the host's randomness, kept as well as wrapped: the initiative
 	// seam needs it wrapped for the composition, and a resolution machine
@@ -124,6 +136,7 @@ func NewManager(cfg *Config) (*Manager, error) {
 		{"Characters", cfg.Characters != nil},
 		{"Events", cfg.Events != nil},
 		{"Dice", cfg.Dice != nil},
+		{"TurnDriver", cfg.TurnDriver != nil},
 	}
 	for _, dep := range required {
 		if !dep.present {
@@ -138,5 +151,6 @@ func NewManager(cfg *Config) (*Manager, error) {
 		events:     cfg.Events,
 		initiative: initiativeSeam{dice: cfg.Dice},
 		dice:       cfg.Dice,
+		turnDriver: turnDriverSeam{driver: cfg.TurnDriver},
 	}, nil
 }

--- a/rulebooks/dnd5e/session/spawn_test.go
+++ b/rulebooks/dnd5e/session/spawn_test.go
@@ -38,7 +38,7 @@ func (s *SpawnTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
 	s.characters = testCharacters()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})

--- a/rulebooks/dnd5e/session/start.go
+++ b/rulebooks/dnd5e/session/start.go
@@ -87,6 +87,7 @@ func (m *Manager) StartSession(ctx context.Context, in *StartSessionInput) (*Sta
 		Initiative: m.initiative,
 		Standing:   m.standingFor(ctx, nil),
 		Sight:      sightSeam{},
+		TurnDriver: m.turnDriver,
 	}); err != nil {
 		// The reason as TEXT, our sentinel as the only thing to match on. A
 		// blob that will not load fails several modules deep, and every one of

--- a/rulebooks/dnd5e/session/start_test.go
+++ b/rulebooks/dnd5e/session/start_test.go
@@ -71,7 +71,7 @@ func (s *StartSessionTestSuite) SetupTest() {
 	s.encounters = newFakeEncounters()
 	s.characters = testCharacters()
 
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions:   s.sessions,
 		Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
@@ -84,7 +84,7 @@ func (s *StartSessionTestSuite) SetupTest() {
 // authoredWorld builds a small valid encounter blob standing in for content
 // from an authoring pipeline.
 func authoredWorld(t fataler) *encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
 		Field:    encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
@@ -190,7 +190,7 @@ func (s *StartSessionTestSuite) TestExistingSessionIsNotOverwritten() {
 // by one that thought the name was free.
 func (s *StartSessionTestSuite) TestBrokenStoreIsNotMistakenForAFreeID() {
 	sessions := &failingSessions{fakeSessions: newFakeSessions(), getErr: errBroken}
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})
@@ -219,7 +219,7 @@ func (s *StartSessionTestSuite) TestBrokenStoreIsNotMistakenForAFreeID() {
 func (s *StartSessionTestSuite) TestBrokenRepositoryIsNotReadAsAnExistingSession() {
 	sessions := &nilDataSessions{fakeSessions: newFakeSessions()}
 	encounters := newFakeEncounters()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -271,7 +271,7 @@ func (s *StartSessionTestSuite) TestSuccessWritesWorldThenSession() {
 func (s *StartSessionTestSuite) TestWorldSaveFailureLeavesNoDanglingSession() {
 	encounters := &failingEncounters{fakeEncounters: newFakeEncounters(), saveErr: errBroken}
 	sessions := newFakeSessions()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -292,7 +292,7 @@ func (s *StartSessionTestSuite) TestWorldSaveFailureLeavesNoDanglingSession() {
 func (s *StartSessionTestSuite) TestSessionSaveFailureLeavesOnlyAnOrphan() {
 	sessions := &failingSessions{fakeSessions: newFakeSessions(), saveErr: errBroken}
 	encounters := newFakeEncounters()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/testroller_test.go
+++ b/rulebooks/dnd5e/session/testroller_test.go
@@ -84,3 +84,15 @@ type encEveryoneStanding struct{}
 func (encEveryoneStanding) Standing(_ []encounter.MemberID) ([]encounter.MemberID, error) {
 	return nil, nil
 }
+
+// encPassDriver is the TurnDriver capability the authored-world fixtures
+// build with: every unplayed member always passes. Same reasoning as
+// encEveryoneStanding — construction-only, and the session under test
+// supplies its own at each of its own load sites (session.Pass wrapped in
+// turnDriverSeam), so this fake must stay dumb enough that no test can
+// accidentally lean on it for an answer.
+type encPassDriver struct{}
+
+func (encPassDriver) Act(encounter.MemberID) (encounter.TurnOutcome, error) {
+	return encounter.Pass{}, nil
+}

--- a/rulebooks/dnd5e/session/turn_test.go
+++ b/rulebooks/dnd5e/session/turn_test.go
@@ -218,6 +218,49 @@ func (s *TurnTestSuite) TestEndingSomebodyElsesTurnIsRefused() {
 // correct by the delivery rule and useless in practice. A client rendering a
 // turn tracker needs to know the turn ended, and "something happened" is not
 // that.
+// pointerPass is a TurnDriver that returns &session.Pass{} rather than
+// session.Pass{} — the idiomatic Go shape for "construct and return a value"
+// — and the exact shape Copilot's review on PR #1166 found the seam
+// rejecting as an unrecognised outcome.
+type pointerPass struct{}
+
+func (pointerPass) Act(string) (session.TurnOutcome, error) {
+	return &session.Pass{}, nil
+}
+
+// TestAPointerPassDrivesThroughTheSameAsAValue pins the fix: a host TurnDriver
+// that returns &Pass{} must be driven through exactly like one that returns
+// Pass{}. Both spellings satisfy TurnOutcome — isTurnOutcome has a value
+// receiver, and Go's method-set rule promotes a value receiver to the
+// pointer's method set too — so the seam has to agree with the type system
+// rather than second-guess it.
+func (s *TurnTestSuite) TestAPointerPassDrivesThroughTheSameAsAValue() {
+	ctx := context.Background()
+	// Fresh stores rather than the suite's own s.sessions/s.encounters — this
+	// scene stands alone, so it gets alice and the ogre with nobody else's
+	// "sess" session sharing the same encounter ID underneath it.
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, TurnDriver: pointerPass{}, Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+		Characters: testCharacters(), Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(ctx, &session.StartSessionInput{
+		Session: "ptr", Encounter: "world", World: ambushWorld(s.T()),
+	})
+	s.Require().NoError(err)
+	_, err = mgr.Move(ctx, &session.MoveInput{
+		Session: "ptr", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+	})
+	s.Require().NoError(err)
+
+	out, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "ptr", Member: "alice"})
+	s.Require().NoError(err, "&Pass{} must drive the ogre through exactly like Pass{} does")
+	s.Equal("alice", out.Next)
+	s.True(out.RoundWrapped)
+}
+
 func (s *TurnTestSuite) TestTheTurnEndingReachesClients() {
 	s.fight()
 

--- a/rulebooks/dnd5e/session/turn_test.go
+++ b/rulebooks/dnd5e/session/turn_test.go
@@ -5,6 +5,7 @@ package session_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -111,37 +112,76 @@ func (s *TurnTestSuite) TestStatusNeverLearnsWhoseTurnItIs() {
 			"of a member")
 }
 
-// TestEndingATurnHandsItOn covers the write verb, including that the story
-// records it.
+// TestEndingATurnHandsItOn is rpg-toolkit#1162's headline case at the seam:
+// alice ends her turn, the ogre has no player, and this single call must not
+// return with the clock parked on it. covers the write verb, including that
+// the story records BOTH ends — hers, and the ogre's driven-through pass.
 func (s *TurnTestSuite) TestEndingATurnHandsItOn() {
 	s.fight()
 	ctx := context.Background()
 
 	out, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)
-	s.Equal("ogre", out.Next, "the fight moves on")
-	s.False(out.RoundWrapped, "one turn in, the round has not come round")
+	s.Equal("alice", out.Next,
+		"the ogre has no player; TurnDriver passes its turn and the round wraps straight back to her")
+	s.True(out.RoundWrapped, "two in the fight, so the ogre's driven-through pass closes the round")
 	s.NotZero(out.Seq)
 	s.Equal([]string{"encounter:world"}, out.Saved.Written)
 
 	after, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)
-	s.Equal("ogre", after.Active, "and the world remembers it")
+	s.Equal("alice", after.Active, "and the world remembers it")
+	s.Equal(2, after.Round, "the driven-through pass advanced the round")
+
+	// The story carries both ends, independently addressed to their member —
+	// a client rendering "the ogre does nothing" reads it from here.
+	story, err := s.mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	var turnEnded, ogrePassed int
+	for _, entry := range story {
+		if entry.Tags["tag"] != "clock" {
+			continue
+		}
+		var p struct {
+			Beat   string `json:"beat"`
+			Member string `json:"member"`
+		}
+		s.Require().NoError(json.Unmarshal(entry.Payload, &p))
+		if p.Beat != "turn-ended" {
+			continue
+		}
+		turnEnded++
+		if p.Member == "ogre" {
+			ogrePassed++
+		}
+	}
+	s.Equal(2, turnEnded, "alice's own end, plus the ogre's driven-through pass")
+	s.Equal(1, ogrePassed, "the story names the ogre's own pass by member")
 }
 
-// TestTheRoundComesRoundPins RoundWrapped, which is the only thing in
+// TestTheRoundComesRound pins RoundWrapped, which is the only thing in
 // EndTurnOutput a caller cannot derive by asking Turn again.
+//
+// rpg-toolkit#1162 collapsed this test's original two-call shape (end
+// alice's turn, then the ogre's, and see the SECOND one wrap) into
+// TestEndingATurnHandsItOn's single call: with only alice and the ogre in
+// the fight, the ogre has no player, so its turn is driven through in the
+// SAME call that ends alice's — there is no longer a separate "the ogre's
+// own turn ends" moment to ask this question about. See that test for the
+// wrap assertion; this one is kept to pin Round advancing past the wrap,
+// which is the fact TestEndingATurnHandsItOn's own assertions do not
+// restate on their own.
 func (s *TurnTestSuite) TestTheRoundComesRound() {
 	s.fight()
 	ctx := context.Background()
 
-	_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	before, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)
+	s.Equal(1, before.Round, "control: the fight opens in round 1")
 
-	last, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "ogre"})
+	last, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)
-	s.True(last.RoundWrapped, "the order came back around")
-	s.Equal("alice", last.Next)
+	s.True(last.RoundWrapped)
 
 	after, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)
@@ -183,7 +223,7 @@ func (s *TurnTestSuite) TestTheTurnEndingReachesClients() {
 
 	stream := &fakeStream{}
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: testCharacters(), Events: stream,
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/turndriver.go
+++ b/rulebooks/dnd5e/session/turndriver.go
@@ -92,6 +92,18 @@ type turnDriverSeam struct {
 // impossibility. Refused by name (ErrBadTurnOutcome) rather than silently
 // treated as a pass, which would let an unrecognised outcome quietly become a
 // different one.
+//
+// BOTH Pass AND *Pass MATCH, deliberately (Copilot, PR #1166).
+// isTurnOutcome() has a value receiver — matching this package's and
+// encounter's other sealed vocabularies, none of which use a pointer
+// receiver for a marker method — and Go's method-set rule promotes a value
+// receiver to the pointer's method set too: *Pass satisfies TurnOutcome
+// exactly as Pass does, whether this switch admits it or not. A host
+// returning &Pass{} — the idiomatic Go shape for "construct and return a
+// value" — is not naming an unrecognised outcome; it is naming Pass through
+// a spelling Go's own type system already allows. Matching only the value
+// would not catch a genuinely unrecognised outcome, only reject a legal
+// spelling of the recognised one.
 func (s turnDriverSeam) Act(member encounter.MemberID) (encounter.TurnOutcome, error) {
 	outcome, err := s.driver.Act(string(member))
 	if err != nil {
@@ -99,7 +111,7 @@ func (s turnDriverSeam) Act(member encounter.MemberID) (encounter.TurnOutcome, e
 	}
 
 	switch outcome.(type) {
-	case Pass:
+	case Pass, *Pass:
 		return encounter.Pass{}, nil
 	default:
 		return nil, fmt.Errorf("turn driver %q: %w: %T", member, ErrBadTurnOutcome, outcome)

--- a/rulebooks/dnd5e/session/turndriver.go
+++ b/rulebooks/dnd5e/session/turndriver.go
@@ -1,0 +1,110 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// TurnDriver decides what a member with no player does when a fight's clock
+// lands on their turn. Required.
+//
+// A FIGHT NOW STARTS ON ITS OWN, and it can start — or a turn can end — with
+// the clock landing on a member the host has no player for: initiative rolled
+// the monster first, or the human ahead of it just ended their own turn.
+// Nothing about that moment is a question this package is allowed to answer;
+// "what does an unplayed member do" is exactly the D&D-shaped decision the
+// Monster AI initiative (rpg-project#201) will eventually own. So the host is
+// asked, the way Standing and Sight already are — required, refused at
+// construction, never defaulted to a guess (rpg-toolkit#1033,
+// rpg-toolkit#1162, ADR-0043).
+//
+// v1's whole answer fits in one shipped implementation: [Pass]. A host wires
+// `TurnDriver: session.Pass{}` and every unplayed member's turn ends the
+// moment the clock reaches it, with the pass recorded as an ordinary
+// turn-ended beat. A real decider replaces that ONE line later, through the
+// identical Config field — nothing in this package's shape has to change to
+// receive it.
+//
+// It is an interface over this package's own vocabulary rather than
+// encounter.TurnDriver directly, for the reason every other capability here
+// is (S2): a host implementing encounter's interface would name a module this
+// SDK intends to keep replaceable underneath it.
+type TurnDriver interface {
+	// Act decides what member does on their turn, or returns an error that
+	// aborts the verb that discovered the unplayed turn — EndTurn, or
+	// whichever verb's own Move/Attack/Spawn triggered a fight forming with
+	// an unplayed member first in initiative. Nothing is persisted on that
+	// error: this package's load-mutate-save shape means the in-memory world
+	// is simply discarded, so a broken driver fails loudly on retry rather
+	// than corrupting a fight's state.
+	Act(member string) (TurnOutcome, error)
+}
+
+// TurnOutcome is a sealed vocabulary (unexported marker method) — this
+// package's own twin of encounter.TurnOutcome, kept separate for the same
+// reason ClockKind and every other wire enum here is: it is what lets the
+// composition's own vocabulary change shape without a host source file
+// changing.
+//
+// ONE CASE TODAY. See encounter.TurnOutcome's own doc for why a second case
+// (an attack, a move) is real vocabulary growth rather than an oversight —
+// the identical reasoning applies here, one layer up.
+type TurnOutcome interface {
+	isTurnOutcome()
+}
+
+// Pass is the only outcome a v1 driver may return: the member's turn ends
+// with no other effect. The SDK's own ready-made implementation of
+// TurnDriver — wire `TurnDriver: session.Pass{}` and every unplayed member
+// passes.
+type Pass struct{}
+
+// isTurnOutcome marks Pass as a TurnOutcome.
+func (Pass) isTurnOutcome() {}
+
+// Act always passes, regardless of who is asked. Pass satisfies TurnDriver as
+// well as being one of its outcomes, so a host that wants v1's whole behavior
+// wires the same value to both jobs.
+func (Pass) Act(string) (TurnOutcome, error) {
+	return Pass{}, nil
+}
+
+// turnDriverSeam adapts the host's TurnDriver to the composition's.
+//
+// Unexported for the reason every seam in this file is: if the host had to
+// satisfy encounter.TurnDriver directly, replacing the composition would
+// break every host that implemented it.
+type turnDriverSeam struct {
+	driver TurnDriver
+}
+
+// Act translates one member's outcome across the boundary.
+//
+// The default arm is NOT purely defensive the way encounter's own sealed
+// switch is: TurnOutcome here is this package's vocabulary, and a host
+// implementing TurnDriver can only ever hand back a Pass today — but the day
+// this package's own TurnOutcome grows a second case, an adapter that has not
+// been updated to translate it is a real, reachable gap, not a compile-time
+// impossibility. Refused by name (ErrBadTurnOutcome) rather than silently
+// treated as a pass, which would let an unrecognised outcome quietly become a
+// different one.
+func (s turnDriverSeam) Act(member encounter.MemberID) (encounter.TurnOutcome, error) {
+	outcome, err := s.driver.Act(string(member))
+	if err != nil {
+		return nil, err
+	}
+
+	switch outcome.(type) {
+	case Pass:
+		return encounter.Pass{}, nil
+	default:
+		return nil, fmt.Errorf("turn driver %q: %w: %T", member, ErrBadTurnOutcome, outcome)
+	}
+}
+
+// compile-time proof the adapter satisfies what it is handed to.
+var _ encounter.TurnDriver = turnDriverSeam{}

--- a/rulebooks/dnd5e/session/where_test.go
+++ b/rulebooks/dnd5e/session/where_test.go
@@ -37,7 +37,7 @@ func TestWhereSuite(t *testing.T) {
 func (s *WhereSuite) SetupTest() {
 	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: testCharacters(), Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -111,7 +111,7 @@ func (s *WhereSuite) TestItSurvivesAReconnect() {
 	s.Require().NoError(err)
 
 	reconnected, err := session.NewManager(&session.Config{
-		Dice: testDice{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
 		Characters: testCharacters(), Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -538,6 +538,7 @@ func (m *Manager) adopt(scope *writeScope, world encounter.EncounterData) error 
 		Initiative: m.initiative,
 		Standing:   scope.standing,
 		Sight:      sightSeam{},
+		TurnDriver: m.turnDriver,
 	})
 	if err != nil {
 		return fmt.Errorf("%q: %w: %v", scope.encounter, ErrInvalidWorld, err)

--- a/rulebooks/dnd5e/session/write_test.go
+++ b/rulebooks/dnd5e/session/write_test.go
@@ -27,7 +27,7 @@ func (s *WriteTestSuite) SetupTest() {
 	s.sessions = newFakeSessions()
 	s.encounters = newFakeEncounters()
 	s.characters = testCharacters()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{},
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})
@@ -197,7 +197,7 @@ func (s *WriteTestSuite) TestWriteVerbsRejectMissingIdentifiers() {
 func (s *WriteTestSuite) TestFailedSaveIsReportedNotSwallowed() {
 	encounters := &failingEncounters{fakeEncounters: newFakeEncounters()}
 	sessions := newFakeSessions()
-	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
+	mgr, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: sessions, Encounters: encounters, Characters: testCharacters(),
 		Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -231,7 +231,7 @@ func (s *WriteTestSuite) TestFailedSaveIsReportedNotSwallowed() {
 func (s *WriteTestSuite) TestStaleWorldIsNotResurrected() {
 	ctx := context.Background()
 
-	other, err := session.NewManager(&session.Config{Dice: testDice{},
+	other, err := session.NewManager(&session.Config{Dice: testDice{}, TurnDriver: session.Pass{},
 		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
 		Events: session.DiscardEvents{},
 	})


### PR DESCRIPTION
## The gap

In the reference tomb the fighter sights skeleton-1, the fight forms, the
fighter calls `EndTurn` and the clock parks on skeleton-1 forever — nothing
can act for it, since `EndTurn` requires `Member` to be the active member
and the host binds `Member` to the authenticated human, who does not own
the skeleton. Observed live by Kirk. Closes #1162 — the third and final PR
in the chain: `encounter` (#1163) → `resolution` (#1165) → this one.

## What this PR adds

`session.Config` gains a required `TurnDriver` field — a session-owned
twin of `encounter.TurnDriver` (S2: a host must never name an inner
module), refused at `NewManager` alongside `Sessions`/`Encounters`/
`Characters`/`Events`/`Dice`. `turnDriverSeam` adapts it into
`encounter.TurnDriver`, threaded into all three `encounter.LoadEncounter`
call sites (`read.go`, `start.go`, `write.go`) and into `attack.go`'s
`resolution.Input` (resolution needs it too — see #1165). The SDK ships
`session.Pass{}`, satisfying `TurnDriver` by always passing: a host wires
`Config.TurnDriver: session.Pass{}` for v1's whole behavior.

Full design and the options considered (SDK auto-yields with no
capability / host drives it via a new verb / a required capability, plus
the `Decider` counter-evidence) are in `encounter`'s
**docs/adr/0043-a-monsters-turn-has-a-driver.md** (#1163) — this PR is a
downstream, mechanical propagation of that decision through `resolution`
and `session`, the same shape `Initiative`/`Standing`/`Sight` already
take through both layers. No new ADR.

## The brief's testable cases, proven at the session seam

- **`TestEndingATurnHandsItOn`** (turn_test.go) — the tomb gate: alice's
  single `EndTurn` call returns `Next=alice`, `RoundWrapped=true`, and
  `Story` carries BOTH her own `"turn-ended"` beat and a separate one
  naming the ogre's driven-through pass (2 total, 1 naming the ogre).
- **`TestAnUnplayedMemberFirstInInitiativeIsAlreadyDrivenPastFightStart`**
  (fight_starts_test.go) — the ogre wins initiative on the dice alone (1
  vs 20, the same mechanism `TestTheDiceDecideTheOrder` already pins);
  the very first `Turn` read after `Formed` already shows alice active,
  with no `EndTurn` of the ogre's own required to reach it.
- **`TestEachRequirementIsCheckedByName/turndriver_absent`**
  (manager_test.go) — no driver supplied refuses at construction
  (`ErrIncompleteConfig`, naming `TurnDriver`), never defaulted.

Two shared test helpers (`nextTurn` in `economy_test.go` and its own copy
in `afford_test.go`) assumed a monster's turn had to be ended explicitly,
one call per fight member — simplified to the one call that is now
sufficient, with a comment explaining why the second call is now refused.

## What rpg-api must supply

One field, one line, at the same place it already wires
`Dice`/`Events`/the repositories:

```go
import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"

mgr, err := session.NewManager(&session.Config{
    // ... existing fields ...
    TurnDriver: session.Pass{},
})
```

No new rpg-api verb, no new authorization, no proto change. rpg-api#803
(verb authorization for a human to puppet a monster) is explicitly **not**
a prerequisite — that is a different feature (a human playing a monster)
this ADR does not touch. When the Monster AI initiative ships a real
decider, it wires into this same `Config.TurnDriver` field with no change
to `session`'s own shape.

## Evidence

`go test -race ./...`: clean across `rulebooks/dnd5e/session` and
`.../cmd/session-workbench`. `golangci-lint run ./...` (auto-discovered
`rulebooks/dnd5e/.golangci.yml`): 0 issues. `gorelease -base=v0.21.3`:
additive/compatible, suggests v0.22.0 (left for auto-tag).
`scripts/check-decisions.sh`: passes.

— asset-pipeline agent, on behalf of KirkDiggler
