### PR TITLE
session: Move spends movement on the turn clock (#1169)

### DIFF
--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -30,10 +30,13 @@ movement is the keyed capacity (`combat.CapacityMovement`) already
 reserved for it, priced per call (5 ft/cell, computed outside the profile
 per the addendum's row-four discipline) and charged through the same
 `combat.Pay` the ruling's foundation already established. First half —
-`encounter.Step`'s turn-clock gate — is
-[#1170](https://github.com/KirkDiggler/rpg-toolkit/pull/1170); the session
-half that actually calls `combat.Pay` before a walk follows in a second
-PR, and fork (d) is fully retired once both land.
+`encounter.Step`'s turn-clock gate — merged as
+[#1170](https://github.com/KirkDiggler/rpg-toolkit/pull/1170)
+(`encounter/v0.30.1`); the session half that actually calls `combat.Pay`
+before a walk and charges the whole requested path — refused whole,
+naming the currency in feet, before any step — is
+[#1171](https://github.com/KirkDiggler/rpg-toolkit/pull/1171). Fork (d) is
+fully retired once #1171 merges.
 
 [census]: https://github.com/KirkDiggler/rpg-toolkit/issues/1035#issuecomment-5326154182
 [supp]: https://github.com/KirkDiggler/rpg-toolkit/issues/1035#issuecomment-5326242250

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -38,6 +38,11 @@ type Verb string
 const (
 	// VerbAttack is [Manager.Attack]: swinging a weapon at another member.
 	VerbAttack Verb = "attack"
+
+	// VerbMove is [Manager.Move]: walking along a path while on the turn
+	// clock. Free-roam movement is not priced and so never appears here —
+	// see [Manager.Afford]'s own doc.
+	VerbMove Verb = "move"
 )
 
 // Slot names which of a turn's three economy shapes a [Declaration] draws
@@ -104,6 +109,22 @@ type Declaration struct {
 	// the absence of one, and a non-Go client reading a missing key cannot
 	// tell that from "the server didn't say".
 	Shortfall string `json:"shortfall"`
+
+	// Remaining is how much of this verb's own currency is left, in the
+	// currency's natural unit — feet, for Move (rpg-toolkit#1169).
+	//
+	// PRESENT ONLY WHERE THE NUMBER MEANS SOMETHING BEYOND CAN-OR-CANNOT.
+	// Attack's declaration has never needed one — a swing either happens or
+	// it does not — but a client walking Move wants to bound its own path
+	// preview to the server's real number rather than re-deriving a
+	// character's speed itself, which is exactly the calculation the
+	// Boundary Rule keeps off the client. Nil for VerbAttack.
+	//
+	// A POINTER, not an omitted zero: false-vs-absent for an int rather than
+	// a bool (types.go's law, generalised) — Remaining:0 is a real answer
+	// (nothing left this turn) and must not collide with "this verb carries
+	// no such number at all".
+	Remaining *int `json:"remaining,omitempty"`
 }
 
 // AffordOutput is what one member can still declare this turn.
@@ -124,7 +145,10 @@ type AffordOutput struct {
 
 // Afford reports what one member can still declare this turn: which of the
 // seam's gated verbs they could pay for right now, and — when they cannot —
-// the same currency-naming text a refused [Manager.Attack] would carry.
+// the same currency-naming text a refused [Manager.Attack] or [Manager.Move]
+// would carry. Move's own declaration (VerbMove, rpg-toolkit#1169) reports
+// Remaining rather than a fixed price, since a walk's cost depends on a path
+// this read is never given — see [affordMove].
 //
 // # The gap this closes
 //
@@ -229,19 +253,47 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 
 	// price.cost is never nil here: priceSwing returns a nil cost only when
 	// the member is on the world clock, already ruled out above.
-	decl := Declaration{Verb: VerbAttack, Slot: slotOf(price.cost.Profile)}
+	attack := Declaration{Verb: VerbAttack, Slot: slotOf(price.cost.Profile)}
 
 	// Charged against the sheet THIS CALL loaded, which is handed to nobody
 	// else and never saved (see the doc comment above). combat.Pay is the
 	// SAME gate the door pays a real swing through, so a payment that
 	// succeeds or fails here answers exactly as Attack's would.
 	if payErr := combat.Pay(sheet, price.cost.Profile); payErr != nil {
-		decl.Shortfall = payErr.Error()
+		attack.Shortfall = payErr.Error()
 	} else {
-		decl.Affordable = true
+		attack.Affordable = true
 	}
 
-	return &AffordOutput{Clock: ClockTurn, Declarations: []Declaration{decl}}, nil
+	// affordMove reads the SAME sheet, already readied for this turn by
+	// priceSwing's own call above — never a second ready, which would
+	// re-seed a bank the attack declaration just read. Safe to share: an
+	// attack's profile never names CapacityMovement, so paying it above
+	// cannot have moved what affordMove is about to read.
+	return &AffordOutput{Clock: ClockTurn, Declarations: []Declaration{attack, affordMove(sheet)}}, nil
+}
+
+// affordMove reports what this member could still spend on movement this
+// turn, off the sheet [Manager.Afford] already loaded and readied above.
+//
+// UNLIKE ATTACK, movement has no fixed price to try paying: what a specific
+// walk costs is a fact about the PATH ([Manager.priceWalk]), and Afford is
+// asked before any path is chosen. So this answers the question Afford CAN
+// answer without one. Remaining is the actual feet left — the number a
+// client bounds its own path preview against — and Affordable answers only
+// whether ANY movement at all is still possible: one cell, five feet, the
+// smallest unit this grid has. Shortfall, when it applies, says so in the
+// same "ft" words [movementShortfall] gives a refused Move, minus a "needed"
+// side this read has no specific request to name.
+func affordMove(sheet *character.Character) Declaration {
+	left := sheet.CapacityLeft(combat.CapacityMovement)
+	decl := Declaration{Verb: VerbMove, Slot: SlotNone, Remaining: &left}
+	if left >= 5 {
+		decl.Affordable = true
+		return decl
+	}
+	decl.Shortfall = fmt.Sprintf("movement: %d ft left", left)
+	return decl
 }
 
 // slotOf reads which of a turn's three slots a compiled price draws from, if

--- a/rulebooks/dnd5e/session/afford_test.go
+++ b/rulebooks/dnd5e/session/afford_test.go
@@ -87,7 +87,7 @@ func (s *AffordSuite) TestAffordableMeansAttackWillNotRefuse() {
 
 	out := s.afford()
 	s.Equal(session.ClockTurn, out.Clock)
-	s.Require().Len(out.Declarations, 1)
+	s.Require().Len(out.Declarations, 2, "attack and move (rpg-toolkit#1169)")
 
 	decl := out.Declarations[0]
 	s.Equal(session.VerbAttack, decl.Verb)
@@ -111,7 +111,7 @@ func (s *AffordSuite) TestUnaffordableMeansAttackRefusesWithTheSameShortfall() {
 	s.Require().True(first.Hit)
 
 	out := s.afford()
-	s.Require().Len(out.Declarations, 1)
+	s.Require().Len(out.Declarations, 2, "attack and move (rpg-toolkit#1169)")
 	decl := out.Declarations[0]
 	s.False(decl.Affordable, "nothing left to buy a second swing")
 	s.NotEmpty(decl.Shortfall, "false carries a reason")
@@ -181,7 +181,7 @@ func (s *AffordSuite) TestANewTurnRefillsWhatAffordSees() {
 	s.nextTurn()
 
 	out := s.afford()
-	s.Require().Len(out.Declarations, 1)
+	s.Require().Len(out.Declarations, 2, "attack and move (rpg-toolkit#1169)")
 	s.True(out.Declarations[0].Affordable, "a new turn buys a new swing")
 	s.Equal(session.SlotAction, out.Declarations[0].Slot)
 }

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -16,7 +16,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -165,6 +164,26 @@ func (m *memCharacters) SaveCharacter(_ context.Context, data *character.Data) e
 // Note what is NOT here: speed. It is derived from race when the character is
 // reconstituted, which is why the transcript printing 25 is evidence the load
 // really happened rather than evidence a map lookup returned something.
+// aliceTheFighter registers alice's own sheet. She had none until
+// rpg-toolkit#1169: nothing before Move's own turn-clock pricing ever needed
+// to load a member's character for a verb this demo calls on her, so the gap
+// was invisible — a fixture that only ever spawned her onto the encounter's
+// roster, never into the Characters store Attack and now Move both read.
+func aliceTheFighter() *character.Data {
+	return &character.Data{
+		ID:               "alice",
+		PlayerID:         "player-alice",
+		Name:             "Alice",
+		Level:            3,
+		ProficiencyBonus: 2,
+		RaceID:           races.Human,
+		ClassID:          classes.Fighter,
+		HitPoints:        24,
+		MaxHitPoints:     28,
+		ArmorClass:       16,
+	}
+}
+
 func bobTheDwarf() *character.Data {
 	return &character.Data{
 		ID:               "bob",
@@ -199,8 +218,10 @@ func drive(out *bytes.Buffer) error {
 	mgr, err := session.NewManager(&session.Config{Dice: loadedDice{},
 		Sessions:   &memSessions{byID: map[string]*session.SessionData{}},
 		Encounters: &memEncounters{byID: map[string]*encounter.EncounterData{}},
-		Characters: &memCharacters{byID: map[string]*character.Data{"bob": bobTheDwarf()}},
-		Events:     &printStream{out: out},
+		Characters: &memCharacters{
+			byID: map[string]*character.Data{"alice": aliceTheFighter(), "bob": bobTheDwarf()},
+		},
+		Events: &printStream{out: out},
 		// The workbench demonstrates verbs a human drives; nothing in it
 		// gives a monster a real behavior yet, so an unplayed member simply
 		// passes (rpg-toolkit#1162).
@@ -336,15 +357,20 @@ func drive(out *bytes.Buffer) error {
 		fmt.Fprintf(out, "   caught unaware: %v\n", crossed.Formed.Surprised)
 	}
 
-	fmt.Fprintln(out, "\n== and she cannot simply walk away ==")
+	fmt.Fprintln(out, "\n== alice can still act, on her own turn ==")
 	// Cells on the map: alice arrived at the vault's (0,1) local, which is
-	// (6,1) with the vault anchored at (6,0). She tries to step deeper in.
+	// (6,1) with the vault anchored at (6,0). She steps deeper in — on the
+	// turn clock now, a walk spends movement rather than being refused
+	// outright (rpg-toolkit#1169), and it is still her turn: she leads the
+	// vault fight's own initiative order.
 	vaultPath := []spatial.Position{{X: 7, Y: 1}, {X: 7, Y: 2}}
-	_, err = mgr.Move(ctx, &session.MoveInput{
+	aliceWalk, err := mgr.Move(ctx, &session.MoveInput{
 		Session: "crypt-run", Member: "alice", Path: vaultPath,
 	})
-	fmt.Fprintf(out, "   free roam refused for a fight member: %v\n",
-		errors.Is(err, session.ErrInBubble))
+	if err != nil {
+		return err
+	}
+	fmt.Fprintf(out, "   she walks %d step(s) into the vault, on her own turn\n", len(aliceWalk.Steps))
 
 	// Bob is not in it. A fight is localized to the members who are in contact,
 	// so the rest of the party keeps exploring while it runs.

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
@@ -36,12 +36,12 @@ func TestWorkbenchRuns(t *testing.T) {
 
 		// A fight that starts itself, end to end. Each of these is a different
 		// claim, and any one regressing would leave the others still true:
-		"a fight starts, in order [alice skel-1 wight]", // contact at the doorway starts it, unasked
-		"free roam refused for a fight member: true",    // and a fighter stops free-roaming
-		"bob walks on regardless, 1 step(s)",            // while everyone not in it carries on
+		"a fight starts, in order [alice skel-1 wight]",       // contact at the doorway starts it, unasked
+		"she walks 2 step(s) into the vault, on her own turn", // the active member still walks (rpg-toolkit#1169)
+		"bob walks on regardless, 1 step(s)",                  // while everyone not in it carries on
 
 		`ended by "withdraw"`,
-		"alice at (6,1)", // she is where the fight stopped her, and it persisted
+		"alice at (7,2)", // she is where her own turn's walk left her, and it persisted
 	} {
 		if !strings.Contains(got, want) {
 			t.Errorf("workbench output missing %q\nfull output:\n%s", want, got)

--- a/rulebooks/dnd5e/session/death_test.go
+++ b/rulebooks/dnd5e/session/death_test.go
@@ -357,14 +357,17 @@ func (s *DeathTestSuite) TestTheSurvivorWalksAgain() {
 	s.startCrypt()
 	s.spawnSkeleton()
 
-	_, blocked := s.mgr.Move(context.Background(), &session.MoveInput{
-		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 2}},
-	})
-	s.Require().ErrorIs(blocked, session.ErrInBubble, "control: mid-fight, she is not free to walk")
+	// Control: mid-fight, she is on the turn clock, not free-roaming — a
+	// direct blocked Move no longer proves this alone since rpg-toolkit#1169,
+	// which lets the active member of a bubble still walk on the turn clock,
+	// at a cost. See move_test.go's own turn-clock suite for that behavior.
+	turn, err := s.mgr.Turn(context.Background(), &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal(session.ClockTurn, turn.Clock, "control: mid-fight, she is on the turn clock")
 
 	s.swingUntilTheSkeletonFalls()
 
-	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
+	_, err = s.mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 2}},
 	})
 	s.Require().NoError(err, "the fight is over, so the walk is hers again")

--- a/rulebooks/dnd5e/session/dissolve_test.go
+++ b/rulebooks/dnd5e/session/dissolve_test.go
@@ -58,11 +58,15 @@ func (s *DissolveTestSuite) TestTheDeadEndIsClosed() {
 	s.fight()
 	ctx := context.Background()
 
-	// The dead end, before it is closed.
-	_, err := s.mgr.Move(ctx, &session.MoveInput{
-		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 2, Y: 3}},
-	})
-	s.Require().ErrorIs(err, session.ErrInBubble, "a fight member does not free-roam")
+	// The dead end, before it is closed: alice is on the turn clock, and
+	// Transfer to the world clock still refuses a member already in a bubble
+	// — the only way off it while the fight runs is through Dissolve. (A
+	// direct Move no longer proves this on its own since rpg-toolkit#1169:
+	// the active member of a bubble may still walk, on the turn clock, at a
+	// cost — see move_test.go's own turn-clock suite.)
+	turn, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal(session.ClockTurn, turn.Clock, "a fight member is on the turn clock, not free to roam")
 
 	out, err := s.mgr.Dissolve(ctx, &session.DissolveInput{
 		Session: "sess", Member: "alice", Cause: session.ByDecision(),

--- a/rulebooks/dnd5e/session/economy.go
+++ b/rulebooks/dnd5e/session/economy.go
@@ -70,19 +70,22 @@ type swingPrice struct {
 // name per EndTurn and the round wraps when it comes back around — so the
 // round IS that member's turn number. Nothing is guessed.
 //
-// # Speed is the honest half-measure, and it is inert in v1
+// # Speed is the honest half-measure, and it stayed one once movement started reading it
 //
 // [character.RefreshForTurnInput] wants the speed a turn seeds AFTER conditions
 // have had their say, and this package has no such number: it can read the
 // sheet's base walking speed and nothing else. So the seeded MovementRemaining
 // is wrong on any hasted or slowed character.
 //
-// It is shipped anyway, deliberately, because in v1 NOTHING READS IT: movement
-// costs nothing (the ruling's fork (d)), so no profile names CapacityMovement
-// and no path spends it. The day movement is charged, this is the line that has
-// to grow a real answer — a speed computed where conditions can be asked, which
-// is above this seam — and it must not be discovered then. It is named here
-// rather than left to be found.
+// It was shipped anyway, deliberately, when nothing read it: movement cost
+// nothing (the ruling's fork (d)), so no profile named CapacityMovement and no
+// path spent it, and this line was named as the one that would have to grow a
+// real answer the day that changed. That day is rpg-toolkit#1169:
+// [Manager.priceWalk] now spends exactly the MovementRemaining this call
+// seeds, through the identical [combat.Pay] gate a swing pays through. The
+// haste/slow gap is unchanged and still real — a speed computed where
+// conditions can be asked is still above this seam — but it is no longer
+// theoretical, and the day it is closed this comment is where to start.
 //
 // It takes the encounter rather than a *writeScope so a read verb can call it
 // too ([Manager.Afford] does): pricing a swing commits nothing on its own, and

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -218,15 +218,21 @@ var (
 	// is unusable, and the repair is upstream of anything a caller can retry.
 	ErrInvalidWorld = errors.New("invalid encounter data")
 
-	// ErrInBubble is returned when a member is asked to free-roam while they
-	// are in a fight. Movement inside a fight goes through its turn structure,
-	// which this SDK does not surface yet.
+	// ErrInBubble is returned when a verb requires its member NOT be in a
+	// running bubble and they are.
+	//
+	// NOT MOVE'S OWN REFUSAL ANY MORE (rpg-toolkit#1169): the active member of
+	// a fight may walk on the turn clock now, priced and gated by whose turn
+	// it is (ErrNotYourTurn) rather than refused outright. What survives here
+	// are the composition's own Form/Transfer-shaped refusals translated
+	// unchanged — naming a member already in a fight, or attempting to enter
+	// one that is already running (#963's one-bubble-per-encounter policy).
 	//
 	// It became reachable with rpg-toolkit#964: a fight now starts by itself,
-	// so a walk can end with the walker in one, and the very next Move is
-	// refused. Before that a member could only enter a fight by a caller
-	// deciding to start one, which nothing in this package ever did — the
-	// sentinel had no path to a host and so did not exist.
+	// so a walk could end with the walker in one and (then) the very next Move
+	// was refused by it. Before that a member could only enter a fight by a
+	// caller deciding to start one, which nothing in this package ever did —
+	// the sentinel had no path to a host and so did not exist.
 	ErrInBubble = errors.New("member is in a fight")
 
 	// ErrNotInFight is returned when a verb needs the member to be in a fight

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -237,6 +237,17 @@ var (
 	// one they guessed wrong about.
 	ErrNotInFight = errors.New("member is not in a fight")
 
+	// ErrNotYourTurn is returned when a verb needs its member to be the
+	// CURRENT active member of the fight they are in, and they are not.
+	//
+	// TWO VERBS SHARE THIS REFUSAL (rpg-toolkit#1169): EndTurn naming someone
+	// whose turn it is not, and Move asking a bubble member who is not the one
+	// the clock is waiting on to walk. Translated from the composition's own
+	// encounter.ErrNotActive rather than left to cross the boundary unnamed
+	// (S2) — see translate. Distinct from ErrNotInFight: this member IS in the
+	// fight, just not up right now.
+	ErrNotYourTurn = errors.New("not your turn")
+
 	// ErrNoCause is returned when a verb that must say WHY is not told.
 	//
 	// Ending a fight is the one that has it: a fight ends either because
@@ -307,7 +318,8 @@ var (
 
 	// ErrCannotAfford is returned when an actor cannot pay for what they
 	// declared: a second swing in a turn that bought only one, a level-5
-	// fighter's third, an action after the action was spent.
+	// fighter's third, an action after the action was spent, or a walk longer
+	// than the turn's remaining movement (rpg-toolkit#1169).
 	//
 	// THIS IS A FACT ABOUT THE GAME, not about the code, and that is the whole
 	// reason it is separate from ErrBadCost. A player who has run out of actions
@@ -319,6 +331,9 @@ var (
 	// The message NAMES THE CURRENCY that ran out — "action: 1 needed, 0 left" —
 	// because a refusal a client cannot explain is a refusal that reads as a bug.
 	// A host may show it or match the sentinel and say it in its own words.
+	// Move's own refusal composes its own "ft"-suffixed text rather than
+	// [combat.SpendProfile]'s unitless one — see [movementShortfall] — but the
+	// YES/NO answer both come from is the same [combat.Pay] call either way.
 	//
 	// It is a FIGHT's refusal. The action economy exists only in combat, so a
 	// member on the world clock is charged nothing and can never see this.

--- a/rulebooks/dnd5e/session/example_session_test.go
+++ b/rulebooks/dnd5e/session/example_session_test.go
@@ -5,7 +5,6 @@ package session_test
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"sort"
 
@@ -159,16 +158,23 @@ func Example_theFightThatStartsItself() {
 	fmt.Printf("stopped after %d/%d: a fight starts, in order %v\n",
 		len(out.Steps), len(path), out.Formed.Order)
 
-	// She cannot simply walk on: she is in the fight, and free roam is for
-	// members who are not. The refusal is the composition's, translated.
-	_, err = mgr.Move(ctx, &session.MoveInput{
+	// She is not free to WANDER — Transfer to the world clock is still refused
+	// while a bubble holds her — but it is her own turn (she is the fight's
+	// first name in initiative), so Move still lets her walk: on the turn
+	// clock a walk spends movement rather than being refused outright
+	// (rpg-toolkit#1169). This cell costs 5 of the feet her speed banked at
+	// the top of the fight.
+	out, err = mgr.Move(ctx, &session.MoveInput{
 		Session: "run", Member: "alice", Path: []spatial.Position{{X: 2, Y: 3}},
 	})
-	fmt.Printf("walking on is refused: %v\n", errors.Is(err, session.ErrInBubble))
+	if err != nil {
+		panic(err)
+	}
+	fmt.Printf("she can still walk on her own turn: %d step(s)\n", len(out.Steps))
 
 	// Output:
 	// stopped after 2/4: a fight starts, in order [alice ogre]
-	// walking on is refused: true
+	// she can still walk on her own turn: 1 step(s)
 }
 
 // panicFataler adapts the test fixtures for use from an Example, which has no

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.1
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,8 +18,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0 h1:BnDZ//xyK/vcFmhUyDV8mRd4KSnj6Ofrz5Kpxy0GH1o=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.1 h1:FHjfYzEtQi90+UBEZe3vIZy6ch9ZVuFdwL1WSJZRQQU=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.1/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1 h1:FCDHPx/vGzDmHIHopHCJQspyybr0HI/KL7z7i68a9Y4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -8,6 +8,8 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -111,12 +113,27 @@ type MoveOutput struct {
 // that happened, happened, and it is exactly what the caller asked for up to
 // the point the world changed.
 //
+// # On the turn clock, a walk spends movement (rpg-toolkit#1169)
+//
+// A member IN A FIGHT may still walk — only when it is their turn, and only as
+// far as their turn's movement reaches. [Manager.priceWalk] compiles the whole
+// requested path at 5 feet per cell and charges it through [combat.Pay] BEFORE
+// any cell is entered, the same door [Manager.Attack] pays a swing through: a
+// path that costs more than the turn has left is refused whole, naming the
+// currency, and not one cell of it happens. Whose turn it is is not re-derived
+// here — [encounter.Step] is the one place that gate lives, and its refusal
+// (ErrNotActive) is translated to ErrNotYourTurn exactly as EndTurn's already
+// is. Free roam is untouched: a member on the world clock pays nothing, exactly
+// as [Manager.priceSwing] charges nothing there.
+//
 // WHAT IS VALIDATED WHOLE, AND WHAT IS NOT (R5, narrowed deliberately by
 // rpg-toolkit#1059). A path that is not a WALK is rejected entire, before a
 // single cell is entered: a gap in it, a step of no distance, a first cell
 // nowhere near the walker. A caller who mis-computed a route wants none of it
 // rather than an arbitrary prefix of it, and those are the mistakes a route
-// computation actually makes.
+// computation actually makes. Movement's own price joins that list: it is
+// charged against the whole path before the walk starts, not metered per cell
+// as the walk goes.
 //
 // The two refusals that need the MAP — a cell no room owns, and a cell in the
 // next room with no doorway joining it — are raised by the composition as each
@@ -124,13 +141,19 @@ type MoveOutput struct {
 // what is crossable, which is the duplication this walk exists without. The
 // caller sees no difference: a refused walk returns an error, and nothing is
 // persisted or published, because the encounter that moved in memory is
-// discarded unsaved.
+// discarded unsaved. The same is true of a charged sheet: [Manager.priceWalk]
+// mutates a [character.Character] loaded fresh for this call, and a walk that
+// fails after paying simply never hands that sheet to [Manager.saveWalker] —
+// nothing durable ever saw the spend.
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrEmptyPath,
 // ErrBrokenPath for a path with a gap in it, ErrNoSession, ErrNoEncounter,
 // ErrNoMember, ErrClosed, ErrBadPosition for a cell no room owns OR a cell the
 // walker is already standing on, ErrNoCrossing for a step into another room
-// with no doorway joining it, or ErrSaveFailed with a populated report.
+// with no doorway joining it, ErrNotYourTurn for a bubble member asked to walk
+// out of turn, ErrCannotAfford naming the movement that ran short,
+// ErrBadCharacter or ErrBadCost if the walker's own sheet cannot be priced, or
+// ErrSaveFailed with a populated report.
 func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("move: %w", ErrNilInput)
@@ -164,9 +187,37 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
+	cost, err := m.priceWalk(ctx, scope, in.Member, len(in.Path))
+	if err != nil {
+		return nil, fmt.Errorf("move: %w", err)
+	}
+
+	// THE ONE PLACE A SPEND GOES for this verb, mirroring Attack's own comment
+	// at its call site: nil profile means free roam or a non-character member,
+	// and combat.Pay treats a nil profile as a free action by its own contract
+	// (see [combat.SpendProfile]), so this branch is a shortcut rather than a
+	// second free-action path.
+	if cost.profile != nil {
+		if err := combat.Pay(cost.sheet, cost.profile); err != nil {
+			left := cost.sheet.CapacityLeft(combat.CapacityMovement)
+			return nil, fmt.Errorf("move: %w: %s", ErrCannotAfford, movementShortfall(cost.feet, left))
+		}
+	}
+
 	res, err := m.runWalk(scope, in.Member, in.Path)
 	if err != nil {
 		return nil, fmt.Errorf("move: %w", err)
+	}
+
+	// The spend is durable only once the walk it paid for actually happened.
+	// Charged for the WHOLE requested path regardless of whether the walk
+	// stopped early on an Outcome or a Formed bubble (see runWalk) — v1 does
+	// not refund an interrupted walk's unused cells, the same way a paid-for
+	// swing is not refunded for missing.
+	if cost.sheet != nil {
+		if err := m.saveWalker(ctx, scope, cost.sheet); err != nil {
+			return nil, fmt.Errorf("move: %w", err)
+		}
 	}
 
 	report, delivery, err := m.commit(ctx, scope)
@@ -182,6 +233,121 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		Saved:      report,
 		Delivery:   delivery,
 	}, nil
+}
+
+// walkCost is what one walk costs its walker, and the sheet that will be
+// charged for it — [swingPrice]'s own shape, carried over rather than
+// reinvented: both fields nil is a price of nothing, never a missing one.
+type walkCost struct {
+	// profile is what the door charges for this walk, or nil to charge
+	// nothing — free roam, or a member the session holds no character sheet
+	// for.
+	profile *combat.SpendProfile
+
+	// sheet is the walker's own sheet with its turn readied, ready to be
+	// charged and, after a successful walk, saved by [Manager.saveWalker].
+	// Nil exactly when profile is.
+	sheet *character.Character
+
+	// feet is the requested path's price, named separately from profile so a
+	// refusal can quote it without re-deriving it from a map lookup.
+	feet int
+}
+
+// priceWalk works out what walking `cells` cells costs this member, and
+// readies the sheet the door will charge for it — [Manager.priceSwing]'s own
+// shape, adapted to a currency priced by the CALL rather than compiled once
+// per actor.
+//
+// # Free roam charges nothing, the same ruling priceSwing states
+//
+// [combat.Ledger] opens with InCombat and refuses every payment from a holder
+// who is not in one, so a walk off the turn clock is priced nothing rather
+// than being handed a cost the gate would refuse outright. A member the
+// session holds no character sheet for — a monster, reachable only if a host
+// calls this verb for one, since the pump moves monsters through
+// [encounter.Encounter]'s own silent stepTo and never through this seam — is
+// priced nothing for the same reason [Manager.Afford] already lets that case
+// speak for itself: ErrNoCharacter is refused by the load below rather than
+// silently priced as free.
+//
+// # What a path costs is the path's business, never the profile's
+//
+// Movement is 5 feet per cell, computed HERE, per call, rather than compiled
+// onto a [combat.SpendProfile] the way an attack's price is. That split is not
+// this seam's invention — the profile's own doc says per-unit movement cost is
+// "deliberately not here" — and it is the whole of what the movement design
+// addendum (rpg-toolkit#1035) named as the ONE thing E1's foundation had to
+// leave room for: "one key constant [5 feet] and one discipline [per-unit
+// cost stays out of the profile]". This is that constant's first caller.
+//
+// # readyForTurn is shared with priceSwing, not duplicated
+//
+// The same function lights a cold sheet or refreshes a stale one for either
+// verb — whichever of Attack or Move a member's turn asks for FIRST is the one
+// that ignites it, and the other finds it already lit. See readyForTurn's own
+// comment for why the session is the layer that has to do this at all.
+//
+// Returns ErrNoMember, ErrNoCharacter, ErrBadCharacter, or ErrBadCost.
+func (m *Manager) priceWalk(
+	ctx context.Context, scope *writeScope, member string, cells int,
+) (*walkCost, error) {
+	clock, err := scope.enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(member)})
+	if err != nil {
+		return nil, translate(err)
+	}
+	if ClockKind(clock.Kind) != ClockTurn {
+		return &walkCost{}, nil
+	}
+
+	data, err := m.fetchCharacterData(ctx, "member", member)
+	if err != nil {
+		return nil, err
+	}
+	sheet, err := character.Load(ctx, data)
+	if err != nil {
+		return nil, fmt.Errorf("member %q: %w: %v", member, ErrBadCharacter, err)
+	}
+
+	if err := readyForTurn(ctx, sheet, clock.Round); err != nil {
+		return nil, fmt.Errorf("member %q: %w: %v", member, ErrBadCost, err)
+	}
+
+	feet := 5 * cells
+	return &walkCost{
+		profile: &combat.SpendProfile{Capacity: map[combat.CapacityType]int{combat.CapacityMovement: feet}},
+		sheet:   sheet,
+		feet:    feet,
+	}, nil
+}
+
+// movementShortfall composes the "ft"-suffixed text a refused Move and
+// Afford's own VerbMove declaration both carry — the SAME text in both
+// places, never a paraphrase of it, the way ErrCannotAfford's own doc
+// requires of every currency this seam names.
+//
+// It is presentation, not a second copy of the arithmetic: the YES/NO
+// affordability answer comes from [combat.Pay]/[combat.CanPay] alone, exactly
+// as it does for a swing. This exists only because [combat.SpendProfile]'s own
+// refusal text has no unit to name ("movement: 20 needed, 15 left") and Kirk's
+// brief wants one a client can say out loud without translating "movement" and
+// a bare integer into feet itself.
+func movementShortfall(needed, left int) string {
+	return fmt.Sprintf("movement: %d ft needed, %d ft left", needed, left)
+}
+
+// saveWalker persists the walker's sheet after a walk has spent from it, and
+// marks the write on the scope so persist's own report opens with it — the
+// same contract [Manager.saveDirty] keeps for a swing's damaged sheets, sized
+// down to the one sheet a walk can ever touch.
+func (m *Manager) saveWalker(ctx context.Context, scope *writeScope, sheet *character.Character) error {
+	data := sheet.ToData()
+	if err := m.characters.SaveCharacter(ctx, data); err != nil {
+		report := SaveReport{Written: scope.written, Failed: []string{"character:" + data.ID}}
+		return &SaveError{Report: report, Err: fmt.Errorf("saving character: %w", err)}
+	}
+	scope.written = append(scope.written, "character:"+data.ID)
+	return nil
 }
 
 // walkResult is what one run of the walk produced.

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -174,28 +174,55 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
-	// A downed member does not walk. Asked after the path is VALIDATED and before a single
-	// cell is entered, which is where R5 puts every other refusal: the path is
-	// validated whole first, so naming a member who is not here or a route that
-	// is not a walk still answers what it always answered, and a walk this
-	// refuses has moved nobody.
+	// Whose turn it is is asked FIRST among the fact-about-this-member
+	// refusals — before downed, before anything is priced, before any sheet
+	// is loaded at all (Copilot finding on #1171). If it is not your turn,
+	// nothing else about you is this call's business yet: encounter.Step's
+	// own gate would eventually refuse a non-active bubble member's first
+	// step with ErrNotActive regardless, but by then refuseIfDown and
+	// priceWalk would both already have loaded a sheet, and combat.Pay might
+	// already have refused with a MISLEADING currency shortfall — a
+	// non-active member low on movement would be told "movement: X ft
+	// needed" instead of "not your turn", naming the wrong reason. This is
+	// not a second copy of Step's rule: it is the same fact, ClockOf, that
+	// Manager.Turn and priceWalk already read for their own purposes, read
+	// once more here before anything else touches this member at all.
+	clock, err := scope.enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(in.Member)})
+	if err != nil {
+		return nil, fmt.Errorf("move: %w", translate(err))
+	}
+	if ClockKind(clock.Kind) == ClockTurn && string(clock.Active) != in.Member {
+		return nil, fmt.Errorf("move: %w", ErrNotYourTurn)
+	}
+
+	// A downed member does not walk. Asked after the path is VALIDATED and
+	// the TURN GATE has passed, and before a single cell is entered, which is
+	// where R5 puts every other refusal: naming a member who is not here, a
+	// route that is not a walk, or a member whose turn has not come still
+	// answers what it always answered, and a walk this refuses has moved
+	// nobody.
 	//
-	// Inside a fight this never fires, because a member in a bubble is refused
-	// the verb outright. It is free roam that needed it — there is no turn
-	// order there to have already taken the walker out.
+	// REACHABLE INSIDE A FIGHT NOW, unlike before rpg-toolkit#1169: a bubble
+	// member used to be refused the verb outright, so a downed one could
+	// never reach this check from here. The active member can now walk, and
+	// nothing in the composition splices a downed member out of initiative on
+	// its own (rpg-toolkit#1077's own ruling) — so this is exactly where a
+	// downed member whose turn the clock IS waiting on still gets refused.
 	if err = refuseIfDown(scope, "member", in.Member); err != nil {
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
-	cost, err := m.priceWalk(ctx, scope, in.Member, len(in.Path))
+	cost, err := m.priceWalk(ctx, scope, in.Member, clock, len(in.Path))
 	if err != nil {
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
 	// THE ONE PLACE A SPEND GOES for this verb, mirroring Attack's own comment
-	// at its call site: nil profile means free roam or a non-character member,
-	// and combat.Pay treats a nil profile as a free action by its own contract
-	// (see [combat.SpendProfile]), so this branch is a shortcut rather than a
+	// at its call site: nil profile means FREE ROAM ONLY — priceWalk refuses
+	// with ErrNoCharacter/ErrBadCharacter for anyone else on the turn clock it
+	// cannot load, rather than silently pricing them as free. combat.Pay
+	// treats a nil profile as a free action by its own contract (see
+	// [combat.SpendProfile]), so this branch is a shortcut rather than a
 	// second free-action path.
 	if cost.profile != nil {
 		if err := combat.Pay(cost.sheet, cost.profile); err != nil {
@@ -259,17 +286,22 @@ type walkCost struct {
 // shape, adapted to a currency priced by the CALL rather than compiled once
 // per actor.
 //
+// clock is the caller's OWN ClockOf read, passed in rather than re-fetched:
+// [Manager.Move] already reads it to gate on whose turn it is before this is
+// ever called, and a second read here would ask the composition the same
+// question twice in one verb.
+//
 // # Free roam charges nothing, the same ruling priceSwing states
 //
 // [combat.Ledger] opens with InCombat and refuses every payment from a holder
 // who is not in one, so a walk off the turn clock is priced nothing rather
-// than being handed a cost the gate would refuse outright. A member the
-// session holds no character sheet for — a monster, reachable only if a host
-// calls this verb for one, since the pump moves monsters through
-// [encounter.Encounter]'s own silent stepTo and never through this seam — is
-// priced nothing for the same reason [Manager.Afford] already lets that case
-// speak for itself: ErrNoCharacter is refused by the load below rather than
-// silently priced as free.
+// than being handed a cost the gate would refuse outright — this is the ONLY
+// case that returns a nil profile. A member the session holds no character
+// sheet for — a monster, reachable only if a host calls this verb for one,
+// since the pump moves monsters through [encounter.Encounter]'s own silent
+// stepTo and never through this seam — is NOT priced nothing: it is refused,
+// by the load below, exactly the way [Manager.Afford] already lets that case
+// speak for itself rather than silently treating it as free.
 //
 // # What a path costs is the path's business, never the profile's
 //
@@ -288,14 +320,10 @@ type walkCost struct {
 // that ignites it, and the other finds it already lit. See readyForTurn's own
 // comment for why the session is the layer that has to do this at all.
 //
-// Returns ErrNoMember, ErrNoCharacter, ErrBadCharacter, or ErrBadCost.
+// Returns ErrNoCharacter, ErrBadCharacter, or ErrBadCost.
 func (m *Manager) priceWalk(
-	ctx context.Context, scope *writeScope, member string, cells int,
+	ctx context.Context, scope *writeScope, member string, clock *encounter.ClockOfOutput, cells int,
 ) (*walkCost, error) {
-	clock, err := scope.enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(member)})
-	if err != nil {
-		return nil, translate(err)
-	}
 	if ClockKind(clock.Kind) != ClockTurn {
 		return &walkCost{}, nil
 	}

--- a/rulebooks/dnd5e/session/move_turnclock_test.go
+++ b/rulebooks/dnd5e/session/move_turnclock_test.go
@@ -1,0 +1,273 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// move_turnclock_test.go pins rpg-toolkit#1169: Move on the turn clock. The
+// active member of a fight may still walk — priced at 5 feet per cell,
+// refused whole before any step, and gated to whoever the clock is waiting
+// on — where before this SDK refused every fight member's Move outright.
+//
+// The fixture is aFight's own shape (economy_test.go), widened to a second
+// player: alice AND bob start in the hall, a skeleton spawns adjacent and
+// pulls all three into one bubble, initiative order [alice, bob, skel-1].
+// TWO REAL PLAYERS is what makes "not alice's turn" an observable state at
+// all — a lone player fighting a Pass-driven monster cycles straight back
+// through EndTurn in one call (see afford_test.go's own nextTurn), so there
+// is no window in which a caller could ask a sole player to move out of
+// turn. Bob's own turn, between alice's and the Pass-driven skeleton's,
+// is that window.
+type MoveTurnClockSuite struct {
+	suite.Suite
+
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	characters *fakeCharacters
+	stream     *fakeStream
+	mgr        *session.Manager
+}
+
+func TestMoveTurnClockSuite(t *testing.T) { suite.Run(t, new(MoveTurnClockSuite)) }
+
+func (s *MoveTurnClockSuite) SetupTest() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
+	s.stream = &fakeStream{}
+
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: s.stream,
+	})
+	s.Require().NoError(err)
+	s.mgr = mgr
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 5, Y: 5}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	s.Require().NoError(err)
+	data := enc.ToData()
+
+	ctx := context.Background()
+	_, err = mgr.StartSession(ctx, &session.StartSessionInput{Session: "sess", Encounter: "world", World: &data})
+	s.Require().NoError(err)
+
+	spawned, err := mgr.Spawn(ctx, &session.SpawnInput{
+		Session: "sess", ID: "skel-1", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 2, Y: 1},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(spawned.Formed, "arriving in plain sight must start a fight")
+
+	turn, err := mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Require().Equal(session.ClockTurn, turn.Clock)
+	s.Require().Equal("alice", turn.Active, "alice is first registered — first in initiative")
+}
+
+func (s *MoveTurnClockSuite) afford(member string) *session.AffordOutput {
+	s.T().Helper()
+	out, err := s.mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: member})
+	s.Require().NoError(err)
+	return out
+}
+
+// moveDecl finds the VerbMove declaration, failing loudly if Afford ever
+// stops carrying one — a silent absence would read as "nothing to report"
+// rather than as the regression it is.
+func (s *MoveTurnClockSuite) moveDecl(out *session.AffordOutput) session.Declaration {
+	s.T().Helper()
+	for _, d := range out.Declarations {
+		if d.Verb == session.VerbMove {
+			return d
+		}
+	}
+	s.Require().Fail("no VerbMove declaration", "declarations: %+v", out.Declarations)
+	return session.Declaration{}
+}
+
+func (s *MoveTurnClockSuite) storedMovement(member string) int {
+	s.T().Helper()
+	stored, ok := s.characters.byID[member]
+	s.Require().True(ok, "%s must be in the repository", member)
+	s.Require().NotNil(stored.ActionEconomy, "%s's sheet was never readied", member)
+	return stored.ActionEconomy.MovementRemaining
+}
+
+func (s *MoveTurnClockSuite) where(member string) spatial.Position {
+	s.T().Helper()
+	out, err := s.mgr.Where(context.Background(), &session.WhereInput{Session: "sess", Member: member})
+	s.Require().NoError(err)
+	return out.Position
+}
+
+// TestActiveMemberSpendsMovementAndAffordSeesIt is the brief's own opening
+// case: a 3-cell walk, on the turn clock, by the active member.
+func (s *MoveTurnClockSuite) TestActiveMemberSpendsMovementAndAffordSeesIt() {
+	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}},
+	})
+	s.Require().NoError(err, "alice is active, and 3 cells cost 15 of her 30 feet")
+	s.Require().Len(out.Steps, 3)
+	s.Equal(spatial.Position{X: 1, Y: 4}, out.Steps[2].Position)
+
+	// The sheet's own spend is durable, not merely reported.
+	s.Equal(15, s.storedMovement("alice"), "30 speed - 15 spent = 15 left, persisted")
+
+	// MOVED reached the stream — the walk is a real one, not a silent charge.
+	var moved int
+	for _, ev := range s.stream.published {
+		if ev.Kind == session.EventMoved && ev.Recipient == "alice" {
+			moved++
+		}
+	}
+	s.Equal(3, moved, "one MOVED per cell entered, delivered to alice's own stream")
+
+	// Afford shows the same number the sheet now holds — never a second copy
+	// of the arithmetic.
+	decl := s.moveDecl(s.afford("alice"))
+	s.Equal(session.VerbMove, decl.Verb)
+	s.True(decl.Affordable, "15 feet is still enough for at least one more cell")
+	s.Require().NotNil(decl.Remaining, "Move's declaration always carries Remaining")
+	s.Equal(15, *decl.Remaining)
+	s.Equal(session.SlotNone, decl.Slot, "movement is capacity, never a per-turn slot")
+}
+
+// TestOverBudgetWalkIsRefusedWholeAndNothingIsSaved is the brief's second
+// case: a walk longer than what is left is refused BEFORE any step, naming
+// the currency, and the sheet it would have spent from is untouched.
+func (s *MoveTurnClockSuite) TestOverBudgetWalkIsRefusedWholeAndNothingIsSaved() {
+	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}},
+	})
+	s.Require().NoError(err, "spends 15, leaves 15")
+
+	_, err = s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 1, Y: 5}, {X: 1, Y: 6}, {X: 1, Y: 7}, {X: 1, Y: 8}},
+	})
+	s.Require().Error(err, "20 feet needed, 15 left")
+	s.ErrorIs(err, session.ErrCannotAfford)
+	s.Contains(err.Error(), "movement: 20 ft needed, 15 ft left",
+		"the exact currency text the brief asks for, not a paraphrase of it")
+
+	// Nothing moved: not the position, not the budget.
+	s.Equal(spatial.Position{X: 1, Y: 4}, s.where("alice"), "the refused walk left her exactly where she was")
+	s.Equal(15, s.storedMovement("alice"), "the refused spend never reached the sheet")
+}
+
+// TestEndTurnRefreshesMovementForTheNextRound is the brief's third case.
+// alice ends her turn, bob — a real player, not Pass-driven — takes his and
+// ends it too, and the round comes back around to alice with her movement
+// seeded fresh from speed rather than left at whatever her first turn spent.
+func (s *MoveTurnClockSuite) TestEndTurnRefreshesMovementForTheNextRound() {
+	ctx := context.Background()
+
+	_, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}},
+	})
+	s.Require().NoError(err, "spends 15 of alice's 30")
+
+	ended, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal("bob", ended.Next, "a real player does not auto-resolve — the order simply advances")
+
+	_, err = s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "bob"})
+	s.Require().NoError(err, "bob's own turn, spending nothing, still ends cleanly")
+
+	turn, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal("alice", turn.Active, "the order wrapped back to her")
+	s.Equal(2, turn.Round)
+
+	decl := s.moveDecl(s.afford("alice"))
+	s.True(decl.Affordable)
+	s.Require().NotNil(decl.Remaining)
+	s.Equal(30, *decl.Remaining, "a new turn re-seeds MovementRemaining from speed, not from where it was left")
+}
+
+// TestNotActiveMoveIsRefusedWithTheNamedSentinel is the brief's fourth case:
+// during bob's turn, alice — still in the very same fight — may not walk.
+// The refusal is the named sentinel, not the leaf play/clock one it is
+// translated from (rpg-toolkit#1169's whole S2 point).
+func (s *MoveTurnClockSuite) TestNotActiveMoveIsRefusedWithTheNamedSentinel() {
+	ctx := context.Background()
+
+	ended, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Require().Equal("bob", ended.Next, "control: it is now genuinely bob's turn")
+
+	_, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 2}},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrNotYourTurn)
+
+	// Nothing moved: a refusal this early must not have moved her at all.
+	s.Equal(spatial.Position{X: 1, Y: 1}, s.where("alice"))
+}
+
+// TestWorldClockMoveNeverTouchesTheEconomy is the brief's fifth case: free
+// roam is untouched. Reuses corridorWorld/MoveTestSuite's own fixture (alice
+// alone, never in a fight) rather than a fixture of this suite's own, so the
+// claim is checked against the SAME scene the walking-a-path tests already
+// exercise.
+func (s *MoveTurnClockSuite) TestWorldClockMoveNeverTouchesTheEconomy() {
+	sessions, encounters := newFakeSessions(), newFakeEncounters()
+	characters := testCharacters()
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: sessions, Encounters: encounters,
+		Characters: characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	ctx := context.Background()
+	_, err = mgr.StartSession(ctx, &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: corridorWorld(s.T()),
+	})
+	s.Require().NoError(err)
+
+	turn, err := mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Require().Equal(session.ClockWorld, turn.Clock, "control: free roam, not a fight")
+
+	out, err := mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 3, Y: 1}},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(out.Steps, 2)
+
+	stored, ok := characters.byID["alice"]
+	s.Require().True(ok)
+	s.Nil(stored.ActionEconomy,
+		"a free-roam walk must never ready, let alone spend from, a sheet — priceWalk skips it by clock kind alone")
+
+	direct, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal(session.ClockWorld, direct.Clock)
+	s.Empty(direct.Declarations, "empty, not zero — the economy does not apply on the world clock at all")
+}

