### PR TITLE
session: the combat turn — reach, per-target Afford, structured shortfall, names+standing, typed events

### DIFF
--- a/docs/ideas/session-sdk/economy-gate.md
+++ b/docs/ideas/session-sdk/economy-gate.md
@@ -38,6 +38,24 @@ naming the currency in feet, before any step — is
 [#1171](https://github.com/KirkDiggler/rpg-toolkit/pull/1171). Fork (d) is
 fully retired once #1171 merges.
 
+**Update, 2026-08-22 — Afford prices per target, still one gate call
+(rpg-project#249, the combat-turn contract).** Reach (rpg-toolkit#1010) adds
+candidates to what `Afford` reports for `VerbAttack` — one `Declaration` per
+sighted member within the compiled weapon's reach, rather than the single
+declaration this ruling's foundation shipped with. That is a fan-out over
+the ANSWER, not a second gate: `combat.Pay` is still called exactly ONCE per
+`Afford` call, against the sheet this call loaded, and the resulting
+affordable/shortfall is shared across every target declaration — reach
+decides the LIST, the economy decides ONE affordable-or-not for all of it.
+Paying per candidate was considered and rejected outright: the second call
+would see the ledger as if the first had already spent it, since `Pay`
+mutates. The `Shortfall` this ruling's `payAtTheDoor` produces is also now
+structured (`Reason`/`Currency`/`Needed`/`Left`, not only `Text`), read off
+the SAME `SlotsLeft`/`CapacityLeft` state the gate's own check consults —
+never by parsing the gate's error string. Neither change touches E1–E3's
+foundation; both are the session-side seam this doc always said would keep
+growing on top of it.
+
 [census]: https://github.com/KirkDiggler/rpg-toolkit/issues/1035#issuecomment-5326154182
 [supp]: https://github.com/KirkDiggler/rpg-toolkit/issues/1035#issuecomment-5326242250
 [move]: https://github.com/KirkDiggler/rpg-toolkit/issues/1035#issuecomment-5326344695

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -274,12 +274,25 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 		return &AffordOutput{Clock: ClockWorld, Declarations: []Declaration{}}, nil
 	}
 
-	// DOWNED, checked before anything else this member's clock state could
-	// answer: a downed member is spliced out of the turn order and can
-	// never be active, so NotYourTurn would eventually say so too — but
-	// Downed is the SPECIFIC fact a client renders differently ("you are
-	// down" versus "wait your turn"), and it is cheaper to ask than to let
-	// a caller infer it from never seeing their own name as active.
+	// NOT YOUR TURN, checked FIRST and cheaply — clock.Active is already in
+	// hand, no sheet touched — the same precedence Move's own gate keeps
+	// (Copilot's finding on #1171: the clock is asked before anything is
+	// loaded, so a refusal this early never reads a sheet at all). The
+	// same clock-active comparison Attack's own gate makes
+	// (rpg-toolkit#1010/#249) — announced here BEFORE a caller ever tries
+	// the verb, which is Afford's whole point.
+	if string(clock.Active) != in.Member {
+		return &AffordOutput{Clock: ClockTurn, Declarations: blockedDeclarations(Shortfall{
+			Reason: ShortfallNotYourTurn, Text: "not your turn",
+		})}, nil
+	}
+
+	// DOWNED, asked only once we know this member is even the one the
+	// clock is waiting on: a downed member is spliced out of the turn
+	// order and can never be active, so NotYourTurn already covers a
+	// downed BYSTANDER — this is the specific fact a client renders
+	// differently ("you are down" versus "wait your turn") for the member
+	// who somehow is still active despite being down.
 	standing := m.standingFor(ctx, data)
 	down, err := standing.Standing([]encounter.MemberID{encounter.MemberID(in.Member)})
 	if err != nil {
@@ -288,15 +301,6 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 	if len(down) > 0 {
 		return &AffordOutput{Clock: ClockTurn, Declarations: blockedDeclarations(Shortfall{
 			Reason: ShortfallDowned, Text: "member is downed",
-		})}, nil
-	}
-
-	// NOT YOUR TURN, the same clock-active comparison Attack's own gate
-	// makes (rpg-toolkit#1010/#249) — announced here BEFORE a caller ever
-	// tries the verb, which is Afford's whole point.
-	if string(clock.Active) != in.Member {
-		return &AffordOutput{Clock: ClockTurn, Declarations: blockedDeclarations(Shortfall{
-			Reason: ShortfallNotYourTurn, Text: "not your turn",
 		})}, nil
 	}
 

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -5,12 +5,15 @@ package session
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
 	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 // AffordInput asks what one member can still declare this turn.
@@ -251,7 +254,11 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 		return nil, fmt.Errorf("afford: %w", ErrNoMemberID)
 	}
 
-	enc, err := m.open(ctx, in.Session)
+	data, err := m.loadSessionData(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("afford: %w", err)
+	}
+	enc, err := m.loadWorld(ctx, data)
 	if err != nil {
 		return nil, fmt.Errorf("afford: %w", err)
 	}
@@ -267,17 +274,49 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 		return &AffordOutput{Clock: ClockWorld, Declarations: []Declaration{}}, nil
 	}
 
-	data, err := m.fetchCharacterData(ctx, "member", in.Member)
+	// DOWNED, checked before anything else this member's clock state could
+	// answer: a downed member is spliced out of the turn order and can
+	// never be active, so NotYourTurn would eventually say so too — but
+	// Downed is the SPECIFIC fact a client renders differently ("you are
+	// down" versus "wait your turn"), and it is cheaper to ask than to let
+	// a caller infer it from never seeing their own name as active.
+	standing := m.standingFor(ctx, data)
+	down, err := standing.Standing([]encounter.MemberID{encounter.MemberID(in.Member)})
 	if err != nil {
 		return nil, fmt.Errorf("afford: %w", err)
 	}
-	// Bus-free, the same loader priceSwing's own caller (compileAttack) reads
-	// the economy through: the action economy is plain sheet data in v1, not
-	// condition-driven, so nothing here needs the conditions a bus-attached
-	// reconstitution would bring. See compileAttack's own comment.
-	sheet, err := character.Load(ctx, data)
+	if len(down) > 0 {
+		return &AffordOutput{Clock: ClockTurn, Declarations: blockedDeclarations(Shortfall{
+			Reason: ShortfallDowned, Text: "member is downed",
+		})}, nil
+	}
+
+	// NOT YOUR TURN, the same clock-active comparison Attack's own gate
+	// makes (rpg-toolkit#1010/#249) — announced here BEFORE a caller ever
+	// tries the verb, which is Afford's whole point.
+	if string(clock.Active) != in.Member {
+		return &AffordOutput{Clock: ClockTurn, Declarations: blockedDeclarations(Shortfall{
+			Reason: ShortfallNotYourTurn, Text: "not your turn",
+		})}, nil
+	}
+
+	// UNREADABLE: the same compile Attack's own door runs, so the two
+	// cannot disagree about whether a swing exists to price at all
+	// (rpg-toolkit#1168's other half — ADR-0042 scoped this out, amended
+	// here). ErrBadCharacter (no sheet, or bytes that will not
+	// reconstitute) stays a hard failure, exactly as before: there is no
+	// sheet to answer ANYTHING about, attack or movement. ErrBadAttack —
+	// a sheet that loads fine but names a weapon this build cannot
+	// compile — becomes a declaration instead of a failed read, so the
+	// rest of a UI's turn panel still renders.
+	sheet, profile, err := m.compileAttack(ctx, in.Member)
 	if err != nil {
-		return nil, fmt.Errorf("afford: member %q: %w: %v", in.Member, ErrBadCharacter, err)
+		if errors.Is(err, ErrBadAttack) {
+			return &AffordOutput{Clock: ClockTurn, Declarations: blockedDeclarations(Shortfall{
+				Reason: ShortfallUnreadable, Text: err.Error(),
+			})}, nil
+		}
+		return nil, fmt.Errorf("afford: %w", err)
 	}
 
 	price, err := m.priceSwing(ctx, enc, in.Member, sheet)
@@ -287,24 +326,114 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 
 	// price.cost is never nil here: priceSwing returns a nil cost only when
 	// the member is on the world clock, already ruled out above.
-	attack := Declaration{Verb: VerbAttack, Slot: slotOf(price.cost.Profile)}
+	slot := slotOf(price.cost.Profile)
 
-	// Charged against the sheet THIS CALL loaded, which is handed to nobody
-	// else and never saved (see the doc comment above). combat.Pay is the
-	// SAME gate the door pays a real swing through, so a payment that
-	// succeeds or fails here answers exactly as Attack's would.
+	// Charged ONCE against the sheet THIS CALL loaded, which is handed to
+	// nobody else and never saved (see the doc comment above). combat.Pay is
+	// the SAME gate Attack's door pays through, so a payment that succeeds
+	// or fails here answers exactly as Attack's would — and it answers the
+	// SAME way for every target below: affordability is an economy
+	// question, not a geometry one, so it is asked once and shared rather
+	// than re-paid per candidate (which would also double-spend the sheet
+	// this call loaded).
+	affordable := true
+	var why *Shortfall
 	if payErr := combat.Pay(sheet, price.cost.Profile); payErr != nil {
-		attack.Shortfall = payErr.Error()
-	} else {
-		attack.Affordable = true
+		affordable = false
+		sf := shortfallForPay(sheet, price.cost.Profile, slot)
+		why = &sf
 	}
+
+	roster, err := enc.Members()
+	if err != nil {
+		return nil, fmt.Errorf("afford: %w", translate(err))
+	}
+	positions := rosterPositions(roster)
+
+	holdings, err := enc.View(&encounter.ViewInput{Member: encounter.MemberID(in.Member)})
+	if err != nil {
+		return nil, fmt.Errorf("afford: %w", translate(err))
+	}
+
+	attackDecls := attackDeclarationsFor(enc, positions, holdings, in.Member, slot, profile.Reach, affordable, why)
 
 	// affordMove reads the SAME sheet, already readied for this turn by
 	// priceSwing's own call above — never a second ready, which would
-	// re-seed a bank the attack declaration just read. Safe to share: an
+	// re-seed a bank the attack declarations just read. Safe to share: an
 	// attack's profile never names CapacityMovement, so paying it above
 	// cannot have moved what affordMove is about to read.
-	return &AffordOutput{Clock: ClockTurn, Declarations: []Declaration{attack, affordMove(sheet)}}, nil
+	return &AffordOutput{
+		Clock:        ClockTurn,
+		Declarations: append(attackDecls, affordMove(sheet)),
+	}, nil
+}
+
+// blockedDeclarations answers both of a turn's verbs the same way, for a
+// reason that blocks the whole turn rather than one price: downed, not your
+// turn, or a sheet this build cannot compile. Neither verb's own numbers
+// mean anything against a member who cannot act at all, so both report the
+// SAME Shortfall rather than one going on to compute a real (and
+// misleading) answer for the other.
+func blockedDeclarations(why Shortfall) []Declaration {
+	return []Declaration{
+		{Verb: VerbAttack, Slot: SlotNone, Affordable: false, Shortfall: why.Text, Why: &why},
+		{Verb: VerbMove, Slot: SlotNone, Affordable: false, Shortfall: why.Text, Why: &why},
+	}
+}
+
+// attackDeclarationsFor builds one ATTACK declaration per candidate the
+// member currently, live, perceives (holdings whose CurrentVia is
+// non-empty — a memory of somebody no longer in sight is not somebody this
+// member could swing at right now) and who stands within reach. Every
+// declaration shares the SAME affordable/why the economy already decided;
+// what varies per declaration is only the target and whether reach passed.
+//
+// NO CANDIDATE IN REACH IS STILL AN ANSWER (rpg-toolkit#1010, rpg-project#249
+// §6): a single declaration with no Target, Affordable false and
+// Why.Reason ShortfallNoTargetInReach — never an empty list, which a client
+// could mistake for "nothing to ask about yet" rather than "nothing is
+// close enough."
+func attackDeclarationsFor(
+	enc *encounter.Encounter, positions map[string]spatial.Position, holdings []intel.Holding,
+	member string, slot Slot, reach int, affordable bool, why *Shortfall,
+) []Declaration {
+	from := positions[member]
+
+	var out []Declaration
+	for _, h := range holdings {
+		subject := string(h.Subject)
+		if subject == member || len(h.CurrentVia) == 0 {
+			continue
+		}
+		to, ok := positions[subject]
+		if !ok || !inReach(enc, from, to, reach) {
+			continue
+		}
+		target := subject
+		out = append(out, Declaration{
+			Verb: VerbAttack, Slot: slot, Target: &target, Affordable: affordable, Why: why,
+			Shortfall: shortfallText(why),
+		})
+	}
+
+	if len(out) == 0 {
+		noTarget := Shortfall{Reason: ShortfallNoTargetInReach, Text: "no target in reach"}
+		return []Declaration{{
+			Verb: VerbAttack, Slot: slot, Affordable: false,
+			Shortfall: noTarget.Text, Why: &noTarget,
+		}}
+	}
+	return out
+}
+
+// shortfallText reads Why.Text, or the empty string for a nil Why — the
+// same value Declaration.Shortfall has always carried, kept in step with
+// Why by construction rather than set separately at each call site.
+func shortfallText(why *Shortfall) string {
+	if why == nil {
+		return ""
+	}
+	return why.Text
 }
 
 // affordMove reports what this member could still spend on movement this
@@ -326,8 +455,84 @@ func affordMove(sheet *character.Character) Declaration {
 		decl.Affordable = true
 		return decl
 	}
-	decl.Shortfall = fmt.Sprintf("movement: %d ft left", left)
+	why := Shortfall{
+		Reason: ShortfallNoBudget, Currency: CurrencyMovement,
+		// Needed names the smallest step this grid has (five feet, one
+		// cell) rather than a specific request's cost: unlike Attack's
+		// fixed action price, a walk's cost is a fact about a PATH this
+		// read is never given (Declaration.Remaining's own doc), so
+		// "needed" can only say how much the least possible move would
+		// take.
+		Needed: 5, Left: left,
+		Text: fmt.Sprintf("movement: %d ft left", left),
+	}
+	decl.Shortfall = why.Text
+	decl.Why = &why
 	return decl
