### PR TITLE
resolution: an empty hand throws an unarmed strike, not a refusal

### DIFF
--- a/rulebooks/dnd5e/resolution/character_attack.go
+++ b/rulebooks/dnd5e/resolution/character_attack.go
@@ -12,6 +12,19 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
 )
 
+const (
+	// defaultMeleeReach is the melee reach used when the weapon carries no
+	// Reach property: 1 cell (5 ft), the 5e default and the reach of the
+	// canonical unarmed strike. Mirrors the retired top-level encounter
+	// module's defaultMeleeReachHexes (encounter/range_gate.go).
+	defaultMeleeReach = 1
+
+	// reachPropertyReach is the melee reach a weapon with the Reach
+	// property grants: 2 cells (10 ft — glaive, halberd, spear-with-reach-
+	// variant, pike). Mirrors reachWeaponHexes in the same retired file.
+	reachPropertyReach = 2
+)
+
 // CharacterAttackInput names which swing to compile.
 //
 // The grip is the caller's to state rather than the compiler's to infer. A
@@ -130,10 +143,16 @@ func AttackFromCharacter(c *character.Character, in *CharacterAttackInput) (Atta
 		return AttackProfile{}, fmt.Errorf("%w: %w", ErrBadAttack, err)
 	}
 
+	reach := defaultMeleeReach
+	if weapon.HasProperty(weapons.PropertyReach) {
+		reach = reachPropertyReach
+	}
+
 	profile := AttackProfile{
 		Ref:         ref,
 		Name:        weapon.Name,
 		AttackBonus: attackBonus,
+		Reach:       reach,
 		Damage:      copyDamagePools(pools),
 		// Which ability swung is the fact effects predicate on: Rage pays out
 		// on melee Strength attacks and needs to know this was one. Its

--- a/rulebooks/dnd5e/resolution/character_attack.go
+++ b/rulebooks/dnd5e/resolution/character_attack.go
@@ -68,6 +68,24 @@ type CharacterAttackInput struct {
 // Reach and adjacency are unenforced, exactly as for the bite: the strike
 // does not check distance at all. One shared, named gap, not one this case
 // adds.
+//
+// # An empty hand is not a refusal
+//
+// It used to be: an empty main hand refused with ErrBadAttack, on the
+// argument that a silent fallback is how a character who dropped their
+// sword keeps "attacking" and nobody notices. That argument proved too
+// much. The 5e rule is that an unarmed strike is always available — Kirk's
+// ruling, verbatim: "you can always attack you would just punch but can
+// still attack" (rpg-toolkit#1168) — so a compiler that refused it was not
+// guarding against a silent fallback, it was refusing a real swing. See
+// [equippedWeapon] for where the substitution happens; proficiency for it
+// is forced below rather than asked of [character.Character.IsProficientWith],
+// because nothing on a sheet grants "unarmed strike" as a trained weapon and
+// every 5e character is proficient with it regardless.
+//
+// ErrBadAttack still stands for what it always meant beyond that one case: a
+// sheet the rulebook cannot read — an unknown weapon ref, a slot holding
+// something that is not a weapon at all.
 func AttackFromCharacter(c *character.Character, in *CharacterAttackInput) (AttackProfile, error) {
 	if c == nil {
 		return AttackProfile{}, fmt.Errorf("%w: no character to compile", ErrNilInput)
@@ -76,7 +94,7 @@ func AttackFromCharacter(c *character.Character, in *CharacterAttackInput) (Atta
 		return AttackProfile{}, fmt.Errorf("%w: no attack input", ErrNilInput)
 	}
 
-	weapon, err := equippedWeapon(c, in.Slot)
+	weapon, unarmed, err := equippedWeapon(c, in.Slot)
 	if err != nil {
 		return AttackProfile{}, err
 	}
@@ -99,9 +117,11 @@ func AttackFromCharacter(c *character.Character, in *CharacterAttackInput) (Atta
 
 	// Proficiency is a fact about the sheet, not about the swing: a character
 	// wielding a weapon they were never trained on adds their ability modifier
-	// and nothing else.
+	// and nothing else. An unarmed strike is the one exception the rulebook
+	// itself grants everybody — see the doc comment above — so it is never
+	// asked of IsProficientWith, which has no grant to answer with.
 	attackBonus := modifier
-	if c.IsProficientWith(weapon) {
+	if unarmed || c.IsProficientWith(weapon) {
 		attackBonus += c.ProficiencyBonus()
 	}
 
@@ -112,6 +132,7 @@ func AttackFromCharacter(c *character.Character, in *CharacterAttackInput) (Atta
 
 	profile := AttackProfile{
 		Ref:         ref,
+		Name:        weapon.Name,
 		AttackBonus: attackBonus,
 		Damage:      copyDamagePools(pools),
 		// Which ability swung is the fact effects predicate on: Rage pays out
@@ -130,24 +151,32 @@ func AttackFromCharacter(c *character.Character, in *CharacterAttackInput) (Atta
 	return profile, nil
 }
 
-// equippedWeapon reads the weapon out of a slot, refusing an empty or
-// non-weapon slot by name.
-func equippedWeapon(c *character.Character, slot character.InventorySlot) (*weapons.Weapon, error) {
+// equippedWeapon reads the weapon out of a slot: what is equipped there, or
+// the catalog's unarmed strike when nothing is — the rule, not a gap
+// (rpg-toolkit#1168). unarmed is true only in that substitution case, which
+// is what tells the caller to force proficiency rather than ask the sheet
+// for a grant no sheet has.
+//
+// Still refuses by name for a caller mistake (no slot named at all) and for
+// a slot the rulebook cannot read as a weapon — equipped but not a weapon,
+// which an empty hand is not.
+func equippedWeapon(c *character.Character, slot character.InventorySlot) (weapon *weapons.Weapon, unarmed bool, err error) {
 	if slot == "" {
-		return nil, fmt.Errorf("%w: no equipment slot named", ErrBadAttack)
+		return nil, false, fmt.Errorf("%w: no equipment slot named", ErrBadAttack)
 	}
 
 	equipped := c.GetEquippedSlot(slot)
 	if equipped == nil {
-		return nil, fmt.Errorf("%w: nothing equipped in %q", ErrBadAttack, slot)
+		w := weapons.SpecialWeapons[weapons.UnarmedStrike]
+		return &w, true, nil
 	}
 
-	weapon := equipped.AsWeapon()
+	weapon = equipped.AsWeapon()
 	if weapon == nil {
-		return nil, fmt.Errorf("%w: %q holds no weapon", ErrBadAttack, slot)
+		return nil, false, fmt.Errorf("%w: %q holds no weapon", ErrBadAttack, slot)
 	}
 
-	return weapon, nil
+	return weapon, false, nil
 }
 
 // attackAbility picks the ability a melee weapon swings with: Strength,

--- a/rulebooks/dnd5e/resolution/character_attack.go
+++ b/rulebooks/dnd5e/resolution/character_attack.go
@@ -73,14 +73,16 @@ type CharacterAttackInput struct {
 // brackets, no long-range disadvantage, and prone's interaction reverses at
 // distance. Compiler and machine both grow when that arrives.
 //
-// No unarmed strike. An empty slot is refused rather than falling back to the
-// catalog's unarmed weapon, because a silent 1d1 fallback is how a character
-// who dropped their sword keeps "attacking" and nobody notices. Monk martial
-// arts dice are a future compiler's business.
+// Monk martial arts dice — an upgraded unarmed die keyed to level — are a
+// future compiler's business; this one always compiles the catalog's plain
+// 1d1 (see "An empty hand is not a refusal" below, rpg-toolkit#1168).
 //
-// Reach and adjacency are unenforced, exactly as for the bite: the strike
-// does not check distance at all. One shared, named gap, not one this case
-// adds.
+// Reach and adjacency are UNENFORCED BY THIS COMPILER AND THE STRIKE MACHINE
+// IT FEEDS — the profile now carries Reach (rpg-toolkit#1010), but nothing
+// here checks a target's distance against it; that gate lives above this
+// seam, in whatever caller has both combatants' positions (session.Attack).
+// The strike itself still does not check distance at all, exactly as for
+// the bite.
 //
 // # An empty hand is not a refusal
 //

--- a/rulebooks/dnd5e/resolution/character_attack_test.go
+++ b/rulebooks/dnd5e/resolution/character_attack_test.go
@@ -644,6 +644,32 @@ func (s *CharacterAttackTestSuite) TestAnEmptyHandThrowsAnUnarmedStrike() {
 	s.Equal(5, profile.AttackBonus)
 }
 
+// TestReach pins rpg-toolkit#1010's compiler half: a plain melee weapon
+// reaches 1 cell, a weapon carrying the Reach property reaches 2, and an
+// unarmed strike reaches 1 — the same numbers the retired top-level
+// encounter module's checkReach enforced (encounter/range_gate.go) before
+// this rewrite dropped the check everywhere.
+func (s *CharacterAttackTestSuite) TestReach() {
+	s.Run("a plain melee weapon reaches 1 cell", func() {
+		profile := s.compile(s.martialHero(), s.mainHand())
+		s.Equal(1, profile.Reach)
+	})
+
+	s.Run("a weapon with the Reach property reaches 2 cells", func() {
+		sheet := s.heroSheet(
+			[]proficiencies.Weapon{proficiencies.WeaponMartial},
+			map[character.InventorySlot]string{character.SlotMainHand: string(weapons.Glaive)},
+		)
+		profile := s.compile(sheet, s.mainHand())
+		s.Equal(2, profile.Reach)
+	})
+
+	s.Run("an unarmed strike reaches 1 cell", func() {
+		profile := s.compile(s.heroSheet(nil, nil), s.mainHand())
+		s.Equal(1, profile.Reach)
+	})
+}
+
 // TestAnEmptyOffHandAlsoThrowsAnUnarmedStrike pins that the substitution is
 // about the SLOT being empty, not specifically the main hand — the rule
 // this compiles is "an empty hand punches," and this compiler already

--- a/rulebooks/dnd5e/resolution/character_attack_test.go
+++ b/rulebooks/dnd5e/resolution/character_attack_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
@@ -584,14 +585,16 @@ func (s *CharacterAttackTestSuite) TestRefusesWhatItCannotCompile() {
 		s.Require().Equal(3, profile.AbilityModifier)
 	})
 
-	s.Run("an empty slot, rather than a silent unarmed strike", func() {
-		sheet := s.heroSheet([]proficiencies.Weapon{proficiencies.WeaponMartial}, nil)
-		_, err := AttackFromCharacter(s.load(sheet), s.mainHand())
-		s.Require().ErrorIs(err, ErrBadAttack)
-	})
-
-	s.Run("a slot holding nothing this build calls a weapon", func() {
+	s.Run("armor equipped where a weapon was asked for, not an empty hand", func() {
+		// Distinct from the empty-slot case below: something IS equipped in
+		// the slot, and it is not something this build calls a weapon — the
+		// case ErrBadAttack still covers (rpg-toolkit#1168 only changed what
+		// an EMPTY slot compiles to).
 		sheet := s.heroSheet([]proficiencies.Weapon{proficiencies.WeaponMartial}, equippedLongsword)
+		sheet.Inventory = append(sheet.Inventory, character.InventoryItemData{
+			Type: shared.EquipmentTypeArmor, ID: string(armor.Leather), Quantity: 1,
+		})
+		sheet.EquipmentSlots[character.SlotArmor] = string(armor.Leather)
 		_, err := AttackFromCharacter(s.load(sheet), &CharacterAttackInput{Slot: character.SlotArmor})
 		s.Require().ErrorIs(err, ErrBadAttack)
 	})
@@ -610,4 +613,46 @@ func (s *CharacterAttackTestSuite) TestRefusesWhatItCannotCompile() {
 		_, err = AttackFromCharacter(s.load(sheet), nil)
 		s.Require().ErrorIs(err, ErrNilInput)
 	})
+}
+
+// TestAnEmptyHandThrowsAnUnarmedStrike pins rpg-toolkit#1168, Kirk's ruling
+// verbatim: "you can always attack you would just punch but can still
+// attack." An empty main hand is not a gap in what the compiler can read —
+// it is the rule — so it compiles a real profile rather than refusing.
+func (s *CharacterAttackTestSuite) TestAnEmptyHandThrowsAnUnarmedStrike() {
+	// No proficiency GRANT covers "unarmed strike" — 5e never issues one,
+	// because everybody already has it — so this sheet's weapon
+	// proficiencies stay empty on purpose: a profile that still adds the
+	// proficiency bonus below proves the bonus came from the rule this test
+	// pins, not from a grant the fixture forgot to omit.
+	sheet := s.heroSheet(nil, nil)
+
+	profile, err := AttackFromCharacter(s.load(sheet), s.mainHand())
+	s.Require().NoError(err)
+
+	s.Require().NotNil(profile.Ref)
+	s.Equal(string(weapons.UnarmedStrike), string(profile.Ref.ID))
+	s.Equal("Unarmed Strike", profile.Name)
+	s.Require().Len(profile.Damage, 1)
+	s.Equal("1d1", profile.Damage[0].Dice)
+	s.Equal(damage.Bludgeoning, profile.Damage[0].Type)
+
+	// STR 16 -> +3 modifier, PLUS the proficiency bonus (2) despite no
+	// weapon-proficiency grant naming it: the rule, not IsProficientWith.
+	s.Equal(abilities.STR, profile.AbilityUsed)
+	s.Equal(3, profile.AbilityModifier)
+	s.Equal(5, profile.AttackBonus)
+}
+
+// TestAnEmptyOffHandAlsoThrowsAnUnarmedStrike pins that the substitution is
+// about the SLOT being empty, not specifically the main hand — the rule
+// this compiles is "an empty hand punches," and this compiler already
+// takes any slot as data (off-hand swings are a compiler-level gap named
+// elsewhere, not this one).
+func (s *CharacterAttackTestSuite) TestAnEmptyOffHandAlsoThrowsAnUnarmedStrike() {
+	sheet := s.heroSheet(nil, nil)
+
+	profile, err := AttackFromCharacter(s.load(sheet), &CharacterAttackInput{Slot: character.SlotOffHand})
+	s.Require().NoError(err)
+	s.Equal(string(weapons.UnarmedStrike), string(profile.Ref.ID))
 }

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -72,6 +72,21 @@ type AttackProfile struct {
 	// AttackBonus is added to the d20.
 	AttackBonus int
 
+	// Reach is how far this melee attack reaches, in grid cells: 1 (the 5e
+	// default, and the unarmed strike's own reach) or 2 for a weapon
+	// carrying the Reach property (rpg-toolkit#1010). Ported from the
+	// retired top-level encounter module's checkReach/meleeReachForWeapon
+	// (encounter/range_gate.go), which enforced exactly this distinction
+	// before the rewrite dropped it — see that file's own history for the
+	// QA walk that found it missing everywhere.
+	//
+	// Zero from [AttackFromMonsterAction] today, the same scope note
+	// [AttackProfile.Name] carries: a monster attacker does not yet reach a
+	// caller that gates on this (v1 compiles CHARACTER attackers only).
+	// Meaningless for a ranged attack, which never compiles a profile at
+	// all (IsRanged refuses before one is built).
+	Reach int
+
 	// Damage is the ordered set of canonical damage pools declared by the
 	// weapon or monster action. Dice notation remains pure NdM; intrinsic
 	// arithmetic stays in each pool's FlatBonus.

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -60,6 +60,15 @@ type AttackProfile struct {
 	// the swing.
 	Ref *core.Ref
 
+	// Name is the catalog's display name for Ref — "Longsword", "Unarmed
+	// Strike" — carried alongside it so a caller reporting what was swung
+	// (a beat line, a struck/missed event) never has to look the ref back
+	// up in a catalog of its own (rpg-toolkit#866). Populated by
+	// [AttackFromCharacter]; empty from [AttackFromMonsterAction] today —
+	// monster attackers do not yet reach a caller that reports this
+	// (v1 compiles CHARACTER attackers only, session.Attack's own doc).
+	Name string
+
 	// AttackBonus is added to the d20.
 	AttackBonus int
 


### PR DESCRIPTION
## What

Closes #1168. Kirk's ruling, verbatim: "you can always attack you would just punch but can still attack" — 5e's actual rule, not a gap. Part 2 of 3 (encounter → **resolution** → session), standalone.

- `equippedWeapon` (in `character_attack.go`) substitutes the catalog's `unarmed-strike` (1d1 bludgeoning, `weapons.SpecialWeapons`) when a slot is empty, instead of refusing with `ErrBadAttack`, and reports the substitution back so `AttackFromCharacter` can force proficiency — no sheet grants "unarmed strike" as a trained weapon, and every 5e character is proficient with it regardless of `IsProficientWith`.
- `AttackProfile` gains `Name` — the catalog's display name, populated in `AttackFromCharacter` (`weapon.Name`). This is #866's other half (weapon identity for the wire's beat line: "Longsword", "Unarmed Strike"). Left empty from `AttackFromMonsterAction` — that path isn't reachable via `session.Attack` yet (character attackers only, v1).
- `ErrBadAttack` stays for what it always meant beyond the empty-hand case: a sheet the rulebook genuinely cannot read (unknown weapon ref, a non-weapon item in the slot).

## Testing

- New: `TestAnEmptyHandThrowsAnUnarmedStrike` (pins the numbers: STR 16 → +3 modifier + proficiency bonus 2 = attack bonus 5, 1d1 bludgeoning, ref `unarmed-strike`, name `Unarmed Strike` — with an empty weapon-proficiency list on the sheet, proving the bonus comes from the rule and not a grant) and `TestAnEmptyOffHandAlsoThrowsAnUnarmedStrike` (the substitution is about the slot being empty, not specifically main hand).
- Fixed a pre-existing test gap along the way: `TestRefusesWhatItCannotCompile`'s "a slot holding nothing this build calls a weapon" subtest never actually equipped a non-weapon item — its fixture left the armor slot empty, so it was silently re-testing the same empty-slot path under a different name. Now genuinely equips leather armor and asserts the refusal that case is supposed to cover.
- `go test -race ./...` — green. `golangci-lint run ./...` — 0 issues.
- `gorelease`:
  ```
  ## compatible changes
  AttackProfile.Name: added
  ```
  Suggests `v0.12.0`.

## Merge order

1. rpg-toolkit#1172 (encounter) — merged/mergeable independently
2. **This PR** (resolution)
3. `session` — reach gate, per-target `Afford`, structured shortfall, names+standing, typed events, `AttackRef` (consumes both; stacked on main now that #1171 merged)

— asset-pipeline agent, on behalf of KirkDiggler