--- a/rulebooks/dnd5e/session/move_turnclock_test.go
+++ b/rulebooks/dnd5e/session/move_turnclock_test.go
@@ -230,6 +230,40 @@ func (s *MoveTurnClockSuite) TestNotActiveMoveIsRefusedWithTheNamedSentinel() {
 	s.Equal(spatial.Position{X: 1, Y: 1}, s.where("alice"))
 }
 
+// TestNotActiveWinsOverAffordability is the precedence Copilot caught on
+// #1171: a member who is both out of turn AND asking for an unaffordable
+// path must be told the TRUE reason, not the currency one Pay would also
+// have refused with. Move asks the clock before it ever loads a sheet or
+// prices anything, so the sheet is never touched at all — asserted directly
+// against the fake repository's own call count, not inferred from the error
+// alone.
+func (s *MoveTurnClockSuite) TestNotActiveWinsOverAffordability() {
+	ctx := context.Background()
+
+	ended, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Require().Equal("bob", ended.Next, "control: it is now genuinely bob's turn")
+
+	before := s.characters.asked["alice"]
+
+	// A path far longer than alice's whole 30-foot speed — if the turn gate
+	// were checked AFTER pricing, or not at all, this would be refused with
+	// ErrCannotAfford naming a currency shortfall instead.
+	_, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{
+			{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}, {X: 1, Y: 5},
+			{X: 1, Y: 6}, {X: 1, Y: 7}, {X: 1, Y: 8},
+		},
+	})
+	s.Require().Error(err)
+	s.ErrorIs(err, session.ErrNotYourTurn)
+	s.NotErrorIs(err, session.ErrCannotAfford, "the wrong reason must not also be true of this refusal")
+
+	s.Equal(before, s.characters.asked["alice"],
+		"the clock is asked before the sheet is — a refusal this early must never have loaded it")
+}
+
 // TestWorldClockMoveNeverTouchesTheEconomy is the brief's fifth case: free
 // roam is untouched. Reuses corridorWorld/MoveTestSuite's own fixture (alice
 // alone, never in a fight) rather than a fixture of this suite's own, so the

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -372,6 +372,14 @@ func translate(err error) error {
 		return fmt.Errorf("%w", ErrInBubble)
 	case errors.Is(err, encounter.ErrNoBubble):
 		return fmt.Errorf("%w", ErrNotInFight)
+	case errors.Is(err, encounter.ErrNotActive):
+		// Two producers, one arm (rpg-toolkit#1169): EndTurn's own refusal for
+		// the wrong member, and now Step's — the active-member gate that lets
+		// a fight member walk at all. Before this arm existed, EndTurn's
+		// refusal reached a caller as the LEAF play/clock.ErrNotActive,
+		// unnamed at every boundary it crossed; naming it here closes that
+		// for both callers at once rather than leaving Move to rediscover it.
+		return fmt.Errorf("%w", ErrNotYourTurn)
 	default:
 		return err
 	}