+}
+
+// currencyOfSlot maps a lit shape onto the ledger word a NoBudget shortfall
+// names — the same three values Slot and Currency coincide on (types.go's
+// own note on why they are still two enums).
+func currencyOfSlot(slot Slot) Currency {
+	switch slot {
+	case SlotAction:
+		return CurrencyAction
+	case SlotBonus:
+		return CurrencyBonus
+	case SlotReaction:
+		return CurrencyReaction
+	default:
+		return ""
+	}
+}
+
+// shortfallForPay determines the structured reason a compiled price could
+// not be paid, read off the SAME ledger state combat.Pay's own check
+// consults — SlotsLeft/CapacityLeft, never by parsing the text Pay's error
+// carries (rpg-toolkit#1010).
+//
+// SLOT FIRST, AND USUALLY ONLY. slot is the declaration's own answer to
+// "which shape does this price light" (slotOf) — the same SpendProfile,
+// asked the same way — and it covers the whole of v1's reachable economy:
+// costOfSwing's own folding (asOnePayment) means a capacity shortfall
+// always resurfaces as the action slot being spent already, so a profile
+// that draws SlotNone (a purely banked swing) never actually runs out in a
+// way this build can produce. That branch is still handled, defensively,
+// rather than assumed away.
+func shortfallForPay(sheet *character.Character, profile *combat.SpendProfile, slot Slot) Shortfall {
+	if profile == nil {
+		return Shortfall{Reason: ShortfallNoBudget, Text: "action cannot be paid for"}
+	}
+
+	switch slot {
+	case SlotAction:
+		return slotShortfall(sheet, coreCombat.ActionStandard, currencyOfSlot(slot), profile.Slots[coreCombat.ActionStandard])
+	case SlotBonus:
+		return slotShortfall(sheet, coreCombat.ActionBonus, currencyOfSlot(slot), profile.Slots[coreCombat.ActionBonus])
+	case SlotReaction:
+		return slotShortfall(sheet, coreCombat.ActionReaction, currencyOfSlot(slot), profile.Slots[coreCombat.ActionReaction])
+	}
+
+	for key, amount := range profile.Capacity {
+		if left := sheet.CapacityLeft(key); left < amount {
+			return Shortfall{
+				Reason: ShortfallNoBudget, Needed: amount, Left: left,
+				Text: fmt.Sprintf("%s: %d needed, %d left", key, amount, left),
+			}
+		}
+	}
+	return Shortfall{Reason: ShortfallNoBudget, Text: "action cannot be paid for"}
+}
+
+// slotShortfall reads one per-turn slot's own state into a Shortfall —
+// currencyOfSlot's figures, filled in.
+func slotShortfall(sheet *character.Character, slotKey coreCombat.ActionType, currency Currency, needed int) Shortfall {
+	left := sheet.SlotsLeft(slotKey)
+	return Shortfall{
+		Reason: ShortfallNoBudget, Currency: currency, Needed: needed, Left: left,
+		Text: fmt.Sprintf("%s: %d needed, %d left", slotKey, needed, left),
+	}
 }
 
 // slotOf reads which of a turn's three slots a compiled price draws from, if

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -108,7 +108,41 @@ type Declaration struct {
 	// beside affordable:true is itself the answer ("nothing ran out"), not
 	// the absence of one, and a non-Go client reading a missing key cannot
 	// tell that from "the server didn't say".
+	//
+	// KEPT FOR OLDER READERS; SUPERSEDED BY Why. This is the same text as
+	// Why.Text — a producer that sets one sets both (rpg-toolkit#1010). A
+	// new reader takes Why, the structured form it can branch on, and never
+	// this.
 	Shortfall string `json:"shortfall"`
+
+	// Target is the candidate this declaration prices, for VerbAttack. ONE
+	// DECLARATION PER TARGET IN REACH (rpg-project#249 §6, Kirk): Afford
+	// gates each candidate through the same reach check Attack refuses
+	// with (melee one cell, the reach property two; ranged stays refused
+	// as today, rpg-toolkit#1010) and emits one declaration for each
+	// target that passes. That list IS the client's "enemies in reach"
+	// highlight — reach is never computed client-side, it is read off
+	// these. When NO candidate is in reach the seam still answers, once: a
+	// single ATTACK declaration with Affordable false, Why.Reason
+	// ShortfallNoTargetInReach, and this field unset.
+	//
+	// A POINTER, not an omitted empty string: a MOVE declaration has no
+	// target at all, and the no-target-in-reach ATTACK declaration has
+	// none either — neither is a target whose id happens to be empty.
+	//
+	// Further strikes are FURTHER DECLARATIONS of this same shape, not new
+	// fields: a monk's Martial Arts bonus strike is
+	// {VerbAttack, SlotBonus, target}; an off-hand swing and a flurry
+	// likewise. Nil for VerbMove.
+	Target *string `json:"target,omitempty"`
+
+	// Why is the structured reason this is unaffordable, present exactly
+	// when Affordable is false — the same presence law Remaining keeps for
+	// "this verb carries no such number": absence beside Affordable true is
+	// itself the answer ("nothing ran out"). Carries the same text
+	// Shortfall does, plus the reason and the figures a UI acts on.
+	// Lands with rpg-toolkit#1010.
+	Why *Shortfall `json:"why,omitempty"`
 
 	// Remaining is how much of this verb's own currency is left, in the
 	// currency's natural unit — feet, for Move (rpg-toolkit#1169).

--- a/rulebooks/dnd5e/session/afford_test.go
+++ b/rulebooks/dnd5e/session/afford_test.go
@@ -10,7 +10,10 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 // afford_test.go pins rpg-toolkit#1138: the affordability read
@@ -236,4 +239,149 @@ func (s *AffordSuite) TestAffordSavesNothing() {
 	s.afford()
 	s.Equal(afterSwing, *s.storedEconomy(),
 		"asking again must not touch the sheet the real swing already wrote")
+}
+
+// TestOneDeclarationPerTargetInReach pins rpg-toolkit#1010/rpg-project#249
+// §6: a second monster within reach earns its OWN attack declaration rather
+// than being folded into — or silently excluded from — the first's. Each
+// carries the SAME affordable/slot the economy already decided; only Target
+// varies.
+func (s *AffordSuite) TestOneDeclarationPerTargetInReach() {
+	s.fightScene(1, 15, 5, 1, 1)
+
+	_, err := s.mgr.Spawn(context.Background(), &session.SpawnInput{
+		Session: "sess", ID: "skeleton-2", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 1, Y: 2}, // adjacent to alice, same as "skeleton"
+	})
+	s.Require().NoError(err)
+
+	out := s.afford()
+	var targets []string
+	attackDecls := 0
+	for _, d := range out.Declarations {
+		if d.Verb != session.VerbAttack {
+			continue
+		}
+		attackDecls++
+		s.Require().NotNil(d.Target, "a declaration naming a real candidate always names it")
+		targets = append(targets, *d.Target)
+		s.True(d.Affordable)
+	}
+	s.Equal(2, attackDecls, "one declaration per target in reach, not one for the fight")
+	s.ElementsMatch([]string{"skeleton", "skeleton-2"}, targets)
+}
+
+// TestNoTargetInReachIsOneDeclarationNotZero pins the other half: nothing in
+// reach still answers, once — never an empty attack-declaration list a
+// client could mistake for "nothing to ask about yet."
+func (s *AffordSuite) TestNoTargetInReachIsOneDeclarationNotZero() {
+	alice := armedFighter("alice")
+	mgr, _, _, _ := aFight(s.T(), alice, []int{1, 1})
+	s.mgr = mgr
+
+	// Move the skeleton out of reach without ending the fight: still in
+	// contact (encEveryoneSees keeps sight unlimited), just too far to swing.
+	_, err := mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice", Path: pathAwayFromSkeleton(),
+	})
+	// alice may not be active in every roll of aFight's own initiative, so a
+	// refusal here would mean this fixture cannot walk — fail loudly rather
+	// than silently asserting nothing.
+	s.Require().NoError(err, "test fixture must be able to walk alice out of reach")
+
+	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+
+	var attackDecls []session.Declaration
+	for _, d := range out.Declarations {
+		if d.Verb == session.VerbAttack {
+			attackDecls = append(attackDecls, d)
+		}
+	}
+	s.Require().Len(attackDecls, 1, "one declaration, not zero, when nothing is in reach")
+	decl := attackDecls[0]
+	s.False(decl.Affordable)
+	s.Nil(decl.Target)
+	s.Require().NotNil(decl.Why)
+	s.Equal(session.ShortfallNoTargetInReach, decl.Why.Reason)
+}
+
+// pathAwayFromSkeleton walks alice five cells from her spawn (1,1), well
+// past a longsword's one-cell reach from the skeleton at (2,1).
+func pathAwayFromSkeleton() []spatial.Position {
+	return []spatial.Position{
+		{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}, {X: 1, Y: 5}, {X: 1, Y: 6},
+	}
+}
+
+// TestShortfallCarriesTheStructuredCurrency pins rpg-toolkit#1010's other
+// half of #1138's own case: Why is not just Text repeated — Reason, Currency,
+// Needed and Left are the figures a UI acts on, agreeing with Text by
+// construction.
+func (s *AffordSuite) TestShortfallCarriesTheStructuredCurrency() {
+	s.fightScene(1, 15, 5, 1, 1)
+
+	_, err := s.swing()
+	s.Require().NoError(err, "spends the action")
+
+	out := s.afford()
+	decl := out.Declarations[0]
+	s.Require().NotNil(decl.Why)
+	s.Equal(session.ShortfallNoBudget, decl.Why.Reason)
+	s.Equal(session.CurrencyAction, decl.Why.Currency)
+	s.Equal(1, decl.Why.Needed)
+	s.Equal(0, decl.Why.Left)
+	s.Equal(decl.Shortfall, decl.Why.Text, "Shortfall and Why.Text must agree")
+}
+
+// TestNotYourTurnIsAnnouncedByAfford is the seam's own promise: a client
+// that reads Afford before trying Attack never sends a swing bob's own
+// TestNotYourTurnIsRefused (attack_test.go) shows Attack would refuse.
+func (s *AffordSuite) TestNotYourTurnIsAnnouncedByAfford() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 5, Y: 5}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	s.Require().NoError(err)
+	data := enc.ToData()
+
+	ctx := context.Background()
+	_, err = mgr.StartSession(ctx, &session.StartSessionInput{Session: "sess", Encounter: "world", World: &data})
+	s.Require().NoError(err)
+
+	spawned, err := mgr.Spawn(ctx, &session.SpawnInput{
+		Session: "sess", ID: "skel-1", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 2, Y: 1},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(spawned.Formed)
+
+	out, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "bob"})
+	s.Require().NoError(err)
+	s.Equal(session.ClockTurn, out.Clock)
+	s.Require().Len(out.Declarations, 2, "attack and move, both blocked the same way")
+	for _, d := range out.Declarations {
+		s.False(d.Affordable)
+		s.Require().NotNil(d.Why)
+		s.Equal(session.ShortfallNotYourTurn, d.Why.Reason)
+	}
+
+	_, err = mgr.Attack(ctx, &session.AttackInput{Session: "sess", Attacker: "bob", Target: "skel-1"})
+	s.ErrorIs(err, session.ErrNotYourTurn, "Attack refuses exactly what Afford announced")
 }

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -194,6 +194,29 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		return nil, fmt.Errorf("attack: %w", err)
 	}
 
+	// NOT YOUR TURN, asked once the attack has compiled so the refusal
+	// still reflects a real swing rather than one that could not have
+	// happened anyway. Free roam asks nothing here — there is no active
+	// member to compare against — which mirrors Move's own turn gate
+	// (rpg-toolkit#1169) and is the same clock read priceSwing makes
+	// below for a different question.
+	clock, err := scope.enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(in.Attacker)})
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", translate(err))
+	}
+	if ClockKind(clock.Kind) == ClockTurn && string(clock.Active) != in.Attacker {
+		return nil, fmt.Errorf("attack: attacker %q: %w", in.Attacker, ErrNotYourTurn)
+	}
+
+	// NO TARGET IN REACH, before pricing: a swing this seam is about to
+	// refuse for distance must not first charge the actor for it.
+	// rpg-toolkit#1010 — melee one cell, the Reach property two, read off
+	// the profile [compileAttack] just built rather than re-deriving a
+	// weapon's own rule here.
+	if err := refuseOutOfReach(scope.enc, roster, in.Attacker, in.Target, profile.Reach); err != nil {
+		return nil, fmt.Errorf("attack: %w", err)
+	}
+
 	// THE ONE PLACE A SPEND GOES, and it is the place its own comment predicted.
 	// The economy turned out not to need a machine above this call: the ruling
 	// (docs/ideas/session-sdk/economy-gate.md) put the price on Input as DATA and

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -169,6 +169,22 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		return nil, fmt.Errorf("attack: attacker %q: %w", in.Attacker, ErrNotACharacter)
 	}
 
+	// NOT YOUR TURN, checked FIRST among the fact-about-this-member
+	// refusals and before anything touches character storage — the same
+	// precedence Move's own gate keeps (Copilot's finding on #1171,
+	// repeated by Copilot here on #1174: this compiled and loaded a sheet
+	// via compileAttack before checking whose turn it was). Free roam asks
+	// nothing here — there is no active member to compare against — which
+	// is the same clock read priceSwing makes below for a different
+	// question.
+	clock, err := scope.enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(in.Attacker)})
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", translate(err))
+	}
+	if ClockKind(clock.Kind) == ClockTurn && string(clock.Active) != in.Attacker {
+		return nil, fmt.Errorf("attack: attacker %q: %w", in.Attacker, ErrNotYourTurn)
+	}
+
 	// A downed member does not swing. Asked AFTER the roster checks, so naming somebody
 	// who is not here is still ErrNoMember — being down is a fact about a
 	// member, and it means nothing about an ID that is not one. Asked about the
@@ -192,20 +208,6 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 	sheet, profile, err := m.compileAttack(ctx, in.Attacker)
 	if err != nil {
 		return nil, fmt.Errorf("attack: %w", err)
-	}
-
-	// NOT YOUR TURN, asked once the attack has compiled so the refusal
-	// still reflects a real swing rather than one that could not have
-	// happened anyway. Free roam asks nothing here — there is no active
-	// member to compare against — which mirrors Move's own turn gate
-	// (rpg-toolkit#1169) and is the same clock read priceSwing makes
-	// below for a different question.
-	clock, err := scope.enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(in.Attacker)})
-	if err != nil {
-		return nil, fmt.Errorf("attack: %w", translate(err))
-	}
-	if ClockKind(clock.Kind) == ClockTurn && string(clock.Active) != in.Attacker {
-		return nil, fmt.Errorf("attack: attacker %q: %w", in.Attacker, ErrNotYourTurn)
 	}
 
 	// NO TARGET IN REACH, before pricing: a swing this seam is about to

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -60,6 +60,12 @@ type AttackOutput struct {
 
 	// Delivery names what reached the event stream.
 	Delivery DeliveryReport `json:"delivery"`
+
+	// Attack is what was swung — ref, name and damage type. The beat line's
+	// "6 slashing" and "with a longsword" come from here; the numbers above
+	// crossed the seam from the first swing and the weapon that produced
+	// them did not, until now (rpg-toolkit#866).
+	Attack AttackRef `json:"attack"`
 }
 
 // Attack swings one member's weapon at another and records what happened.
@@ -251,7 +257,7 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 
 	// And now the beat, on a world whose sheets say what the swing did — see the
 	// godoc for why this is not the other way round.
-	recorded, err := scope.enc.Record(recordFor(in, struck))
+	recorded, err := scope.enc.Record(recordFor(in, struck, profile))
 	if err != nil {
 		return nil, fmt.Errorf("attack: %w", reportUnrecorded(scope, translate(err)))
 	}
@@ -271,7 +277,30 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		Seq:      recorded.Seq,
 		Saved:    report,
 		Delivery: delivery,
+		Attack:   attackRefFor(profile),
 	}, nil
+}
+
+// attackRefFor projects a compiled attack profile's identity onto the wire
+// shape — ref, name, damage type — carried on AttackOutput and, via
+// [encounter.AttackIdentity], on the Struck/Missed beat every witness reads
+// (rpg-toolkit#866).
+//
+// The damage type reported is the FIRST declared pool's, which is every
+// weapon this compiler produces today (rulebooks/dnd5e/resolution's
+// AttackFromCharacter names no weapon with a second damage pool). A weapon
+// that ever declares two would need this to say which one the beat line
+// means, and that decision belongs beside the day such a weapon compiles,
+// not guessed at here.
+func attackRefFor(profile resolution.AttackProfile) AttackRef {
+	ref := AttackRef{Name: profile.Name}
+	if profile.Ref != nil {
+		ref.Ref = string(profile.Ref.ID)
+	}
+	if len(profile.Damage) > 0 {
+		ref.DamageType = DamageType(profile.Damage[0].Type)
+	}
+	return ref
 }
 
 // reportUnrecorded turns a failure AFTER the sheets landed into one a caller can
@@ -371,7 +400,9 @@ func translateResolution(err error) error {
 // Champion's 19–20 — produces a critical hit at roll:19 that this beat cannot
 // tell from an ordinary one. THAT is the caller that earns recorded crit
 // vocabulary, and when it arrives this comment is where to start.
-func recordFor(in *AttackInput, struck resolution.StrikeOutcome) *encounter.RecordInput {
+func recordFor(
+	in *AttackInput, struck resolution.StrikeOutcome, profile resolution.AttackProfile,
+) *encounter.RecordInput {
 	values := map[encounter.OutcomeValue]int{
 		encounter.ValueRoll:    struck.Roll,
 		encounter.ValueTotal:   struck.Total,
@@ -382,11 +413,15 @@ func recordFor(in *AttackInput, struck resolution.StrikeOutcome) *encounter.Reco
 		kind = encounter.OutcomeStruck
 		values[encounter.ValueAmount] = struck.Damage
 	}
+
+	ref := attackRefFor(profile)
 	return &encounter.RecordInput{
-		Kind:    kind,
-		Actor:   encounter.MemberID(in.Attacker),
-		Targets: []encounter.MemberID{encounter.MemberID(in.Target)},
-		Values:  values,
+		Kind:     kind,
+		Actor:    encounter.MemberID(in.Attacker),
+		Targets:  []encounter.MemberID{encounter.MemberID(in.Target)},
+		Values:   values,
+		Critical: struck.Critical,
+		Attack:   &encounter.AttackIdentity{Ref: ref.Ref, Name: ref.Name, DamageType: string(ref.DamageType)},
 	}
 }
 

--- a/rulebooks/dnd5e/session/attack_internal_test.go
+++ b/rulebooks/dnd5e/session/attack_internal_test.go
@@ -77,7 +77,7 @@ func TestRecordUsesAggregateFromTypedStrikeOutcome(t *testing.T) {
 	require.NoError(t, err)
 
 	recorded, err := enc.Record(recordFor(
-		&AttackInput{Attacker: "alice", Target: "bob"}, struck,
+		&AttackInput{Attacker: "alice", Target: "bob"}, struck, resolution.AttackProfile{},
 	))
 	require.NoError(t, err)
 	require.NotZero(t, recorded.Seq)
@@ -86,7 +86,8 @@ func TestRecordUsesAggregateFromTypedStrikeOutcome(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, story)
 	require.JSONEq(t,
-		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":9}`,
+		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":9,`+
+			`"critical":false,"attack":{"ref":"","name":"","damage_type":""}}`,
 		string(story[len(story)-1].Payload),
 		"the persisted encounter record carries the aggregate and no typed damage collection",
 	)

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -36,12 +36,30 @@ func TestAttackSuite(t *testing.T) {
 	suite.Run(t, new(AttackTestSuite))
 }
 
+// unarmedFighter is armedFighter's twin with nothing equipped: the fixture
+// TestAnEmptyHandThrowsAnUnarmedStrike proves the unarmed catalog entry, not
+// a compiler gap (rpg-toolkit#1168).
+func unarmedFighter(id string) *character.Data {
+	return &character.Data{
+		ID:       id,
+		PlayerID: "player-" + id,
+		Name:     id,
+		Level:    3,
+		ClassID:  classes.Fighter,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, abilities.DEX: 14, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 8,
+		},
+		HitPoints:        24,
+		MaxHitPoints:     28,
+		ArmorClass:       16,
+		ProficiencyBonus: 2,
+	}
+}
+
 // armedFighter is a sheet that can actually swing: a longsword in the main
 // hand and the proficiency to use it.
-//
-// The shared dwarf fixture carries no weapon, which is correct for every other
-// verb and useless here — an empty hand is refused by the compiler rather than
-// falling back to an unarmed strike, deliberately.
 func armedFighter(id string) *character.Data {
 	return &character.Data{
 		ID:       id,
@@ -170,8 +188,10 @@ func (s *AttackTestSuite) TestASwingLandsAndTheStoryRecordsIt() {
 	s.Equal(out.Seq, last.Seq, "AttackOutput.Seq references the recorded beat")
 	s.Equal("outcome", last.Tags["tag"])
 	s.JSONEq(
-		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":8}`,
+		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":8,`+
+			`"critical":false,"attack":{"ref":"longsword","name":"Longsword","damage_type":"slashing"}}`,
 		string(last.Payload))
+	s.Equal(session.AttackRef{Ref: "longsword", Name: "Longsword", DamageType: session.DamageSlashing}, out.Attack)
 }
 
 // TestAMissIsRecordedToo pins the other arm, including that a miss carries no
@@ -187,7 +207,8 @@ func (s *AttackTestSuite) TestAMissIsRecordedToo() {
 	story, err := mgr.Story(context.Background(), &session.StoryInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)
 	s.JSONEq(
-		`{"beat":"missed","actor":"alice","targets":["bob"],"roll":2,"total":7,"against":12}`,
+		`{"beat":"missed","actor":"alice","targets":["bob"],"roll":2,"total":7,"against":12,`+
+			`"attack":{"ref":"longsword","name":"Longsword","damage_type":"slashing"}}`,
 		string(story[len(story)-1].Payload))
 }
 
@@ -403,13 +424,21 @@ func (s *AttackTestSuite) TestRefusals() {
 	s.ErrorIs(err, session.ErrNoMember)
 }
 
-// TestAnEmptyHandIsRefused pins the compiler's own gap reaching the host under
-// this package's sentinel rather than the rulebook's.
-func (s *AttackTestSuite) TestAnEmptyHandIsRefused() {
+// TestAnEmptyHandThrowsAnUnarmedStrike pins rpg-toolkit#1168 at the seam: an
+// empty main hand swings and lands with the unarmed strike's own numbers
+// rather than being refused. Exact arithmetic, the same discipline
+// TestASwingLandsAndTheStoryRecordsIt holds attack.go to: a d20 of 15 plus a
+// proficient STR 16 (+3) plus the proficiency bonus every 5e character has
+// for an unarmed strike regardless of weapon training (+2) totals 20 against
+// bob's effective AC 12 — a hit — and the damage die is 1d1, so the roll
+// script's damage entry (any value) resolves to 1 plus the +3 modifier: 4
+// bludgeoning.
+func (s *AttackTestSuite) TestAnEmptyHandThrowsAnUnarmedStrike() {
 	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
-	s.characters = newFakeCharacters(dwarfCharacter("alice"), armedFighter("bob"))
+	s.characters = newFakeCharacters(unarmedFighter("alice"), armedFighter("bob"))
 	mgr, err := session.NewManager(&session.Config{
-		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
+		Dice: &sequenceDice{rolls: []int{15, 1}}, TurnDriver: session.Pass{},
+		Sessions: s.sessions, Encounters: s.encounters,
 		Characters: s.characters, Events: session.DiscardEvents{},
 	})
 	s.Require().NoError(err)
@@ -431,9 +460,13 @@ func (s *AttackTestSuite) TestAnEmptyHandIsRefused() {
 	})
 	s.Require().NoError(err)
 
-	_, err = s.swing(mgr)
-	s.ErrorIs(err, session.ErrBadAttack,
-		"an unarmed character is refused rather than silently swinging for 1")
+	out, err := s.swing(mgr)
+	s.Require().NoError(err)
+	s.Equal(15, out.Roll)
+	s.Equal(20, out.Total, "15 + 3 STR + 2 proficiency (unarmed is always proficient)")
+	s.Equal(12, out.Against)
+	s.True(out.Hit)
+	s.Equal(4, out.Damage, "1d1 + 3 STR")
 }
 
 // TestASheetlessTargetIsRefusedByName covers content standing in a world that

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
@@ -467,6 +468,140 @@ func (s *AttackTestSuite) TestAnEmptyHandThrowsAnUnarmedStrike() {
 	s.Equal(12, out.Against)
 	s.True(out.Hit)
 	s.Equal(4, out.Damage, "1d1 + 3 STR")
+}
+
+// reachWorld is duelWorld's shape with the distance between alice and bob
+// under the caller's control, so a test can put the target just inside or
+// just outside a weapon's reach without touching sight range at all —
+// encEveryoneSees keeps the two in contact (and so in one fight) regardless
+// of how far apart they stand, which is what lets this fixture isolate
+// reach from perception.
+func reachWorld(t fataler, bobAt spatial.Position) *encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms: []encounter.RoomInput{{ID: "hall", Width: 20, Height: 20}}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: bobAt},
+		},
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	if err != nil {
+		t.Fatalf("building the reach world: %v", err)
+	}
+	data := enc.ToData()
+	return &data
+}
+
+// TestOutOfReachIsRefused pins rpg-toolkit#1010 at the seam: a target beyond
+// the weapon's reach is refused before anything is priced or resolved, even
+// though the two are in the same fight (encEveryoneSees keeps them in
+// contact regardless of distance — reach is a different question from
+// sight).
+func (s *AttackTestSuite) TestOutOfReachIsRefused() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	// A longsword reaches 1 cell; bob stands 4 away.
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: reachWorld(s.T(), spatial.Position{X: 5, Y: 1}),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.swing(mgr)
+	s.ErrorIs(err, session.ErrOutOfReach)
+	s.Contains(err.Error(), "bob")
+}
+
+// TestReachPropertyExtendsToTwoCells pins the other half: a weapon carrying
+// the Reach property swings at 2 cells, where a plain longsword could not.
+func (s *AttackTestSuite) TestReachPropertyExtendsToTwoCells() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	glaiveAlice := armedFighter("alice")
+	glaiveAlice.Inventory = []character.InventoryItemData{
+		{Type: shared.EquipmentTypeWeapon, ID: string(weapons.Glaive), Quantity: 1},
+	}
+	glaiveAlice.EquipmentSlots = character.EquipmentSlots{character.SlotMainHand: string(weapons.Glaive)}
+	s.characters = newFakeCharacters(glaiveAlice, armedFighter("bob"))
+	mgr, err := session.NewManager(&session.Config{
+		Dice: &sequenceDice{rolls: []int{2, 1}}, TurnDriver: session.Pass{},
+		Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: reachWorld(s.T(), spatial.Position{X: 3, Y: 1}),
+	})
+	s.Require().NoError(err)
+
+	_, err = s.swing(mgr)
+	s.Require().NoError(err, "a glaive reaches 2 cells; bob stands 2 away")
+}
+
+// TestNotYourTurnIsRefused pins the third refusal Afford is supposed to
+// announce ahead of time: only the fight's active member swings.
+//
+// TWO REAL PLAYERS is what makes "not alice's turn" observable at all — two
+// players standing near each other never form a fight on their own (contact
+// is a hostile-sides question), so this borrows move_turnclock_test.go's own
+// fixture shape: alice and bob start in the hall, a skeleton spawns adjacent
+// and pulls all three into one bubble, initiative order [alice, bob,
+// skel-1]. Bob — seated but not active — is refused for trying to act out of
+// turn, distinctly from being out of reach or unable to pay.
+func (s *AttackTestSuite) TestNotYourTurnIsRefused() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 5, Y: 5}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	s.Require().NoError(err)
+	data := enc.ToData()
+
+	ctx := context.Background()
+	_, err = mgr.StartSession(ctx, &session.StartSessionInput{Session: "sess", Encounter: "world", World: &data})
+	s.Require().NoError(err)
+
+	spawned, err := mgr.Spawn(ctx, &session.SpawnInput{
+		Session: "sess", ID: "skel-1", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 2, Y: 1},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(spawned.Formed, "arriving in plain sight must start a fight")
+
+	turn, err := mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Require().Equal("alice", turn.Active, "alice is first registered — first in initiative")
+
+	// bob swinging at the skeleton while it is alice's turn, not his.
+	_, err = mgr.Attack(ctx, &session.AttackInput{
+		Session: "sess", Attacker: "bob", Target: "skel-1",
+	})
+	s.ErrorIs(err, session.ErrNotYourTurn)
+	s.Contains(err.Error(), "bob")
 }
 
 // TestASheetlessTargetIsRefusedByName covers content standing in a world that

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -597,11 +597,20 @@ func (s *AttackTestSuite) TestNotYourTurnIsRefused() {
 	s.Require().Equal("alice", turn.Active, "alice is first registered — first in initiative")
 
 	// bob swinging at the skeleton while it is alice's turn, not his.
+	before := s.characters.asked["bob"]
 	_, err = mgr.Attack(ctx, &session.AttackInput{
 		Session: "sess", Attacker: "bob", Target: "skel-1",
 	})
 	s.ErrorIs(err, session.ErrNotYourTurn)
 	s.Contains(err.Error(), "bob")
+
+	// Copilot's finding on PR #1174: the turn gate must be asked before
+	// compileAttack ever loads bob's sheet — the same precedence Move's own
+	// gate keeps (Copilot on #1171) and Afford's DOWNED-vs-NOT_YOUR_TURN
+	// ordering keeps (TestNotActiveWinsOverAffordability's own claim,
+	// asked here of Attack instead of Move).
+	s.Equal(before, s.characters.asked["bob"],
+		"the clock is asked before the sheet is — a refusal this early must never have loaded it")
 }
 
 // TestASheetlessTargetIsRefusedByName covers content standing in a world that

--- a/rulebooks/dnd5e/session/attackevents_test.go
+++ b/rulebooks/dnd5e/session/attackevents_test.go
@@ -141,3 +141,60 @@ func (s *AttackEventsTestSuite) TestTheSwingLeavesNothingUnknown() {
 			"beat at seq %d reached %s unnamed", event.Seq, event.Recipient)
 	}
 }
+
+// bodiesAtSeq is kindsAtSeq's own twin for Body: the typed value each
+// recipient's event carries for one story sequence.
+func (s *AttackEventsTestSuite) bodiesAtSeq(seq uint64) map[string]session.EventBody {
+	out := map[string]session.EventBody{}
+	for _, event := range s.stream.published {
+		if event.Seq != seq {
+			continue
+		}
+		out[event.Recipient] = event.Body
+	}
+	return out
+}
+
+// TestAHitCarriesATypedBody pins rpg-toolkit#941/#866 at the stream: a
+// witness who is NOT the attacker — bob, reading his own struck event —
+// gets the SAME numbers and weapon identity AttackOutput gave alice, from
+// StruckBody rather than from decoding Payload by hand.
+func (s *AttackEventsTestSuite) TestAHitCarriesATypedBody() {
+	mgr := s.duelWithStream(&sequenceDice{rolls: []int{15, 5}})
+
+	out := s.swing(mgr)
+	s.Require().True(out.Hit)
+
+	bodies := s.bodiesAtSeq(out.Seq)
+	for _, recipient := range []string{"alice", "bob"} {
+		body, ok := bodies[recipient].(session.StruckBody)
+		s.Require().True(ok, "%s's event carries a StruckBody, got %T", recipient, bodies[recipient])
+		s.Equal("alice", body.Attacker)
+		s.Equal("bob", body.Target)
+		s.Equal(out.Roll, body.Roll)
+		s.Equal(out.Total, body.Total)
+		s.Equal(out.Against, body.Against)
+		s.Equal(out.Damage, body.Damage)
+		s.Equal(out.Critical, body.Critical)
+		s.Equal(out.Attack, body.Attack, "the SAME weapon identity AttackOutput reported")
+	}
+}
+
+// TestAMissCarriesATypedBody is the hit's own twin: MissedBody, with no
+// Damage or Critical field to even get wrong.
+func (s *AttackEventsTestSuite) TestAMissCarriesATypedBody() {
+	mgr := s.duelWithStream(&sequenceDice{rolls: []int{2, 5}})
+
+	out := s.swing(mgr)
+	s.Require().False(out.Hit)
+
+	bodies := s.bodiesAtSeq(out.Seq)
+	body, ok := bodies["bob"].(session.MissedBody)
+	s.Require().True(ok, "bob's event carries a MissedBody, got %T", bodies["bob"])
+	s.Equal("alice", body.Attacker)
+	s.Equal("bob", body.Target)
+	s.Equal(out.Roll, body.Roll)
+	s.Equal(out.Total, body.Total)
+	s.Equal(out.Against, body.Against)
+	s.Equal(out.Attack, body.Attack)
+}

--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -209,7 +209,7 @@ func projectStatus(in *encounter.Status) *Status {
 	return out
 }
 
-func projectSightings(in []intel.Holding) []Sighting {
+func projectSightings(in []intel.Holding, names map[string]string, down map[string]bool) []Sighting {
 	out := make([]Sighting, 0, len(in))
 	for _, h := range in {
 		via := make([]string, 0, len(h.CurrentVia))
@@ -218,7 +218,8 @@ func projectSightings(in []intel.Holding) []Sighting {
 		}
 		out = append(out, Sighting{
 			Subject:    string(h.Subject),
-			Seen:       projectSeen(h.Channel, h.Payload),
+			Name:       names[string(h.Subject)],
+			Seen:       projectSeen(h.Channel, h.Payload, down[string(h.Subject)]),
 			Payload:    append([]byte(nil), h.Payload...),
 			Channel:    string(h.Channel),
 			At:         h.At,
@@ -229,18 +230,23 @@ func projectSightings(in []intel.Holding) []Sighting {
 	return out
 }
 
-// projectSeen copies the sight channel's typed knowledge into Seen (ADR-0041).
-// It is nil for every channel but sight, and nil if a sight-channel payload
-// somehow fails to decode — an impossible state today (the composition is the
-// only writer of sight payloads) that a wrong Position would be worse than
-// admitting to.
+// projectSeen copies the sight channel's typed knowledge into Seen (ADR-0041,
+// rpg-toolkit#1137). It is nil for every channel but sight, and nil if a
+// sight-channel payload somehow fails to decode — an impossible state today
+// (the composition is the only writer of sight payloads) that a wrong
+// Position would be worse than admitting to.
 //
 // The decode itself happens in encounter.DecodeSightPayload, not here: this
 // package never calls encoding/json on a payload. h.Channel is intel's own
 // provenance field — a holding's last accepted testimony — so a held memory
 // (CurrentVia empty) still carries the channel and payload that produced it,
 // and still gets a Seen: "a memory keeps its last Seen" (the ADR's words).
-func projectSeen(channel intel.Channel, payload []byte) *Seen {
+//
+// downed is the caller's own batched Standing() answer for this subject —
+// asked once per verb over the whole roster (turn.go's own pattern), never
+// once per sighting, and passed in rather than looked up here so this stays
+// a pure projection.
+func projectSeen(channel intel.Channel, payload []byte, downed bool) *Seen {
 	if channel != intel.Sight {
 		return nil
 	}
@@ -248,7 +254,11 @@ func projectSeen(channel intel.Channel, payload []byte) *Seen {
 	if !ok {
 		return nil
 	}
-	return &Seen{Position: pos}
+	standing := StandingUp
+	if downed {
+		standing = StandingDowned
+	}
+	return &Seen{Position: pos, Standing: standing}
 }
 
 // projectStory drops each entry's audience roster deliberately.
@@ -348,7 +358,7 @@ func projectOutcome(in *encounter.Outcome) *Outcome {
 // present key means "something changed for this observer", and manufacturing
 // empty entries for everyone who happened to be in the encounter would make
 // the map's size meaningless to a caller deciding whom to notify.
-func projectDiscoveries(in map[encounter.MemberID]*intel.SurveilOutput) map[string]Discovery {
+func projectDiscoveries(in map[encounter.MemberID]*intel.SurveilOutput, down map[string]bool) map[string]Discovery {
 	if len(in) == 0 {
 		return nil
 	}
@@ -357,7 +367,7 @@ func projectDiscoveries(in map[encounter.MemberID]*intel.SurveilOutput) map[stri
 		if delta == nil {
 			continue
 		}
-		out[string(id)] = projectDiscovery(delta)
+		out[string(id)] = projectDiscovery(delta, down)
 	}
 	if len(out) == 0 {
 		return nil
@@ -365,12 +375,12 @@ func projectDiscoveries(in map[encounter.MemberID]*intel.SurveilOutput) map[stri
 	return out
 }
 
-func projectDiscovery(in *intel.SurveilOutput) Discovery {
+func projectDiscovery(in *intel.SurveilOutput, down map[string]bool) Discovery {
 	out := Discovery{}
 	for _, r := range in.FirstContact {
 		out.FirstContact = append(out.FirstContact, Report{
 			Subject: string(r.Subject),
-			Seen:    projectReportSeen(r.Payload),
+			Seen:    projectReportSeen(r.Payload, down[string(r.Subject)]),
 			Payload: append([]byte(nil), r.Payload...),
 		})
 	}
@@ -401,10 +411,14 @@ func projectDiscovery(in *intel.SurveilOutput) Discovery {
 // (seen_internal_test.go) documents the risk rather than closing it: closing
 // it needs SurveilOutput (or the percept it is built from) to carry its own
 // channel, which is a play/intel change outside this PR's scope.
-func projectReportSeen(payload []byte) *Seen {
+func projectReportSeen(payload []byte, downed bool) *Seen {
 	pos, ok := encounter.DecodeSightPayload(payload)
 	if !ok {
 		return nil
 	}
-	return &Seen{Position: pos}
+	standing := StandingUp
+	if downed {
+		standing = StandingDowned
+	}
+	return &Seen{Position: pos, Standing: standing}
 }

--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -284,6 +284,7 @@ func projectMember(in encounter.Member) Member {
 	return Member{
 		ID:       string(in.ID),
 		Kind:     MemberKind(in.Kind),
+		Name:     in.Name,
 		Position: in.Position,
 	}
 }

--- a/rulebooks/dnd5e/session/death_test.go
+++ b/rulebooks/dnd5e/session/death_test.go
@@ -294,6 +294,26 @@ func (s *DeathTestSuite) TestTheLastOneDownedEndsTheFightByDefeat() {
 	s.Equal(session.ClockWorld, turn.Clock, "alice is free-roaming again, and nobody asked for that")
 }
 
+// TestDownedAndFightEndedCarryTypedBodies pins rpg-toolkit#941's other pair:
+// the killing blow's own consequences — the body, and the fight ending it —
+// reach a client as DownedBody and FightEndedBody, not as payload a client
+// decodes itself.
+func (s *DeathTestSuite) TestDownedAndFightEndedCarryTypedBodies() {
+	s.dropTheSkeleton()
+
+	downed := s.eventsOfKind(session.EventDowned)
+	s.Require().NotEmpty(downed)
+	body, ok := downed[0].Body.(session.DownedBody)
+	s.Require().True(ok, "got %T", downed[0].Body)
+	s.Equal("skeleton", body.Member)
+
+	ended := s.eventsOfKind(session.EventFightEnded)
+	s.Require().NotEmpty(ended)
+	endedBody, ok := ended[0].Body.(session.FightEndedBody)
+	s.Require().True(ok, "got %T", ended[0].Body)
+	s.Equal(session.DissolveByDefeat, endedBody.Cause)
+}
+
 // TestTheBeatOrderReachesTheClientAsCauseThenEffect is the composition's
 // ordering law arriving where a table actually reads it.
 //

--- a/rulebooks/dnd5e/session/death_test.go
+++ b/rulebooks/dnd5e/session/death_test.go
@@ -574,6 +574,46 @@ func (s *DeathTestSuite) TestAKillingBlowAboutADownedMemberIsStillLegal() {
 // Downed, not dead — the distinction has teeth. Zero hit points has no exit in
 // v1, but the name does not claim the character is gone, and when death saves
 // arrive these reads are what a client renders them from.
+// TestADownedMemberIsSplicedOutOfParticipantsToo pins that Participants
+// mirrors Order EXACTLY, including a fact Order already held before this
+// feature: the composition splices a downed member out of the turn order
+// the moment it notices them (encounter.noticeDown, rpg-toolkit#1078 — "a
+// body keeps no turn, and the order closes over the gap rather than
+// holding it open"). Participant is a projection of Order, not a second
+// opinion about who belongs in it, so it does not re-add what the
+// composition removed.
+//
+// TWO SKELETONS, deliberately: dropping the last standing member of a side
+// dissolves the bubble entirely (TestTheLastOneDownedEndsTheFightByDefeat),
+// which would leave nothing for THIS test to read Participants off of. A
+// second skeleton keeps the fight alive with the first one down inside it.
+func (s *DeathTestSuite) TestADownedMemberIsSplicedOutOfParticipantsToo() {
+	s.startCrypt()
+	s.spawnSkeleton()
+
+	_, err := s.mgr.Spawn(context.Background(), &session.SpawnInput{
+		Session: "sess", ID: "skeleton-2", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 2, Y: 2},
+	})
+	s.Require().NoError(err)
+
+	s.swingUntilTheSkeletonFalls()
+
+	turn, err := s.mgr.Turn(context.Background(), &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal(session.ClockTurn, turn.Clock, "skeleton-2 is still standing; the fight must still be running")
+	s.NotContains(turn.Order, "skeleton", "the composition already spliced the body out (rpg-toolkit#1078)")
+
+	for _, p := range turn.Participants {
+		s.NotEqual("skeleton", p.Member, "Participants must not re-add what Order does not hold")
+	}
+
+	// The downed member is still a MEMBER, still answerable — just not a
+	// PARTICIPANT in this fight's rotation any more.
+	_, err = s.mgr.Where(context.Background(), &session.WhereInput{Session: "sess", Member: "skeleton"})
+	s.Require().NoError(err, "a downed member is still a member, on the map and answerable")
+}
+
 func (s *DeathTestSuite) TestTheReadsStayOpenToTheDowned() {
 	s.duelAtZero()
 	ctx := context.Background()

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -322,6 +322,21 @@ var (
 	// semantics for.
 	ErrBadAttack = errors.New("attack cannot be made")
 
+	// ErrOutOfReach is returned when Attack names a target further from the
+	// attacker than the compiled weapon's reach permits: one cell for a
+	// melee weapon, two for one carrying the Reach property
+	// (rpg-toolkit#1010). A ranged weapon stays refused as today —
+	// AttackFromCharacter refuses it before a profile with a Reach exists
+	// to check.
+	//
+	// Afford's per-target ATTACK declarations are this same gate asked
+	// ahead of time: a target this seam would refuse with ErrOutOfReach is
+	// a target no declaration names. When no candidate is in reach at all,
+	// Afford still answers once — a single declaration naming no target,
+	// Affordable false, Why.Reason ShortfallNoTargetInReach — rather than
+	// an empty list a client could mistake for "nothing to ask about yet."
+	ErrOutOfReach = errors.New("no target in reach")
+
 	// ErrCannotAfford is returned when an actor cannot pay for what they
 	// declared: a second swing in a turn that bought only one, a level-5
 	// fighter's third, an action after the action was spent, or a walk longer

--- a/rulebooks/dnd5e/session/events.go
+++ b/rulebooks/dnd5e/session/events.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 // EventStream delivers events to the host, which routes them to clients.
@@ -123,14 +124,16 @@ func (m *Manager) projectEvents(
 		}
 
 		for _, entry := range entries {
+			kind, body := decodeBeat(entry.Payload)
 			events = append(events, Event{
 				Session:     scope.session,
 				Seq:         entry.Seq,
 				At:          entry.At,
 				Correlation: entry.Correlation,
 				Recipient:   string(member),
-				Kind:        kindOf(entry.Payload),
+				Kind:        kind,
 				Payload:     append([]byte(nil), entry.Payload...),
+				Body:        body,
 			})
 		}
 	}
@@ -138,38 +141,67 @@ func (m *Manager) projectEvents(
 	return events
 }
 
-// kindOf maps a beat onto the wire enum.
+// decodeBeat determines a beat's wire EventKind and, for the kinds this
+// version types, its typed EventBody — DELETING kindOf's own JSON sniffing
+// (rpg-toolkit#941). It is still the one place this package interprets a
+// payload rather than passing it through: the composition's own "beat" key
+// is a DECLARED kind (every append site in encounter names it explicitly),
+// not content this function guesses at, the same peek-then-dispatch pattern
+// LoadJSON's own routing already uses for conditions and features elsewhere
+// in this codebase.
 //
-// TEMPORARY SHAPE, pending toolkit#941. This is the one place the package
-// interprets a payload rather than passing it through, and that is a coupling
-// worth being uncomfortable about: if the composition changes its payload
-// shape, kind detection fails SILENTLY — every event degrades to EventUnknown,
-// nothing errors, no test fails, and the symptom is a table where nothing
-// narrates correctly.
+// An unrecognised beat, or one whose declared kind decodes to a shape this
+// build's struct does not match, becomes (EventUnknown, nil) rather than
+// being dropped. A client that receives something it cannot interpret still
+// learns its sequence advanced, which keeps gap-detection working; dropping
+// it would manufacture a hole and send every client into a resync it did
+// not need. It also means a newer composition can add beats without older
+// clients losing their place.
+// decodeBeat determines a beat's wire EventKind and, for the kinds this
+// version types, its typed EventBody — DELETING kindOf's own JSON sniffing
+// (rpg-toolkit#941). It is still the one place this package interprets a
+// payload rather than passing it through: the composition's own "beat" key
+// is a DECLARED kind (every append site in encounter names it explicitly),
+// not content this function guesses at, the same peek-then-dispatch pattern
+// LoadJSON's own routing already uses for conditions and features elsewhere
+// in this codebase.
 //
-// It is here because the composition's tags are currently coarser than its
-// beats: "membership" covers both a join and an exit, "movement" covers both a
-// step and a doorway crossing. Four tags stand in front of seven beats and two
-// of those groupings pair opposites, so the tag cannot answer "what happened"
-// — and a client cannot narrate an arrival and a departure the same way.
+// KIND AND BODY ARE TWO SEPARATE QUESTIONS, on purpose. kindFor answers the
+// first from "beat" alone and is total over every string the composition
+// can write there; bodyFor attempts the second, and a payload whose other
+// fields do not match (a hand-built fixture missing "targets", a future
+// composition version that renamed one) yields a nil Body without ALSO
+// demoting a correctly-identified Kind to EventUnknown. Conflating the two
+// would mean a single missing field anywhere in a payload could make an
+// otherwise-ordinary struck beat unrecognisable, which is a worse failure
+// than the one #941 set out to fix.
 //
-// When #941 enriches the tags, this reads declared metadata instead of parsed
-// content and the coupling disappears.
-//
-// An unrecognised beat becomes EventUnknown rather than being dropped. A client
-// that receives something it cannot interpret still learns its sequence
-// advanced, which keeps gap-detection working; dropping it would manufacture a
-// hole and send every client into a resync it did not need. It also means a
-// newer composition can add beats without older clients losing their place.
-func kindOf(payload []byte) EventKind {
-	var beat struct {
+// An unrecognised beat becomes EventUnknown rather than being dropped. A
+// client that receives something it cannot interpret still learns its
+// sequence advanced, which keeps gap-detection working; dropping it would
+// manufacture a hole and send every client into a resync it did not need.
+// It also means a newer composition can add beats without older clients
+// losing their place.
+func decodeBeat(payload []byte) (EventKind, EventBody) {
+	var peek struct {
 		Beat string `json:"beat"`
 	}
-	if err := json.Unmarshal(payload, &beat); err != nil {
-		return EventUnknown
+	if err := json.Unmarshal(payload, &peek); err != nil {
+		return EventUnknown, nil
 	}
 
-	switch beat.Beat {
+	kind := kindFor(peek.Beat)
+	if kind == EventUnknown {
+		return EventUnknown, nil
+	}
+	return kind, bodyFor(kind, payload)
+}
+
+// kindFor maps the composition's declared "beat" string onto the wire enum.
+// Total: every string reaches an arm, and the ones this build does not
+// recognise fall to EventUnknown alongside an empty or unparseable one.
+func kindFor(beat string) EventKind {
+	switch beat {
 	case "moved":
 		return EventMoved
 	case "joined":
@@ -211,14 +243,112 @@ func kindOf(payload []byte) EventKind {
 	// that LEAVES the session is the unambiguous one, while the composition's
 	// own kind — which is persisted in every stored world — is left alone. A
 	// rename there would be a migration; a translation here is a line.
-	//
-	// This is therefore the one case in this function where the two strings
-	// deliberately differ, which is also why its pin is built from
-	// encounter.OutcomeDown rather than from a literal: the composition's
-	// string is the half that must not drift, and nothing else would notice.
 	case "down":
 		return EventDowned
 	default:
 		return EventUnknown
+	}
+}
+
+// bodyFor decodes payload into the typed body kind names, or nil if the
+// payload does not match what that kind's body needs — a best-effort
+// second step that never changes the Kind decodeBeat already settled on.
+func bodyFor(kind EventKind, payload []byte) EventBody {
+	switch kind {
+	case EventMoved:
+		var p struct {
+			Member   string           `json:"member"`
+			Position spatial.Position `json:"position"`
+		}
+		if json.Unmarshal(payload, &p) != nil {
+			return nil
+		}
+		return MovedBody{Member: p.Member, To: p.Position}
+	case EventTurnEnded:
+		var p struct {
+			Member string `json:"member"`
+			Next   string `json:"next"`
+		}
+		if json.Unmarshal(payload, &p) != nil {
+			return nil
+		}
+		return TurnEndedBody{Member: p.Member, Next: p.Next}
+	case EventFightStarted:
+		var p struct {
+			Order []string `json:"order"`
+		}
+		if json.Unmarshal(payload, &p) != nil {
+			return nil
+		}
+		return FightStartedBody{Members: p.Order}
+	case EventFightEnded:
+		var p struct {
+			Cause string `json:"cause"`
+		}
+		if json.Unmarshal(payload, &p) != nil {
+			return nil
+		}
+		return FightEndedBody{Cause: DissolveKind(p.Cause)}
+	case EventStruck:
+		return structBody(payload, true)
+	case EventMissed:
+		return structBody(payload, false)
+	case EventDowned:
+		var p struct {
+			Member string `json:"member"`
+		}
+		if json.Unmarshal(payload, &p) != nil {
+			return nil
+		}
+		return DownedBody{Member: p.Member}
+	default:
+		// EventJoined, EventExited, EventEnded, EventSceneOpened, EventTick:
+		// no body member exists for these — see EventBody's own doc.
+		return nil
+	}
+}
+
+// beatAttack is the wire shape Record's payload writes an attack identity
+// as (attack.go's recordFor) — decoded here rather than re-derived, since
+// this package is the one that wrote it in the first place.
+type beatAttack struct {
+	Ref        string `json:"ref"`
+	Name       string `json:"name"`
+	DamageType string `json:"damage_type"`
+}
+
+func (a beatAttack) toRef() AttackRef {
+	return AttackRef{Ref: a.Ref, Name: a.Name, DamageType: DamageType(a.DamageType)}
+}
+
+// structBody decodes a struck or missed outcome beat's shared fields.
+// wantAmount distinguishes the two: a struck beat carries Amount and
+// Critical, a missed one carries neither, matching StruckBody/MissedBody's
+// own shapes. targets is always exactly one member for an attack
+// (recordFor's own shape); a beat with none does not type.
+func structBody(payload []byte, wantAmount bool) EventBody {
+	var p struct {
+		Actor    string     `json:"actor"`
+		Targets  []string   `json:"targets"`
+		Roll     int        `json:"roll"`
+		Total    int        `json:"total"`
+		Against  int        `json:"against"`
+		Amount   int        `json:"amount"`
+		Critical bool       `json:"critical"`
+		Attack   beatAttack `json:"attack"`
+	}
+	if json.Unmarshal(payload, &p) != nil || len(p.Targets) == 0 {
+		return nil
+	}
+	if wantAmount {
+		return StruckBody{
+			Attacker: p.Actor, Target: p.Targets[0],
+			Roll: p.Roll, Total: p.Total, Against: p.Against, Damage: p.Amount,
+			Attack: p.Attack.toRef(), Critical: p.Critical,
+		}
+	}
+	return MissedBody{
+		Attacker: p.Actor, Target: p.Targets[0],
+		Roll: p.Roll, Total: p.Total, Against: p.Against, Attack: p.Attack.toRef(),
 	}
 }

--- a/rulebooks/dnd5e/session/events.go
+++ b/rulebooks/dnd5e/session/events.go
@@ -260,7 +260,7 @@ func bodyFor(kind EventKind, payload []byte) EventBody {
 			Member   string           `json:"member"`
 			Position spatial.Position `json:"position"`
 		}
-		if json.Unmarshal(payload, &p) != nil {
+		if json.Unmarshal(payload, &p) != nil || p.Member == "" {
 			return nil
 		}
 		return MovedBody{Member: p.Member, To: p.Position}
@@ -269,7 +269,7 @@ func bodyFor(kind EventKind, payload []byte) EventBody {
 			Member string `json:"member"`
 			Next   string `json:"next"`
 		}
-		if json.Unmarshal(payload, &p) != nil {
+		if json.Unmarshal(payload, &p) != nil || p.Member == "" || p.Next == "" {
 			return nil
 		}
 		return TurnEndedBody{Member: p.Member, Next: p.Next}
@@ -277,7 +277,7 @@ func bodyFor(kind EventKind, payload []byte) EventBody {
 		var p struct {
 			Order []string `json:"order"`
 		}
-		if json.Unmarshal(payload, &p) != nil {
+		if json.Unmarshal(payload, &p) != nil || len(p.Order) == 0 {
 			return nil
 		}
 		return FightStartedBody{Members: p.Order}
@@ -285,7 +285,7 @@ func bodyFor(kind EventKind, payload []byte) EventBody {
 		var p struct {
 			Cause string `json:"cause"`
 		}
-		if json.Unmarshal(payload, &p) != nil {
+		if json.Unmarshal(payload, &p) != nil || p.Cause == "" {
 			return nil
 		}
 		return FightEndedBody{Cause: DissolveKind(p.Cause)}
@@ -297,7 +297,7 @@ func bodyFor(kind EventKind, payload []byte) EventBody {
 		var p struct {
 			Member string `json:"member"`
 		}
-		if json.Unmarshal(payload, &p) != nil {
+		if json.Unmarshal(payload, &p) != nil || p.Member == "" {
 			return nil
 		}
 		return DownedBody{Member: p.Member}
@@ -337,7 +337,12 @@ func structBody(payload []byte, wantAmount bool) EventBody {
 		Critical bool       `json:"critical"`
 		Attack   beatAttack `json:"attack"`
 	}
-	if json.Unmarshal(payload, &p) != nil || len(p.Targets) == 0 {
+	if json.Unmarshal(payload, &p) != nil ||
+		p.Actor == "" || len(p.Targets) != 1 || p.Attack.Ref == "" {
+		// EXACTLY one target, not merely "at least one": recordFor's own
+		// shape always writes one for an attack (attack.go), so a payload
+		// naming zero or several is not a shape this decoder recognises
+		// rather than an ambiguous one to guess at (Copilot, PR #1174).
 		return nil
 	}
 	if wantAmount {

--- a/rulebooks/dnd5e/session/events_internal_test.go
+++ b/rulebooks/dnd5e/session/events_internal_test.go
@@ -11,9 +11,18 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 )
 
+// testKindOf is decodeBeat's own Kind half, isolated for the tests below
+// that pin kindFor's mapping without caring what bodyFor makes of the rest
+// of the payload (rpg-toolkit#941 split decodeBeat's old single-return
+// kindOf into kindFor + bodyFor; these pins moved with it).
+func testKindOf(payload string) EventKind {
+	kind, _ := decodeBeat([]byte(payload))
+	return kind
+}
+
 // TestAnUnrecognisedBeatStaysUnknown pins the mapper's default arm.
 //
-// Pinned HERE, against kindOf directly, rather than through a verb — because no
+// Pinned HERE, against kindFor directly, rather than through a verb — because no
 // verb can produce it. Every beat the composition emits today has a case, which
 // is the point of rpg-toolkit#1038; the arm exists for the beat a LATER
 // composition adds, and there is no honest way to drive that from this side of
@@ -26,11 +35,11 @@ import (
 // composition ship a beat this version has never heard of without older clients
 // losing their place.
 func TestAnUnrecognisedBeatStaysUnknown(t *testing.T) {
-	require.Equal(t, EventUnknown, kindOf([]byte(`{"beat":"transmogrified"}`)),
+	require.Equal(t, EventUnknown, testKindOf(`{"beat":"transmogrified"}`),
 		"a beat this version does not know is delivered, not dropped")
-	require.Equal(t, EventUnknown, kindOf([]byte(`{"actor":"alice"}`)),
+	require.Equal(t, EventUnknown, testKindOf(`{"actor":"alice"}`),
 		"and so is a beat with no name at all")
-	require.Equal(t, EventUnknown, kindOf([]byte(`not json`)),
+	require.Equal(t, EventUnknown, testKindOf(`not json`),
 		"including a payload this package cannot even parse")
 }
 
@@ -39,11 +48,11 @@ func TestAnUnrecognisedBeatStaysUnknown(t *testing.T) {
 //
 // The seam-level pins drive real scenes and are the evidence that matters —
 // attackevents_test.go for the two swings, death_test.go for the third. This
-// asks the narrower question those cannot: does kindOf's literal still equal
+// asks the narrower question those cannot: does kindFor's literal still equal
 // the composition's own constant?
 //
 // It is BUILT FROM the composition's constants rather than from strings typed
-// twice, and that is the whole strength of it. kindOf matches on literals, so a
+// twice, and that is the whole strength of it. kindFor matches on literals, so a
 // rename upstream degrades every event of that kind to EventUnknown with
 // nothing failing — the silent failure its own doc warns about. A test that
 // also spelled the literal out would keep passing through exactly that change.
@@ -66,7 +75,7 @@ func TestTheOutcomeBeatsAreTheCompositionsOwnStrings(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(string(tc.kind), func(t *testing.T) {
 			require.Equal(t, tc.want,
-				kindOf([]byte(`{"beat":"`+string(tc.kind)+`","member":"goblin"}`)))
+				testKindOf(`{"beat":"`+string(tc.kind)+`","member":"goblin"}`))
 		})
 	}
 }
@@ -84,7 +93,7 @@ func TestTheOutcomeBeatsAreTheCompositionsOwnStrings(t *testing.T) {
 //     asserting the CONSTANT alone would not have noticed it changing.
 //   - The composition keeps "down", because that kind is persisted in every
 //     stored world. Renaming it there is a migration; translating here is a
-//     line in kindOf.
+//     line in kindFor.
 //
 // The third assertion is the one that earns its keep. Both single-value rows
 // pass happily if somebody aligns the two — that is the tidy-looking change
@@ -96,5 +105,5 @@ func TestTheSeamSaysDownedWhereTheCompositionSaysDown(t *testing.T) {
 	require.Equal(t, encounter.OutcomeKind("down"), encounter.OutcomeDown,
 		"the composition's persisted kind, deliberately left alone")
 	require.NotEqual(t, string(EventDowned), string(encounter.OutcomeDown),
-		"these two must not be aligned: see kindOf, and rpg-toolkit#1084")
+		"these two must not be aligned: see kindFor, and rpg-toolkit#1084")
 }

--- a/rulebooks/dnd5e/session/events_internal_test.go
+++ b/rulebooks/dnd5e/session/events_internal_test.go
@@ -107,3 +107,52 @@ func TestTheSeamSaysDownedWhereTheCompositionSaysDown(t *testing.T) {
 	require.NotEqual(t, string(EventDowned), string(encounter.OutcomeDown),
 		"these two must not be aligned: see kindFor, and rpg-toolkit#1084")
 }
+
+// TestBodyForRefusesAMissingRequiredField pins the fix for Copilot's finding
+// on PR #1174: json.Unmarshal does not fail when a struct's fields are
+// simply absent from the payload, so bodyFor (and structBody, its own arm
+// for struck/missed) must check for the required fields explicitly rather
+// than trusting a successful Unmarshal alone — an incomplete beat must
+// leave Body nil, not populate it with zero-valued fields that read as
+// real answers ("" for a member id, an empty AttackRef).
+func TestBodyForRefusesAMissingRequiredField(t *testing.T) {
+	cases := []struct {
+		name string
+		kind EventKind
+		json string
+	}{
+		{"moved with no member", EventMoved, `{"beat":"moved","position":{"x":1,"y":2}}`},
+		{"turn-ended with no next", EventTurnEnded, `{"beat":"turn-ended","member":"alice"}`},
+		{"turn-ended with no member", EventTurnEnded, `{"beat":"turn-ended","next":"bob"}`},
+		{"bubble-formed with an empty order", EventFightStarted, `{"beat":"bubble-formed","order":[]}`},
+		{"bubble-dissolved with no cause", EventFightEnded, `{"beat":"bubble-dissolved"}`},
+		{"down with no member", EventDowned, `{"beat":"down"}`},
+		{"struck with no actor", EventStruck, `{"beat":"struck","targets":["bob"],"attack":{"ref":"longsword"}}`},
+		{"struck with no targets", EventStruck, `{"beat":"struck","actor":"alice","attack":{"ref":"longsword"}}`},
+		{"struck with two targets", EventStruck, `{"beat":"struck","actor":"alice","targets":["bob","carol"],"attack":{"ref":"longsword"}}`},
+		{"struck with no attack ref", EventStruck, `{"beat":"struck","actor":"alice","targets":["bob"]}`},
+		{"missed with no actor", EventMissed, `{"beat":"missed","targets":["bob"],"attack":{"ref":"longsword"}}`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, body := decodeBeat([]byte(tc.json))
+			require.Equal(t, tc.kind, kind, "the KIND is still correctly identified from the declared beat")
+			require.Nil(t, body, "but the body is nil rather than populated with zero-valued fields")
+		})
+	}
+}
+
+// TestBodyForAcceptsACompleteBeat is the companion pin: every field the
+// case above found missing, present, produces a typed body — the stricter
+// check must not have overreached into refusing valid beats.
+func TestBodyForAcceptsACompleteBeat(t *testing.T) {
+	kind, body := decodeBeat([]byte(
+		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":8,` +
+			`"critical":false,"attack":{"ref":"longsword","name":"Longsword","damage_type":"slashing"}}`))
+	require.Equal(t, EventStruck, kind)
+	require.Equal(t, StruckBody{
+		Attacker: "alice", Target: "bob", Roll: 15, Total: 20, Against: 12, Damage: 8,
+		Attack: AttackRef{Ref: "longsword", Name: "Longsword", DamageType: DamageSlashing},
+	}, body)
+}

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822090354-20689f95d426
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822090901-fc1ee3ba5a34
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822092020-0a649305420b
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822090354-20689f95d426
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822092020-0a649305420b
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822095344-9e268587e077
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822095454-74a62e764e8d
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -9,8 +9,8 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.1
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822090354-20689f95d426
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822090901-fc1ee3ba5a34
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,10 +18,10 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822090354-20689f95d426 h1:PGpeiEpL3yJsgtW/L8wwhk4Bdc9Rr4Yq7TfvoFsT45o=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822090354-20689f95d426/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822092020-0a649305420b h1:dvLAi9GAH2QdG9E4ao1VmnoZDNo18c5g+BBQOXKfHY8=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822092020-0a649305420b/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822095344-9e268587e077 h1:A7RSob5tVwwO/J82HOTgveyOKoROWrpLhec3oOfgZOY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822095344-9e268587e077/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822095454-74a62e764e8d h1:zfiVSCDhN1MNSPRkW4rFzGOFU8hxEU9FZXAX/7rTItY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822095454-74a62e764e8d/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -20,8 +20,12 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.1 h1:FHjfYzEtQi90+UBEZe3vIZy6ch9ZVuFdwL1WSJZRQQU=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.1/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822090354-20689f95d426 h1:PGpeiEpL3yJsgtW/L8wwhk4Bdc9Rr4Yq7TfvoFsT45o=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822090354-20689f95d426/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1 h1:FCDHPx/vGzDmHIHopHCJQspyybr0HI/KL7z7i68a9Y4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822090901-fc1ee3ba5a34 h1:qwm9LMNo3JBPAjtplBIK76+7zI9gJVnpZLXFWI8rAV0=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822090901-fc1ee3ba5a34/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -18,14 +18,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.1 h1:FHjfYzEtQi90+UBEZe3vIZy6ch9ZVuFdwL1WSJZRQQU=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.1/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822090354-20689f95d426 h1:PGpeiEpL3yJsgtW/L8wwhk4Bdc9Rr4Yq7TfvoFsT45o=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822090354-20689f95d426/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1 h1:FCDHPx/vGzDmHIHopHCJQspyybr0HI/KL7z7i68a9Y4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822090901-fc1ee3ba5a34 h1:qwm9LMNo3JBPAjtplBIK76+7zI9gJVnpZLXFWI8rAV0=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822090901-fc1ee3ba5a34/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822092020-0a649305420b h1:dvLAi9GAH2QdG9E4ao1VmnoZDNo18c5g+BBQOXKfHY8=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822092020-0a649305420b/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -26,6 +26,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1 h1:FCDHPx/
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.1/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822090901-fc1ee3ba5a34 h1:qwm9LMNo3JBPAjtplBIK76+7zI9gJVnpZLXFWI8rAV0=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822090901-fc1ee3ba5a34/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822092020-0a649305420b h1:dvLAi9GAH2QdG9E4ao1VmnoZDNo18c5g+BBQOXKfHY8=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822092020-0a649305420b/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -231,7 +231,18 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		}
 	}
 
-	res, err := m.runWalk(scope, in.Member, in.Path)
+	// Standing, batched once for the whole walk (rpg-toolkit#1137) and only
+	// NOW — after every gate that must refuse without touching a sheet has
+	// already passed (Copilot's own precedence finding on #1171, pinned by
+	// TestNotActiveWinsOverAffordability): a Move cannot down or revive
+	// anyone, so the answer is stable across every step's own Discovery, and
+	// asking once here beats asking once per step.
+	down, err := discoveryStanding(scope)
+	if err != nil {
+		return nil, fmt.Errorf("move: %w", err)
+	}
+
+	res, err := m.runWalk(scope, in.Member, in.Path, down)
 	if err != nil {
 		return nil, fmt.Errorf("move: %w", err)
 	}
@@ -404,7 +415,9 @@ type walkResult struct {
 // a fight and a fight member does not free-roam — the composition would refuse
 // the next step with ErrInBubble — so stopping is a fact about the world rather
 // than a policy about perception.
-func (m *Manager) runWalk(scope *writeScope, member string, path []spatial.Position) (*walkResult, error) {
+func (m *Manager) runWalk(
+	scope *writeScope, member string, path []spatial.Position, down map[string]bool,
+) (*walkResult, error) {
 	res := &walkResult{discovered: map[string]Discovery{}}
 
 	for i, cell := range path {
@@ -436,7 +449,7 @@ func (m *Manager) runWalk(scope *writeScope, member string, path []spatial.Posit
 			Position: stepped.Stepped.To,
 			Seq:      stepped.Seq,
 		})
-		mergeDiscoveries(res.discovered, projectDiscoveries(stepped.IntelDeltas))
+		mergeDiscoveries(res.discovered, projectDiscoveries(stepped.IntelDeltas, down))
 
 		if stepped.Outcome != nil {
 			// The encounter ended underfoot. Every remaining step is abandoned:

--- a/rulebooks/dnd5e/session/move_turnclock_test.go
+++ b/rulebooks/dnd5e/session/move_turnclock_test.go
@@ -305,3 +305,57 @@ func (s *MoveTurnClockSuite) TestWorldClockMoveNeverTouchesTheEconomy() {
 	s.Equal(session.ClockWorld, direct.Clock)
 	s.Empty(direct.Declarations, "empty, not zero — the economy does not apply on the world clock at all")
 }
+
+// TestMovedTurnEndedAndFightStartedCarryTypedBodies pins rpg-toolkit#941 for
+// the three beat families this fixture's own setup and Move already produce:
+// the spawn that pulled everyone into one bubble (FightStartedBody, in
+// initiative order), a step of the walk (MovedBody), and ending alice's turn
+// (TurnEndedBody). Bob — a real player, next in initiative — is NOT
+// Pass-driven through automatically the way skel-1 would be, so this is
+// exactly one turn-ended BEAT, delivered once per recipient (three events,
+// one beat).
+func (s *MoveTurnClockSuite) TestMovedTurnEndedAndFightStartedCarryTypedBodies() {
+	ctx := context.Background()
+
+	started := s.eventsOfKind(session.EventFightStarted)
+	s.Require().NotEmpty(started, "the spawn in SetupTest already formed the bubble")
+	fsBody, ok := started[0].Body.(session.FightStartedBody)
+	s.Require().True(ok, "got %T", started[0].Body)
+	s.Equal([]string{"alice", "bob", "skel-1"}, fsBody.Members)
+
+	_, err := s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 2}},
+	})
+	s.Require().NoError(err)
+
+	moved := s.eventsOfKind(session.EventMoved)
+	s.Require().NotEmpty(moved)
+	movedBody, ok := moved[0].Body.(session.MovedBody)
+	s.Require().True(ok, "got %T", moved[0].Body)
+	s.Equal("alice", movedBody.Member)
+	s.Equal(spatial.Position{X: 1, Y: 2}, movedBody.To)
+
+	ended, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Equal("bob", ended.Next)
+
+	turnEnded := s.eventsOfKind(session.EventTurnEnded)
+	s.Require().Len(turnEnded, 3, "one beat, delivered once per member of the encounter")
+	first, ok := turnEnded[0].Body.(session.TurnEndedBody)
+	s.Require().True(ok, "got %T", turnEnded[0].Body)
+	s.Equal("alice", first.Member)
+	s.Equal("bob", first.Next)
+}
+
+// eventsOfKind collects everything of one kind published across this
+// suite's stream — MoveTurnClockSuite's own copy of DeathTestSuite's helper,
+// since the two suites do not share a base.
+func (s *MoveTurnClockSuite) eventsOfKind(kind session.EventKind) []session.Event {
+	var out []session.Event
+	for _, event := range s.stream.published {
+		if event.Kind == kind {
+			out = append(out, event)
+		}
+	}
+	return out
+}

--- a/rulebooks/dnd5e/session/reach.go
+++ b/rulebooks/dnd5e/session/reach.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// rosterPositions indexes a roster read by member id, for the reach checks
+// below and for Afford's per-target declarations — both need "where does
+// this member stand" and both already hold the roster read that answers it,
+// so this is a lookup rather than a second fetch.
+func rosterPositions(roster []encounter.Member) map[string]spatial.Position {
+	out := make(map[string]spatial.Position, len(roster))
+	for _, m := range roster {
+		out[string(m.ID)] = m.Position
+	}
+	return out
+}
+
+// inReach reports whether to is within reach cells of from, on enc's own
+// grid (Encounter.Distance — the same primitive refreshSight's sight check
+// uses internally, exposed minimally: rpg-toolkit#1010).
+func inReach(enc *encounter.Encounter, from, to spatial.Position, reach int) bool {
+	return enc.Distance(from, to) <= float64(reach)
+}
+
+// refuseOutOfReach refuses target unless it is within reach cells of
+// attacker's current position — session.Attack's own gate, ported from the
+// retired top-level encounter module's checkReach (encounter/range_gate.go):
+// melee one cell, the Reach property two, read off the compiled profile
+// rather than re-derived here.
+//
+// Both ids are already known to be members of positions by the time this is
+// called — Attack's own roster checks run first — so a missing entry would
+// be this function being asked about someone that earlier check should have
+// refused, not a case this seam narrates to a caller.
+func refuseOutOfReach(enc *encounter.Encounter, roster []encounter.Member, attacker, target string, reach int) error {
+	positions := rosterPositions(roster)
+	if !inReach(enc, positions[attacker], positions[target], reach) {
+		return fmt.Errorf("target %q: %w", target, ErrOutOfReach)
+	}
+	return nil
+}

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -167,7 +167,11 @@ func (m *Manager) View(ctx context.Context, in *ViewInput) ([]Sighting, error) {
 	if in.Member == "" {
 		return nil, fmt.Errorf("view: %w", ErrNoMemberID)
 	}
-	enc, err := m.open(ctx, in.Session)
+	data, err := m.loadSessionData(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("view: %w", err)
+	}
+	enc, err := m.loadWorld(ctx, data)
 	if err != nil {
 		return nil, fmt.Errorf("view: %w", err)
 	}
@@ -177,7 +181,19 @@ func (m *Manager) View(ctx context.Context, in *ViewInput) ([]Sighting, error) {
 		return nil, fmt.Errorf("view: %w", translate(err))
 	}
 
-	return projectSightings(holdings), nil
+	// Names and standing, batched over the whole roster rather than per
+	// sighting (rpg-toolkit#1137) — the observer might hold a sighting for
+	// anyone in it, live or memory.
+	roster, err := enc.Members()
+	if err != nil {
+		return nil, fmt.Errorf("view: %w", translate(err))
+	}
+	down, err := standingSet(m.standingFor(ctx, data), rosterIDs(roster))
+	if err != nil {
+		return nil, fmt.Errorf("view: %w", err)
+	}
+
+	return projectSightings(holdings, rosterNames(roster), down), nil
 }
 
 // Story returns the beats a member has witnessed, from FromSeq onward

--- a/rulebooks/dnd5e/session/read_test.go
+++ b/rulebooks/dnd5e/session/read_test.go
@@ -378,3 +378,28 @@ func (s *ReadTestSuite) TestASquareAtlasHasNoLayout() {
 	s.Require().NoError(err)
 	s.Empty(atlas.Layout, "square grids have no hex layout; the field is absent, not defaulted")
 }
+
+// TestViewCarriesNameAndStanding pins rpg-toolkit#1137's perception half:
+// a sighted subject's display name and whether they are on their feet ride
+// along on the SAME read that already answers "what do I see" — no second
+// lookup, and no roster read this seam otherwise refuses to offer.
+func (s *ReadTestSuite) TestViewCarriesNameAndStanding() {
+	mgr, _, _, characters := aFight(s.T(), armedFighter("alice"), nil)
+	s.mgr = mgr
+	s.characters = characters
+
+	sightings, err := s.mgr.View(context.Background(),
+		&session.ViewInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+
+	var skeleton *session.Sighting
+	for i := range sightings {
+		if sightings[i].Subject == "skeleton" {
+			skeleton = &sightings[i]
+		}
+	}
+	s.Require().NotNil(skeleton, "alice must currently see the skeleton aFight spawned adjacent to her")
+	s.NotEmpty(skeleton.Name, "a spawned monster's catalog display name projects onto Sighting.Name")
+	s.Require().NotNil(skeleton.Seen, "a live sight-channel sighting carries Seen")
+	s.Equal(session.StandingUp, skeleton.Seen.Standing, "nothing has touched it yet")
+}

--- a/rulebooks/dnd5e/session/rosterlookup.go
+++ b/rulebooks/dnd5e/session/rosterlookup.go
@@ -1,0 +1,44 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+
+// rosterNames indexes a roster read by member id — the lookup Sighting.Name
+// and Participant.Name both need (rpg-toolkit#1137), built once per verb
+// from a roster read the caller already has rather than fetched again per
+// subject.
+func rosterNames(roster []encounter.Member) map[string]string {
+	out := make(map[string]string, len(roster))
+	for _, m := range roster {
+		out[string(m.ID)] = m.Name
+	}
+	return out
+}
+
+// standingSet batches a down-check over a set of member ids into a lookup —
+// one Standing() call per verb rather than one per sighted subject or
+// participant, and the same batching turn.go's own participantsFor uses.
+func standingSet(standing encounter.Standing, ids []encounter.MemberID) (map[string]bool, error) {
+	down, err := standing.Standing(ids)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]bool, len(down))
+	for _, id := range down {
+		out[string(id)] = true
+	}
+	return out, nil
+}
+
+// rosterIDs pulls the bare ids out of a roster read, for callers that need
+// to ask Standing about everyone rather than a narrower set (View's own
+// call: the observer might hold a sighting for anyone in the roster).
+func rosterIDs(roster []encounter.Member) []encounter.MemberID {
+	out := make([]encounter.MemberID, len(roster))
+	for i, m := range roster {
+		out[i] = m.ID
+	}
+	return out
+}

--- a/rulebooks/dnd5e/session/seen_internal_test.go
+++ b/rulebooks/dnd5e/session/seen_internal_test.go
@@ -37,10 +37,12 @@ func TestProjectSightingsSightChannelGetsASeen(t *testing.T) {
 		Status:     intel.Current,
 	}}
 
-	out := projectSightings(holdings)
+	out := projectSightings(holdings, nil, map[string]bool{"skeleton-1": true})
 	require.Len(t, out, 1)
 	require.NotNil(t, out[0].Seen, "a sight-channel holding must carry Seen")
 	require.Equal(t, spatial.Position{X: 10, Y: 3}, out[0].Seen.Position)
+	require.Equal(t, StandingDowned, out[0].Seen.Standing,
+		"the batched down-set this subject appears in projects onto Seen.Standing (rpg-toolkit#1137)")
 }
 
 // TestProjectSightingsNonSightChannelGetsNoSeen pins the other half: a
@@ -58,7 +60,7 @@ func TestProjectSightingsNonSightChannelGetsNoSeen(t *testing.T) {
 		Status:     intel.Current,
 	}}
 
-	out := projectSightings(holdings)
+	out := projectSightings(holdings, nil, nil)
 	require.Len(t, out, 1)
 	require.Nil(t, out[0].Seen, "a non-sight channel must not carry Seen, however the payload happens to decode")
 }
@@ -77,10 +79,11 @@ func TestProjectSightingsHeldMemoryKeepsItsLastSeen(t *testing.T) {
 		Status:     intel.Held,
 	}}
 
-	out := projectSightings(holdings)
+	out := projectSightings(holdings, nil, nil)
 	require.Len(t, out, 1)
 	require.NotNil(t, out[0].Seen, "a held memory must keep its last Seen")
 	require.Equal(t, spatial.Position{X: 6, Y: 10}, out[0].Seen.Position)
+	require.Equal(t, StandingUp, out[0].Seen.Standing, "not in the down set: reports up")
 }
 
 // TestProjectSeenIsNilWhenASightPayloadFailsToDecode is the defensive arm: an
@@ -88,7 +91,7 @@ func TestProjectSightingsHeldMemoryKeepsItsLastSeen(t *testing.T) {
 // payloads), pinned so a future regression that corrupts a sight payload
 // fails loudly as a missing Seen rather than a wrong Position.
 func TestProjectSeenIsNilWhenASightPayloadFailsToDecode(t *testing.T) {
-	got := projectSeen(intel.Sight, []byte("not json"))
+	got := projectSeen(intel.Sight, []byte("not json"), false)
 	require.Nil(t, got)
 }
 
@@ -111,7 +114,8 @@ func TestProjectReportSeenCannotDistinguishSightFromALookalikePayload(t *testing
 	lookalike := sightPayloadBytes(t, 1, 2) // could be any future channel's bytes that
 	// happen to parse as {x,y}; today it can only actually be sight.
 
-	got := projectReportSeen(lookalike)
+	got := projectReportSeen(lookalike, true)
 	require.NotNil(t, got, "documents the gap: any {x,y}-shaped payload decodes, whatever channel actually produced it")
 	require.Equal(t, spatial.Position{X: 1, Y: 2}, got.Position)
+	require.Equal(t, StandingDowned, got.Standing, "the down flag still projects even through the gap")
 }

--- a/rulebooks/dnd5e/session/sentinels_test.go
+++ b/rulebooks/dnd5e/session/sentinels_test.go
@@ -387,22 +387,16 @@ func (s *SentinelSuite) TestEndingATurnWhileFreeRoaming() {
 	s.refusedInOurVocabulary(err, session.ErrNotInFight)
 }
 
-// TestASwingWithAnEmptyHand is the resolution module's headline case, and the
-// reason the second list above exists.
-//
-// A character with nothing in the main hand is refused rather than falling back
-// to an unarmed strike, which makes this the first refusal any host meets that
-// comes from the rules rather than from the map — a party member who unequipped
-// and forgot, or a sheet seeded without a weapon. The compiler asks resolution
-// to read the attack off the sheet, resolution says it cannot, and its sentinel
-// rode out under ours.
-func (s *SentinelSuite) TestASwingWithAnEmptyHand() {
-	mgr := s.armedDuel(newFakeCharacters(dwarfCharacter("alice"), armedFighter("bob")))
+// TestASwingWithAnEmptyHandIsNotRefused pins the other side of rpg-toolkit#1168
+// at this seam: a character with nothing in the main hand swings anyway — an
+// unarmed strike, the rule rather than a gap — so this is no longer among the
+// refusals a host meets from the rules. See attack_test.go's
+// TestAnEmptyHandThrowsAnUnarmedStrike for the numbers.
+func (s *SentinelSuite) TestASwingWithAnEmptyHandIsNotRefused() {
+	mgr := s.armedDuel(newFakeCharacters(unarmedFighter("alice"), armedFighter("bob")))
 
 	err := s.swing(mgr)
-	s.refusedInOurVocabulary(err, session.ErrBadAttack)
-	s.Contains(err.Error(), "alice",
-		"and the refusal still names who could not swing")
+	s.NoError(err)
 }
 
 // TestOneSheetStoredUnderTwoNames drives the resolution module's own validation

--- a/rulebooks/dnd5e/session/turn.go
+++ b/rulebooks/dnd5e/session/turn.go
@@ -53,6 +53,53 @@ type TurnOutput struct {
 	// Order is the initiative order of the fight they are in, first to act
 	// first. Empty on the world clock.
 	Order []string `json:"order,omitempty"`
+
+	// Participants is the same members as Order, in the same order, each
+	// with what a bare id cannot carry: name, kind, standing, and whether
+	// they are the active one. Empty on the world clock. Order stays for
+	// the readers it already has — a new client reads this and never joins
+	// the two. Lands with rpg-toolkit#1137.
+	//
+	// NOT A ROSTER READ, and the line matters because this seam refuses one
+	// on purpose (see Manager.Where). Participants are the members of the
+	// fight the asker is IN — two sides that have, by construction, seen
+	// each other — so nothing here leaks a cell or a member the asker has
+	// not perceived. There is no position on it for that reason: where a
+	// participant stands is View's answer, gated by sight.
+	Participants []Participant `json:"participants,omitempty"`
+}
+
+// Participant is one member of the fight the asker is in, as TurnOutput
+// reports them. Lands with rpg-toolkit#1137.
+type Participant struct {
+	// Member is the member's id, as it appears in Order.
+	Member string `json:"member"`
+
+	// Name is the display name. Never empty for a member the server can
+	// name — which is every member it can list.
+	Name string `json:"name"`
+
+	// Kind categorises the member.
+	Kind MemberKind `json:"kind"`
+
+	// Standing is on their feet or downed.
+	//
+	// A DOWNED PARTICIPANT DOES NOT LINGER HERE. This mirrors Order exactly
+	// (Participants is a projection of it, never a second opinion about who
+	// belongs), and the composition splices a body out of Order the moment
+	// it notices one (encounter.noticeDown, rpg-toolkit#1078: "a body keeps
+	// no turn, and the order closes over the gap rather than holding it
+	// open"). Standing is still meaningful here, though: a member reported
+	// active or seated in an initiative order this call already trusts can
+	// still, in principle, be down for one beat before the next sight
+	// refresh notices — Where, View and Story all keep answering about a
+	// downed member regardless of whether Order still holds them.
+	Standing Standing `json:"standing"`
+
+	// Active is whether it is this member's turn. Exactly one true on the
+	// turn clock — the same member TurnOutput.Active names — so a caller
+	// marks the active row without a lookup.
+	Active bool `json:"active"`
 }
 
 // Turn reports what one member is waiting on.
@@ -85,7 +132,11 @@ func (m *Manager) Turn(ctx context.Context, in *TurnInput) (*TurnOutput, error) 
 		return nil, fmt.Errorf("turn: %w", ErrNoMemberID)
 	}
 
-	enc, err := m.open(ctx, in.Session)
+	data, err := m.loadSessionData(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("turn: %w", err)
+	}
+	enc, err := m.loadWorld(ctx, data)
 	if err != nil {
 		return nil, fmt.Errorf("turn: %w", err)
 	}
@@ -95,7 +146,61 @@ func (m *Manager) Turn(ctx context.Context, in *TurnInput) (*TurnOutput, error) 
 		return nil, fmt.Errorf("turn: %w", translate(err))
 	}
 
-	return projectTurn(clock), nil
+	participants, err := m.participantsFor(ctx, data, enc, clock)
+	if err != nil {
+		return nil, fmt.Errorf("turn: %w", err)
+	}
+
+	out := projectTurn(clock)
+	out.Participants = participants
+	return out, nil
+}
+
+// participantsFor builds the Participant list a TurnOutput reports: the
+// same members Order names, each with a display name, kind, standing, and
+// whether they are the active one — what a bare id on Order cannot carry
+// (rpg-toolkit#1137). Nil on the world clock, where Order is empty too.
+func (m *Manager) participantsFor(
+	ctx context.Context, data *SessionData, enc *encounter.Encounter, clock *encounter.ClockOfOutput,
+) ([]Participant, error) {
+	if len(clock.Order) == 0 {
+		return nil, nil
+	}
+
+	roster, err := enc.Members()
+	if err != nil {
+		return nil, translate(err)
+	}
+	names := rosterNames(roster)
+	kinds := make(map[string]encounter.MemberKind, len(roster))
+	for _, member := range roster {
+		kinds[string(member.ID)] = member.Kind
+	}
+
+	// The same capability every other standing consult in this package
+	// uses (standing.go) — asked fresh, not cached, exactly as the
+	// composition's own consults are.
+	downSet, err := standingSet(m.standingFor(ctx, data), clock.Order)
+	if err != nil {
+		return nil, err
+	}
+
+	out := make([]Participant, 0, len(clock.Order))
+	for _, id := range clock.Order {
+		key := string(id)
+		st := StandingUp
+		if downSet[key] {
+			st = StandingDowned
+		}
+		out = append(out, Participant{
+			Member:   key,
+			Name:     names[key],
+			Kind:     MemberKind(kinds[key]),
+			Standing: st,
+			Active:   key == string(clock.Active),
+		})
+	}
+	return out, nil
 }
 
 // EndTurnInput ends one member's turn in the fight they are in.

--- a/rulebooks/dnd5e/session/turn_test.go
+++ b/rulebooks/dnd5e/session/turn_test.go
@@ -283,3 +283,51 @@ func (s *TurnTestSuite) TestTheTurnEndingReachesClients() {
 	s.Positive(kinds[session.EventTurnEnded], "the turn ending is a kind, not a mystery")
 	s.Zero(kinds[session.EventUnknown], "and nothing else in this verb is one either")
 }
+
+// TestTurnCarriesParticipants pins rpg-toolkit#1137: a cold client reading
+// Turn learns names, kinds, standing and who is active from the SAME read
+// that already gave it Order — no second lookup, no roster read this seam
+// otherwise refuses to offer.
+func (s *TurnTestSuite) TestTurnCarriesParticipants() {
+	// SetupTest already started ambushWorld — alice and the ogre, neither
+	// carrying a Name (buildAmbush's own fixture predates rpg-toolkit#1137).
+	// That is fine: the point of this test is the PROJECTION reaching
+	// Participant correctly, not the authoring, so Name is asserted as
+	// empty rather than faked.
+	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 2, Y: 1}, {X: 2, Y: 2}, {X: 2, Y: 3}, {X: 2, Y: 4}},
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.Formed, "the scene must actually put them in a fight")
+
+	turn, err := s.mgr.Turn(context.Background(), &session.TurnInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	s.Require().Len(turn.Participants, len(turn.Order), "Participants mirrors Order one for one")
+
+	byID := make(map[string]session.Participant, len(turn.Participants))
+	for _, p := range turn.Participants {
+		byID[p.Member] = p
+	}
+
+	alice, ok := byID["alice"]
+	s.Require().True(ok)
+	s.Equal(session.KindPlayer, alice.Kind)
+	s.Equal(session.StandingUp, alice.Standing)
+	s.Empty(alice.Name, "this fixture never authored one — see the comment above")
+
+	ogre, ok := byID["ogre"]
+	s.Require().True(ok)
+	s.Equal(session.KindMonster, ogre.Kind)
+	s.Equal(session.StandingUp, ogre.Standing)
+
+	// Exactly one Active, and it is the same member TurnOutput.Active names.
+	activeCount := 0
+	for _, p := range turn.Participants {
+		if p.Active {
+			activeCount++
+			s.Equal(turn.Active, p.Member)
+		}
+	}
+	s.Equal(1, activeCount)
+}

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -548,9 +548,123 @@ type Event struct {
 	// Kind names what happened.
 	Kind EventKind `json:"kind"`
 
-	// Payload is the kind-specific body, encoded by this package.
+	// Payload is the kind-specific body, encoded by this package. REMAINS
+	// FOR KINDS NOT YET TYPED — a client reads Body and never decodes this,
+	// not as a fallback, not for a field it wishes were typed (rpg-toolkit#941).
 	Payload []byte `json:"payload,omitempty"`
+
+	// Body is the beat, typed: a sealed interface with one struct per kind
+	// that has one, decoded from the SAME payload this package already
+	// wrote rather than a second encoding of it (rpg-toolkit#941). Nil for
+	// a kind with no typed body member (JOINED, EXITED, ENDED,
+	// SCENE_OPENED, TICK, UNKNOWN) and for a beat this build's decoder does
+	// not recognise — see decodeBeat.
+	Body EventBody `json:"-"`
 }
+
+// EventBody is the beat, typed — a sealed interface with one struct per
+// kind Event.Body carries: TurnEndedBody, DownedBody, StruckBody,
+// MissedBody, FightStartedBody, FightEndedBody, MovedBody. Sealed the way
+// DissolveCause is (dissolve.go) and for the same reason: a caller matches
+// on it with a type switch, and a second implementation declared outside
+// this package would be indistinguishable from these to anyone reading the
+// switch.
+//
+// ONE-TO-ONE WITH EventKind where a body exists (rpg-toolkit#941). A kind
+// with no body member here leaves Event.Body nil and is read from Kind
+// alone.
+type EventBody interface {
+	// isEventBody seals the set.
+	isEventBody()
+}
+
+// TurnEndedBody is EventTurnEnded's typed body: a member's turn ended and
+// the order moved on. Also "X's turn" as a moment — one of these per driven
+// member, so a monster's turn is a visible beat rather than a gap between
+// two of a player's.
+type TurnEndedBody struct {
+	// Member is whose turn ended.
+	Member string `json:"member"`
+	// Next is whose turn it is now.
+	Next string `json:"next"`
+}
+
+func (TurnEndedBody) isEventBody() {}
+
+// DownedBody is EventDowned's typed body: who is at zero hit points and out
+// of the fight. Who, and nothing else — see EventDowned's own doc for why
+// hit points are not here.
+type DownedBody struct {
+	Member string `json:"member"`
+}
+
+func (DownedBody) isEventBody() {}
+
+// StruckBody is EventStruck's typed body: an attack landed. The numbers
+// AttackOutput gives the attacker, here for every witness, plus what was
+// swung.
+type StruckBody struct {
+	Attacker string `json:"attacker"`
+	Target   string `json:"target"`
+	// Roll is the d20 as rolled.
+	Roll int `json:"roll"`
+	// Total is the roll plus everything the attack chain added.
+	Total int `json:"total"`
+	// Against is the number the total had to reach.
+	Against int `json:"against"`
+	// Damage is what was dealt. Never zero on a Struck; a miss is a Missed.
+	Damage int `json:"damage"`
+	// Attack is what was swung — ref, name, damage type.
+	Attack   AttackRef `json:"attack"`
+	Critical bool      `json:"critical"`
+}
+
+func (StruckBody) isEventBody() {}
+
+// MissedBody is EventMissed's typed body: an attack did not land. A
+// separate body from StruckBody rather than one with a Damage of zero — a
+// whiff is a different animation, sound and sentence — and it carries no
+// damage field at all so "missed for 0" cannot be said.
+type MissedBody struct {
+	Attacker string    `json:"attacker"`
+	Target   string    `json:"target"`
+	Roll     int       `json:"roll"`
+	Total    int       `json:"total"`
+	Against  int       `json:"against"`
+	Attack   AttackRef `json:"attack"`
+}
+
+func (MissedBody) isEventBody() {}
+
+// FightStartedBody is EventFightStarted's typed body: two sides came into
+// contact and a fight began. Delivered to every member of the encounter, in
+// or out of the fight.
+type FightStartedBody struct {
+	// Members is the fight's members in initiative order, first to act
+	// first.
+	Members []string `json:"members"`
+}
+
+func (FightStartedBody) isEventBody() {}
+
+// FightEndedBody is EventFightEnded's typed body: a fight dissolved and its
+// members returned to free roam. Cause says why, in the same enum
+// DissolveOutput.Cause speaks.
+type FightEndedBody struct {
+	Cause DissolveKind `json:"cause"`
+}
+
+func (FightEndedBody) isEventBody() {}
+
+// MovedBody is EventMoved's typed body: a member stepped to a new cell.
+// One body per step — a walk of four cells is four of these, each with its
+// own Event.Seq.
+type MovedBody struct {
+	Member string           `json:"member"`
+	To     spatial.Position `json:"to"`
+}
+
+func (MovedBody) isEventBody() {}
 
 // SaveReport names which aggregates were persisted by a verb and which were
 // not.

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -714,6 +714,100 @@ type AttackRef struct {
 	DamageType DamageType `json:"damage_type"`
 }
 
+// ShortfallReason names WHY a declaration is unaffordable, as a value a UI
+// can act on rather than prose it can only repeat. Lands with
+// rpg-toolkit#1010 (reach) and the structured Shortfall it carries.
+//
+// Each value is one of the refusals the matching verb would give, named
+// here BEFORE the refusal — the same promise Afford has always made,
+// extended from the economy to the turn and to reach. A client greys a
+// target for NoTargetInReach and dims a shape for NoBudget; it never
+// parses Text to tell them apart.
+type ShortfallReason string
+
+const (
+	// ShortfallNoBudget is the currency running out — what Attack refuses
+	// as ErrCannotAfford ("action: 1 needed, 0 left"). Currency, Needed and
+	// Left are populated.
+	ShortfallNoBudget ShortfallReason = "no_budget"
+
+	// ShortfallNotYourTurn is it not being this member's turn — what
+	// Attack, Move and EndTurn refuse as ErrNotYourTurn.
+	ShortfallNotYourTurn ShortfallReason = "not_your_turn"
+
+	// ShortfallNoTargetInReach is nothing to swing at within reach — what
+	// Attack refuses as ErrOutOfReach (rpg-toolkit#1010). The one shortfall
+	// that arrives on a declaration with no Target: when no candidate is
+	// in reach, Afford still says so, once, rather than saying nothing.
+	ShortfallNoTargetInReach ShortfallReason = "no_target_in_reach"
+
+	// ShortfallDowned is the member being downed and unable to act — what
+	// the verbs refuse as ErrDowned.
+	ShortfallDowned ShortfallReason = "downed"
+
+	// ShortfallUnreadable is the rulebook being unable to compile this
+	// member's price — the sheet is unreadable (ErrBadAttack for anything
+	// but an empty hand, which compiles to the unarmed strike instead,
+	// rpg-toolkit#1168). Afford reports it rather than failing the read,
+	// so the rest of the declarations still arrive.
+	ShortfallUnreadable ShortfallReason = "unreadable"
+)
+
+// Currency names which of a turn's budgets a NO_BUDGET shortfall ran out
+// of. Lands with the structured Shortfall (rpg-project#249).
+//
+// This is the economy's word for what ran out — it is NOT Slot, although
+// three values coincide. Slot says which shape a declaration LIGHTS;
+// Currency says which ledger a refusal DRAINED, and movement is a ledger
+// with no shape. The two are kept separate so a client that lights shapes
+// never has to treat feet as a fourth one.
+type Currency string
+
+const (
+	// CurrencyAction is the standard action.
+	CurrencyAction Currency = "action"
+	// CurrencyBonus is the bonus action.
+	CurrencyBonus Currency = "bonus"
+	// CurrencyReaction is the reaction.
+	CurrencyReaction Currency = "reaction"
+	// CurrencyMovement is feet, not a count — Needed and Left on a MOVEMENT
+	// shortfall are in feet, at the server's five per cell.
+	CurrencyMovement Currency = "movement"
+)
+
+// Shortfall is the structured reason a declaration cannot be paid for.
+// Lands with rpg-toolkit#1010 as the seam's own answer to "why not."
+//
+// STRUCTURED SO THE UI CAN ACT ON IT; TEXT STAYS FOR NARRATION. The string
+// form alone ("action: 1 needed, 0 left") is enough to repeat a refusal in
+// the player's own words and not enough to do anything else with it —
+// Reason is what it branches on, Currency/Needed/Left are the figures it
+// shows, and Text is what it says. The three agree by construction: Text is
+// rendered from the other four, never the reverse.
+type Shortfall struct {
+	// Reason is what kind of refusal this is. Always set.
+	Reason ShortfallReason `json:"reason"`
+
+	// Currency is which ledger ran out. Set for NoBudget; empty for every
+	// other reason, which has no currency to name.
+	Currency Currency `json:"currency,omitempty"`
+
+	// Needed is how much the verb costs, in that currency's unit (feet for
+	// MOVEMENT, a count otherwise). Meaningful for NoBudget; zero
+	// otherwise.
+	Needed int `json:"needed,omitempty"`
+
+	// Left is how much is left. Meaningful for NoBudget; zero otherwise —
+	// and a real zero, which is the usual case.
+	Left int `json:"left,omitempty"`
+
+	// Text is the refusal in the SDK's own words — "action: 1 needed, 0
+	// left", "movement: 20 ft needed, 15 ft left", "not your turn", "no
+	// target in reach". The same text Declaration.Shortfall carries and the
+	// same text the verb's own refusal error would.
+	Text string `json:"text"`
+}
+
 // Discovery is what changed in one observer's perception.
 //
 // Three disjoint lists rather than a single "here is everything you now

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -288,12 +288,48 @@ type MemberOutcome struct {
 type Seen struct {
 	// Position is the sighted subject's cell, dungeon-absolute.
 	Position spatial.Position `json:"position"`
+
+	// Standing is whether the sighted subject is on their feet.
+	// SIGHT-CHANNEL KNOWLEDGE, not roster truth: an observer who can see a
+	// member can see whether they are standing, which is why it belongs
+	// inside Seen and not on a roster read this seam deliberately lacks.
+	// A memory (CurrentVia empty) keeps the standing it last saw, exactly
+	// as it keeps the position. Lands with rpg-toolkit#1137.
+	Standing Standing `json:"standing"`
 }
+
+// Standing says whether a member is still on their feet. Lands with
+// rpg-toolkit#1137.
+//
+// A READ, NOT A REPLAY DEPENDENCY: the composition has known the answer all
+// along — it asks the rulebook who is standing at every sight refresh — so
+// this is that answer projected onto Participant and Seen, the same
+// treatment Where gives position.
+//
+// TWO VALUES, AND NOT "DOWN". Downed is at zero hit points and out of the
+// fight; a bare "down" also reads as PRONE, a posture condition on a member
+// still acting (Kirk's ruling, rpg-toolkit#1084 — see ErrDowned).
+type Standing string
+
+const (
+	// StandingUp is on their feet, in the fight.
+	StandingUp Standing = "up"
+	// StandingDowned is at zero hit points, out of the fight — still on the
+	// map and in the roster.
+	StandingDowned Standing = "downed"
+)
 
 // Sighting is one thing an observer currently perceives.
 type Sighting struct {
 	// Subject names what is perceived.
 	Subject string `json:"subject"`
+
+	// Name is the sighted subject's display name — "skeleton-1", not a ref
+	// or an id. Beside Subject so a client labels what it draws and
+	// narrates what it sees without a second lookup. Names are not a
+	// perception question: anything an observer can sight, they can name.
+	// Lands with rpg-toolkit#1137.
+	Name string `json:"name,omitempty"`
 
 	// Seen is the sight channel's own typed knowledge; see [Seen]. Decoded by
 	// the composition, not by this package — session never unmarshals

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -561,6 +561,11 @@ type Member struct {
 	// Kind categorises the member.
 	Kind MemberKind `json:"kind"`
 
+	// Name is the member's display name — "skeleton-1", not a ref or an id.
+	// Never empty for a member the composition can name, which is every
+	// member it can place (rpg-toolkit#1137).
+	Name string `json:"name,omitempty"`
+
 	// Position is the cell they stand on, in dungeon-absolute space.
 	//
 	// It replaced a room id, and the swap is the reshape in one field: which
@@ -656,6 +661,57 @@ type MonsterState struct {
 	// ProficiencyBonus is the monster's proficiency bonus, derived from its
 	// challenge rating.
 	ProficiencyBonus int `json:"proficiency_bonus"`
+}
+
+// DamageType names the kind of damage an attack deals: the rulebook's own
+// thirteen. Lands with rpg-toolkit#866, carried on AttackRef.
+//
+// A CLOSED SET, SO A GO TYPE A CLIENT-FACING ENUM CAN MIRROR (Kirk,
+// rpg-project#249 §6): a UI branches on it — a colour, a sound, a word in
+// the beat line ("6 slashing") — and thirteen is the whole of 5e's list,
+// sealed by the rulebook rather than open to a catalog. Compare AttackRef.Ref,
+// which is an OPEN set and stays a string.
+//
+// The string values match damage.Type's own exactly, on purpose: this type
+// exists so a host mapping onto a proto enum has something to switch on
+// without importing the rulebook's own damage package across the boundary
+// (S2), not to invent a second vocabulary for the same thirteen words.
+type DamageType string
+
+// The rulebook's thirteen damage types, mirroring damage.Type.
+const (
+	DamageAcid        DamageType = "acid"
+	DamageBludgeoning DamageType = "bludgeoning"
+	DamageCold        DamageType = "cold"
+	DamageFire        DamageType = "fire"
+	DamageForce       DamageType = "force"
+	DamageLightning   DamageType = "lightning"
+	DamageNecrotic    DamageType = "necrotic"
+	DamagePiercing    DamageType = "piercing"
+	DamagePoison      DamageType = "poison"
+	DamagePsychic     DamageType = "psychic"
+	DamageRadiant     DamageType = "radiant"
+	DamageSlashing    DamageType = "slashing"
+	DamageThunder     DamageType = "thunder"
+)
+
+// AttackRef identifies WHAT was swung — weapon identity, which this seam
+// dropped on the floor since the first swing (rpg-toolkit#866). Carried on
+// AttackOutput and on the Struck/Missed event bodies, so a beat line can say
+// "6 slashing" and "with a longsword" for every witness, not only the
+// attacker whose own verb response held the compiled profile.
+type AttackRef struct {
+	// Ref is the catalog ref the attack compiled from — "longsword",
+	// "unarmed-strike". An OPEN set, so a string: the client already maps
+	// refs to models and icons, and the catalog grows without this type
+	// changing.
+	Ref string `json:"ref"`
+
+	// Name is the catalog's display name — "Longsword", "Unarmed Strike".
+	Name string `json:"name"`
+
+	// DamageType is the kind of damage it deals. Closed set — see DamageType.
+	DamageType DamageType `json:"damage_type"`
 }
 
 // Discovery is what changed in one observer's perception.

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -211,6 +211,11 @@ func (m *Manager) Join(ctx context.Context, in *JoinInput) (*JoinOutput, error) 
 		return nil, fmt.Errorf("join: %w", err)
 	}
 
+	down, err := discoveryStanding(scope)
+	if err != nil {
+		return nil, fmt.Errorf("join: %w", err)
+	}
+
 	report, delivery, err := m.commit(ctx, scope)
 	if err != nil {
 		return nil, fmt.Errorf("join: %w", err)
@@ -219,13 +224,30 @@ func (m *Manager) Join(ctx context.Context, in *JoinInput) (*JoinOutput, error) 
 	return &JoinOutput{
 		Member:     projectMember(placed.Member),
 		Character:  projectCharacter(ch),
-		Discovered: projectDiscoveries(placed.IntelDeltas),
+		Discovered: projectDiscoveries(placed.IntelDeltas, down),
 		Seq:        placed.Seq,
 		Outcome:    projectOutcome(placed.Outcome),
 		Formed:     projectFormed(placed.Formed),
 		Saved:      report,
 		Delivery:   delivery,
 	}, nil
+}
+
+// discoveryStanding batches a down-check over the WHOLE roster this scope's
+// encounter now holds, for projecting Discovery/Sighting's Seen.Standing
+// (rpg-toolkit#1137): a discovery's first-contact reports can name anyone
+// the observer just perceived, so the safe set to ask about is everyone,
+// asked once per verb rather than once per report.
+//
+// Fetched BEFORE commit, deliberately: a failure here must leave nothing
+// persisted (R5 atomicity), the same discipline every other pre-commit
+// check in this file already keeps.
+func discoveryStanding(scope *writeScope) (map[string]bool, error) {
+	roster, err := scope.enc.Members()
+	if err != nil {
+		return nil, translate(err)
+	}
+	return standingSet(scope.standing, rosterIDs(roster))
 }
 
 // Spawn instantiates content that lives in code and places it as a new member.
@@ -319,6 +341,11 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 		return nil, fmt.Errorf("spawn: %w", err)
 	}
 
+	down, err := discoveryStanding(scope)
+	if err != nil {
+		return nil, fmt.Errorf("spawn: %w", err)
+	}
+
 	report, delivery, err := m.commit(ctx, scope)
 	if err != nil {
 		return nil, fmt.Errorf("spawn: %w", err)
@@ -327,7 +354,7 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 	return &SpawnOutput{
 		Member:     projectMember(placed.Member),
 		NPC:        projectMonster(sheet),
-		Discovered: projectDiscoveries(placed.IntelDeltas),
+		Discovered: projectDiscoveries(placed.IntelDeltas, down),
 		Seq:        placed.Seq,
 		Outcome:    projectOutcome(placed.Outcome),
 		Formed:     projectFormed(placed.Formed),
@@ -397,6 +424,15 @@ func (m *Manager) Exit(ctx context.Context, in *ExitInput) (*ExitOutput, error) 
 		return nil, fmt.Errorf("exit: %w", translate(err))
 	}
 
+	roster, err := scope.enc.Members()
+	if err != nil {
+		return nil, fmt.Errorf("exit: %w", translate(err))
+	}
+	down, err := standingSet(scope.standing, rosterIDs(roster))
+	if err != nil {
+		return nil, fmt.Errorf("exit: %w", err)
+	}
+
 	report, delivery, err := m.commit(ctx, scope)
 	if err != nil {
 		return nil, fmt.Errorf("exit: %w", err)
@@ -404,7 +440,7 @@ func (m *Manager) Exit(ctx context.Context, in *ExitInput) (*ExitOutput, error) 
 
 	return &ExitOutput{
 		Outcome:  projectMemberOutcome(left.Outcome),
-		Carry:    projectSightings(left.Carry),
+		Carry:    projectSightings(left.Carry, rosterNames(roster), down),
 		Seq:      left.Seq,
 		Closed:   projectOutcome(left.Closed),
 		Saved:    report,

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -206,7 +206,7 @@ func (m *Manager) Join(ctx context.Context, in *JoinInput) (*JoinOutput, error) 
 		return nil, fmt.Errorf("join: %w", err)
 	}
 
-	placed, err := place(scope, in.Member, KindPlayer, in.Position)
+	placed, err := place(scope, in.Member, KindPlayer, ch.GetName(), in.Position)
 	if err != nil {
 		return nil, fmt.Errorf("join: %w", err)
 	}
@@ -314,7 +314,7 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 	scope.data.NPCs = append(scope.data.NPCs, *sheet)
 	scope.touched = true
 
-	placed, err := place(scope, in.ID, KindMonster, in.Position)
+	placed, err := place(scope, in.ID, KindMonster, sheet.Name, in.Position)
 	if err != nil {
 		return nil, fmt.Errorf("spawn: %w", err)
 	}
@@ -348,7 +348,7 @@ func (m *Manager) Spawn(ctx context.Context, in *SpawnInput) (*SpawnOutput, erro
 // Setup and Load were made to share one validator so that a single mutation
 // kills the pins on both. Same reasoning, one layer up.
 func place(
-	scope *writeScope, id string, kind MemberKind, at spatial.Position,
+	scope *writeScope, id string, kind MemberKind, name string, at spatial.Position,
 ) (*encounter.JoinOutput, error) {
 	// This used to resolve the cell to a room first, because the composition's
 	// verbs were room-local by law and somebody had to say which chamber owned
@@ -364,6 +364,7 @@ func place(
 	placed, err := scope.enc.Join(&encounter.JoinInput{
 		Member: encounter.MemberID(id),
 		Kind:   encounter.MemberKind(kind),
+		Name:   name,
 		Cell:   at,
 	})
 	if err != nil {


### PR DESCRIPTION
## What

Closes #1010, #1137, #941, #866. Design: rpg-project#249 (ruled 2026-08-22). Part 3 of 3 (encounter → resolution → **session**), stacked on `main` (which already carries #1171, Move on the turn clock).

**Depends on #1172 (encounter) and #1173 (resolution)**, not yet merged — `go.mod` currently pins their pushed-branch pseudo-versions:
```
rulebooks/dnd5e/encounter v0.30.2-0.20260822090354-20689f95d426   (feat/turn-encounter)
rulebooks/dnd5e/resolution v0.11.2-0.20260822092020-0a649305420b (feat/turn-resolution, includes the Reach follow-up commit)
```
**This PR is not mergeable as-is** — `go.mod` needs a final re-pin to tagged releases once #1172/#1173 land. I'll do that re-pin (or it's a two-line `go get` + commit) once both are tagged; flagging now so it isn't missed.

### 1. Reach (session.Attack + Afford)

- `Attack` refuses `ErrNotYourTurn` (non-active member of a turn-clock fight) and `ErrOutOfReach` (target beyond the compiled weapon's reach) before pricing — both checked cheaply (no sheet load) before anything that touches one.
- `Encounter.Distance` (toolkit#1172) exposes the composition's own grid distance; `AttackProfile.Reach` (toolkit#1173) carries melee 1 cell / Reach-property 2 cell, ported from the retired top-level `encounter/range_gate.go`.
- `Afford` now emits one `Declaration{Verb: attack, Target, Slot, Affordable, Why}` per live-sighted candidate in reach (View's holdings ∩ reach), all sharing ONE `combat.Pay` call's answer (paying per-candidate would double-spend the loaded sheet). No candidate in reach → one declaration, no `Target`, `Why.Reason: NoTargetInReach`.

### 2. Structured shortfall

`Shortfall{Reason, Currency, Needed, Left, Text}` + `ShortfallReason` (NoBudget/NotYourTurn/NoTargetInReach/Downed/Unreadable) + `Currency` (Action/Bonus/Reaction/Movement). `Declaration.Why *Shortfall` alongside the existing `Shortfall string` (superseded, kept for old readers — a producer sets both). Read off the SAME `SlotsLeft`/`CapacityLeft` state `combat.Pay`'s own check consults, never by parsing its error text. Move's declaration carries it too.

`Afford` also now reports `Downed` and `Unreadable` (toolkit#1168's other half — an unknown weapon ref becomes a declaration, not a failed read) as blocking states for BOTH declarations, ordered NOT_YOUR_TURN → DOWNED → UNREADABLE (cheapest/no-sheet-load check first — matches the precedence Copilot caught on #1171 for Move, and I found the same ordering bug in my own first pass here before `TestNotActiveWinsOverAffordability` caught it).

### 3. Names + standing (closes #1137)

- `Participant{Member,Name,Kind,Standing,Active}` + `TurnOutput.Participants`, mirroring `Order` one-for-one.
- `Sighting.Name`, `Seen.Standing` (on both `Sighting` and `Report`) — threaded through `View`, `Join`, `Spawn`, `Exit`, `Move`, all via batched roster+`Standing()` lookups (`rosterlookup.go`), never a call per member.
- **Design discrepancy found, not papered over**: the wire design's own `Participant` comment says "a downed participant stays in the order; they do not act." The composition already does the opposite (`encounter.noticeDown`, toolkit#1078: "the order closes over the gap rather than holding it open"), deliberately and well-reasoned on its own terms. `Participant` mirrors `Order`'s actual behavior — stated explicitly in its doc comment now — rather than re-adding what the composition removed. **Worth fixing in the design doc / proto comment**; I did not touch `encounter`'s splice behavior, which is out of scope and correct as-is.

### 4. Typed event bodies (closes #941) + weapon identity (closes #866)

- `EventBody` sealed interface (`isEventBody()`, matching `DissolveCause`'s existing pattern) — `TurnEndedBody`, `DownedBody`, `StruckBody`, `MissedBody`, `FightStartedBody`, `FightEndedBody`, `MovedBody`. `Event.Body` carries it; `Payload` remains for untyped kinds and as passthrough.
- `kindOf`'s JSON-sniffing is deleted, replaced by `decodeBeat` → `kindFor` (total over the composition's declared `"beat"` string alone) + `bodyFor` (best-effort typed decode). Splitting these fixed a real bug in my first draft: a combined version demoted a correctly-identified `struck` beat to `EventUnknown` when a minimal fixture payload was missing `actor`/`targets` — `TestTheOutcomeBeatsAreTheCompositionsOwnStrings` caught it.
- `AttackOutput.Attack AttackRef{Ref,Name,DamageType}` — from the compiled profile, `DamageType` a closed Go type mirroring `damage.Type`'s 13 values (string-identical, so it's a direct cast). Carried on `Struck`/`Missed` beats too, via `encounter.RecordInput.Attack` (toolkit#1172) — every witness gets weapon identity, not only the attacker's own response.

## Exact Go shapes rpg-api needs to project

```go
// session/types.go
type Standing string                    // "up" | "downed"
type DamageType string                  // 13 values, string-identical to damage.Type
type AttackRef struct { Ref, Name string; DamageType DamageType }
type ShortfallReason string             // no_budget | not_your_turn | no_target_in_reach | downed | unreadable
type Currency string                    // action | bonus | reaction | movement
type Shortfall struct { Reason ShortfallReason; Currency Currency; Needed, Left int; Text string }

// session/turn.go
type Participant struct { Member, Name string; Kind MemberKind; Standing Standing; Active bool }
// TurnOutput gains: Participants []Participant

// session/afford.go — Declaration gains:
//   Target *string   (nil for VerbMove and the no-target-in-reach case)
//   Why    *Shortfall (present iff Affordable == false)

// session/attack.go — AttackOutput gains: Attack AttackRef

// session/errors.go: ErrOutOfReach = errors.New("no target in reach")
// session/errors.go: ErrNotYourTurn already existed (#1171)

// session/types.go — Sighting gains: Name string; Seen gains: Standing Standing

// session/events.go
type EventBody interface{ isEventBody() }
type TurnEndedBody struct{ Member, Next string }
type DownedBody struct{ Member string }
type StruckBody struct{ Attacker, Target string; Roll, Total, Against, Damage int; Attack AttackRef; Critical bool }
type MissedBody struct{ Attacker, Target string; Roll, Total, Against int; Attack AttackRef }
type FightStartedBody struct{ Members []string }
type FightEndedBody struct{ Cause DissolveKind }
type MovedBody struct{ Member string; To spatial.Position }
// Event gains: Body EventBody (a type switch on it, alongside the existing Kind)
```

## Testing

- `go test -race -count=1 ./...` — green throughout, ~30 new test cases across `afford_test.go`, `attack_test.go`, `turn_test.go`, `death_test.go`, `move_turnclock_test.go`, `attackevents_test.go`, `read_test.go`, plus internal fixes to `seen_internal_test.go`/`events_internal_test.go`/`convert_test.go` for the new function signatures the structural completeness guard (`TestEveryInnerFieldIsCarriedOrJustified`) forced.
- `golangci-lint run ./...` — 0 issues.
- `gorelease` — all changes compatible, suggests `v0.22.0` (full list in the run below).
- Existing unarmed-hand tests (`TestASwingWithAnEmptyHand`, empty-hand-refused in `attack_test.go`) rewritten as positive-path unarmed-strike assertions rather than deleted, since the toolkit#1168 behavior change is real and needs coverage on both sides of it.

## Merge order (unchanged from #1172/#1173)

1. #1172 (encounter)
2. #1173 (resolution)
3. **This PR** — re-pin `go.mod` to tagged versions once both above are tagged, then it's ready.

— asset-pipeline agent, on behalf of KirkDiggler