--- a/rulebooks/dnd5e/session/turn.go
+++ b/rulebooks/dnd5e/session/turn.go
@@ -138,10 +138,11 @@ type EndTurnOutput struct {
 // anything if one clock were privileged.
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
-// ErrNoEncounter, ErrNoMember, ErrNotInFight, ErrClosed, or ErrSaveFailed with
-// a populated report. Ending a turn that is not yours is refused by the clock
-// itself, and that refusal passes through wrapped rather than being flattened
-// into a sentinel this package invented — see translate.
+// ErrNoEncounter, ErrNoMember, ErrNotInFight, ErrNotYourTurn, ErrClosed, or
+// ErrSaveFailed with a populated report. Ending a turn that is not yours is
+// refused by the clock itself and translated to ErrNotYourTurn — the same
+// sentinel Move's own turn gate produces (rpg-toolkit#1169) — rather than
+// left unnamed; see translate.
 func (m *Manager) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("endturn: %w", ErrNilInput)


### PR DESCRIPTION
## What

toolkit#1169: Move on the turn clock. This PR is the **session half** — movement pricing, the turn gate's translation, and `Afford`'s `VerbMove` declaration. The encounter half (the active-member gate `Step` now enforces) is #1170, merged as `encounter/v0.30.1`.

Kirk's direction: "it feels like we are rushing to the attack but I think better would be operating in the new clock. take turn, move maybe, end turn monster takes turn." With #1170 alone, the active member *could* call `Step`, but nothing priced it and nothing on the session boundary named "not your turn" — this PR closes both.

This is implementation of the already-decided economy-gate ruling (shape D, pure `CanPay`/`Pay` on the ledger, `docs/ideas/session-sdk/economy-gate.md`) applied to movement — not a new architectural fork, so there's no ADR here. The small calls (sentinel name, `Declaration.Remaining`'s shape) are made in the code's own doc comments and below.

## The change

**Pricing** (`Manager.priceWalk`, `move.go`) — mirrors `priceSwing`'s own shape: nil profile/sheet for free roam, otherwise loads the walker's character, calls the *same* `readyForTurn` `priceSwing` already uses (shared, not duplicated — whichever of Attack or Move asks first ignites the turn's economy, the other finds it already lit), and prices the *whole requested path* at 5 feet per cell, computed per call rather than compiled onto a `combat.SpendProfile` — the profile's own doc says per-unit movement cost is "deliberately not here," and this is the "one key constant, one discipline" the movement design addendum (issue #1035 comment 5326344695) named as movement's entire marginal ask on the economy foundation.

**Charging** (`Move`, `move.go`) — pays via `combat.Pay` *before* `runWalk` touches a single cell: insufficient movement is refused whole, naming the currency — `"movement: 20 ft needed, 15 ft left"` (`movementShortfall`). The "ft" suffix is this seam's own addition (`combat.SpendProfile`'s native refusal text is unitless — `"movement: 20 needed, 15 left"`); the yes/no affordability answer still comes from `combat.Pay` alone, never re-derived — only the formatting is custom, the same way `translateResolution` already customizes `ErrCannotAfford`'s wrapped text. A refused Move mutates only a locally-loaded, never-saved `character.Character` — nothing durable ever sees a spend that didn't complete.

**Saving** (`Manager.saveWalker`, `move.go`) — after a walk succeeds (even if it stopped early on an `Outcome`/`Formed`), the walker's sheet is persisted and the write is tracked on `scope.written` so `persist`'s own report opens with it — the same contract `saveDirty` keeps for a swing's damaged sheets, sized down to Move's one possible sheet.

**The turn gate is not re-derived in session.** `encounter.Step` already refuses a non-active bubble member with `ErrNotActive` (#1170); this PR only adds the translation session was missing — `encounter.ErrNotActive` → the new `session.ErrNotYourTurn`, in `translate()` (`read.go`). `EndTurn`'s own identical refusal (previously reaching a caller as the **unwrapped leaf `play/clock.ErrNotActive`** — a real S2 gap) is fixed by the same one-line arm, since `EndTurn` already routes through `translate()`.

**`Afford` grows `VerbMove`** (`afford.go`): `Declaration.Remaining *int` (feet, `omitempty`) — present for Move, absent for Attack, following the exact `Outcome`/`Seen` pointer-optional pattern `types.go` already uses (not the bool false-vs-absent law, which doesn't apply to a genuinely-optional field). Unlike Attack, Move has no single fixed price Afford can try paying — a path isn't chosen yet — so `affordMove` answers what it *can*: `Remaining` is the actual budget, and `Affordable` is whether *any* movement is still possible (≥5 ft, one cell). Reads the *same* sheet `priceSwing` already readied for the turn inside `Afford`'s own body — never a second ready, and safe to share since an attack's profile never touches `CapacityMovement`.

## Fixture fallout from #1170 (expected, not new scope)

Three existing tests used a blocked Move as their own control ("mid-fight, she is not free to walk") — now false for the *active* member, so each retargets to a `Turn`/`ClockTurn` check instead: `TestTheDeadEndIsClosed` (dissolve_test.go), `TestTheSurvivorWalksAgain` (death_test.go), and the `Example_theFightThatStartsItself` godoc example (now shows the walk succeeding, on her own turn, at a cost). The `session-workbench` demo needed alice's own character sheet registered for the first time — nothing before Move's own pricing ever needed to load a *member's* character for a verb that demo calls on her — and its "she cannot simply walk away" beat became "she can still act, on her own turn."

## Tests (`move_turnclock_test.go`, new)

Fixture: `aFight`'s own shape widened to a second player — alice, bob, and a skeleton, spawned into one bubble, initiative `[alice, bob, skel-1]`. Two real players is what makes "not alice's turn" observable at all — a lone player vs. a Pass-driven monster cycles straight back through `EndTurn` in one call.

- `TestActiveMemberSpendsMovementAndAffordSeesIt` — 3 cells (15 ft) succeeds, position updates, 3×`EventMoved` delivered, `Afford` shows `Remaining=15`, `Affordable=true`, `Slot=SlotNone`.
- `TestOverBudgetWalkIsRefusedWholeAndNothingIsSaved` — 4 more cells (20 ft, 15 left) refused with the exact brief text, position and stored budget both unchanged.
- `TestEndTurnRefreshesMovementForTheNextRound` — alice ends (advances to bob, a real player — no cascade), bob ends (cascades through the Pass-driven skeleton, back to alice, round 2), `Afford` shows `Remaining=30`.
- `TestNotActiveMoveIsRefusedWithTheNamedSentinel` — during bob's turn, alice's Move is refused with `session.ErrNotYourTurn`, nothing moved.
- `TestWorldClockMoveNeverTouchesTheEconomy` — a free-roam walk never readies (`ActionEconomy` stays nil) or spends from a sheet; `Afford` still reports empty `Declarations` on `ClockWorld`.

Plus `afford_test.go`'s three `Len(Declarations, 1)` assertions updated to `2` (attack + move) now that `Afford` always reports both on the turn clock.

## CI evidence (local, module `rulebooks/dnd5e/session`)

- `go test -race ./...` — clean (both the module and its `cmd/session-workbench`)
- `golangci-lint run ./...` — 0 issues
- `scripts/check-decisions.sh` — passes (45 ADRs — unchanged, no new ADR)
- `gorelease -base=v0.21.4` — compatible changes only (`Declaration.Remaining: added`, `ErrNotYourTurn: added`, `VerbMove: added`); suggested next tag `v0.22.0`
- `go.mod` bumped to `rulebooks/dnd5e/encounter v0.30.1` (the merged #1170 tag)

## rpg-api / web implications

- **New sentinel → status code.** `session.ErrNotYourTurn` needs the same mapping `ErrCannotAfford` already has (a rules refusal, not a caller defect) — `FAILED_PRECONDITION` or equivalent, not `INVALID_ARGUMENT`.
- **`Declaration.Remaining` → new optional proto field**, `int32`, matching `Shortfall`/`Slot`'s existing optional treatment on `Declaration` — present for a Move declaration, absent for Attack.
- **No new verb, no proto surface change to `Move` itself** — the existing RPC gains new refusal cases (`ErrNotYourTurn`, `ErrCannotAfford` naming movement) rather than a new shape.

Posting these as an issue comment on #1169 as well, per process.

---
Closes #1169. Part 2/2 (encounter half: #1170).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu
