### PR TITLE
encounter: Record refuses an Attack with empty Ref or Name

### DIFF
--- a/rulebooks/dnd5e/encounter/outcome.go
+++ b/rulebooks/dnd5e/encounter/outcome.go
@@ -122,23 +122,20 @@ type RecordInput struct {
 // the beat can answer "with a longsword" and "6 slashing" for every witness,
 // not only the one whose own verb response held the compiled profile.
 //
-// PLAIN STRINGS, MEANT TO BE USED LIKE MemberID IS ON THIS INPUT — BUT NOT
-// CHECKED THE WAY MemberID IS (Copilot, PR #1172). Actor and Targets are
-// validated against the roster before anything is appended
-// (`e.members[in.Actor]`); nothing here validates Ref, Name or DamageType
-// against any catalog, because this module's go.mod cannot import the one
-// that would answer whether "longsword" is real (C1). The intended values
-// are the catalog's own identifier and display label — "longsword",
-// "Longsword" — and the rulebook's own word for the damage dealt, fixed by
-// a sealed weapon/action catalog rather than composed at the call site. But
-// that is a promise about session's one caller today, not a guarantee this
-// composition enforces: a caller that handed over prose here would have it
-// copied into the shared story payload unchecked, exactly like a raw
-// narration field would. What this struct is not is a NEW hole of that
-// shape — session's Attack() is the only caller in this codebase, and it
-// only ever supplies what resolution.AttackProfile already compiled — but a
-// reader auditing this input's "no prose" claim should read this note
-// rather than the comparison to Actor/Targets alone.
+// PLAIN STRINGS, MEANT TO BE USED LIKE MemberID IS ON THIS INPUT — CHECKED
+// FOR PRESENCE THE WAY MemberID IS, BUT NOT FOR MEANING (Copilot, PR #1172).
+// [Encounter.Record] refuses ErrInvalidData when Ref or Name is empty, the
+// same as it refuses an empty Actor — that is the minimum this composition
+// CAN check without a catalog. It does not, and cannot, validate that Ref or
+// Name names anything real, or that DamageType is one of the rulebook's own
+// words: this module's go.mod cannot import the catalog that would answer
+// whether "longsword" is real (C1). The intended values are the catalog's
+// own identifier and display label — "longsword", "Longsword" — and the
+// rulebook's own word for the damage dealt, fixed by a sealed weapon/action
+// catalog rather than composed at the call site, and it is session — which
+// already depends on that package — that maps DamageType onto a closed Go
+// type. The composition guarantees presence; the rulebook guarantees
+// meaning.
 type AttackIdentity struct {
 	// Ref is the catalog ref the attack compiled from — "longsword",
 	// "unarmed-strike".
@@ -230,8 +227,9 @@ type RecordOutput struct {
 //
 // Errors: ErrNilInput, ErrClosed, ErrNoMember (empty or unknown actor, unknown
 // target), ErrInvalidData (a kind or value name this composition does not
-// know), and anything the [Standing] capability answers with — including
-// ErrNotMember for an answer naming a stranger.
+// know, or an Attack whose Ref or Name is empty), and anything the
+// [Standing] capability answers with — including ErrNotMember for an answer
+// naming a stranger.
 //
 // The input refusals all run before anything is appended, so a rejected input
 // costs the rulebook nothing. The consult does not: it runs after the beat, so a
@@ -307,6 +305,12 @@ func (e *Encounter) Record(in *RecordInput) (*RecordOutput, error) {
 		payload["critical"] = in.Critical
 	}
 	if in.Attack != nil {
+		if in.Attack.Ref == "" {
+			return nil, fmt.Errorf("record: attack ref: %w", ErrInvalidData)
+		}
+		if in.Attack.Name == "" {
+			return nil, fmt.Errorf("record: attack name: %w", ErrInvalidData)
+		}
 		payload["attack"] = map[string]string{
 			"ref":         in.Attack.Ref,
 			"name":        in.Attack.Name,

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -179,17 +179,20 @@ func (s *OutcomeTestSuite) TestTheTargetHearsItToo() {
 // Critical is a bool — nothing to narrate. Attack is a pointer to
 // [encounter.AttackIdentity], meant to carry a catalog-owned identifier or
 // the rulebook's own closed word for what happened ("longsword",
-// "slashing") — not free text a caller composes for effect. Unlike Actor
-// and Targets, this input does NOT validate those fields against any
-// catalog (AttackIdentity's own doc, updated after Copilot's review on
-// PR #1172, says so plainly): the guarantee is a promise about session's
-// one caller, which only ever supplies what an already-compiled attack
-// profile named, not something this composition enforces. Widening
-// RecordInput to accept it was still the right call — it widens what a
-// caller can IDENTIFY, the same category Actor/Targets already occupy, not
-// what a caller can SAY — but "no prose" here is a narrower, softer claim
-// than it is for the validated fields beside it, and this test's list
-// growing is not evidence of the stronger one.
+// "slashing") — not free text a caller composes for effect. Record refuses
+// an Attack whose Ref or Name is empty (ErrInvalidData) — the same presence
+// floor Actor and Targets are already held to; see
+// TestRefusalsAreCheckedAgainstTheRoster. What it still cannot do is
+// validate that Ref or Name names anything real, or that DamageType is one
+// of the rulebook's own words: this module's go.mod cannot import the
+// catalog that would answer that (C1), so that half of the promise is
+// about session's one caller — which only ever supplies what an
+// already-compiled attack profile named — not something this composition
+// enforces. Widening RecordInput to accept Attack was still the right
+// call — it widens what a caller can IDENTIFY, the same category
+// Actor/Targets already occupy, not what a caller can SAY — and "no prose"
+// here now holds for presence exactly as it does for the fields beside it;
+// only meaning is still the rulebook's to guarantee.
 func (s *OutcomeTestSuite) TestAnOutcomeCarriesNoProse() {
 	s.Equal([]string{"Kind", "Actor", "Targets", "Values", "Critical", "Attack"},
 		structFieldNames(encounter.RecordInput{}),
@@ -248,6 +251,37 @@ func (s *OutcomeTestSuite) TestRefusalsAreCheckedAgainstTheRoster() {
 			Kind: encounter.OutcomeStruck, Actor: alice,
 		})
 		s.ErrorIs(err, encounter.ErrClosed)
+	})
+}
+
+// TestAnAttackWithNoRefOrNameIsRefused pins the minimum Record CAN check
+// about AttackIdentity without a catalog: Ref and Name are non-empty, held
+// to the same floor as Actor. What names is real, and what DamageType
+// means, stays the rulebook's to guarantee (AttackIdentity's own doc) —
+// this is presence, not meaning.
+func (s *OutcomeTestSuite) TestAnAttackWithNoRefOrNameIsRefused() {
+	s.Run("empty ref", func() {
+		_, err := s.scene().Record(&encounter.RecordInput{
+			Kind: encounter.OutcomeStruck, Actor: alice, Targets: []encounter.MemberID{goblin},
+			Attack: &encounter.AttackIdentity{Name: "Longsword", DamageType: "slashing"},
+		})
+		s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	})
+
+	s.Run("empty name", func() {
+		_, err := s.scene().Record(&encounter.RecordInput{
+			Kind: encounter.OutcomeStruck, Actor: alice, Targets: []encounter.MemberID{goblin},
+			Attack: &encounter.AttackIdentity{Ref: "longsword", DamageType: "slashing"},
+		})
+		s.Require().ErrorIs(err, encounter.ErrInvalidData)
+	})
+
+	s.Run("both empty", func() {
+		_, err := s.scene().Record(&encounter.RecordInput{
+			Kind: encounter.OutcomeStruck, Actor: alice, Targets: []encounter.MemberID{goblin},
+			Attack: &encounter.AttackIdentity{},
+		})
+		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	})
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #1172. Copilot flagged that `AttackIdentity`'s fields were
uncheckable there because the module can't import the catalog that would
answer whether "longsword" is real (C1) — and the first-round fix on #1172
just softened the doc comment to admit the gap, rather than enforcing what
this composition actually CAN check. Kirk's call: enforce, don't soften.

- `Record` now refuses `ErrInvalidData` when `in.Attack.Ref` or
  `in.Attack.Name` is empty, the same presence floor `Actor` is already
  held to. `DamageType` stays unchecked — that's the rulebook's to
  guarantee downstream (session), not this composition's.
- `AttackIdentity`'s doc comment and `TestAnOutcomeCarriesNoProse`'s doc
  are both updated so "no prose" is true again: presence is enforced here
  exactly like Actor/Targets; only catalog *meaning* is still deferred.
- New test: `TestAnAttackWithNoRefOrNameIsRefused` (empty ref, empty name,
  both empty).

This is the fix from the crossed message on #1172 that didn't land before
Kirk merged it (encounter v0.30.2) — reopened here against current `main`
per team-lead's follow-up instruction, using the simplified non-empty-only
spec (no ref-shape parsing, `AttackIdentity.Ref` stays a bare catalog id
exactly as the wire already expects).

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race -count=1 ./...` — all green (encounter + cmd/freeroam-workbench + dungeonspec)
- `golangci-lint run ./...` — 0 issues
- `gorelease` — backward compatible, suggests `v0.30.3`
- `./scripts/check-decisions.sh` — all 45 ADRs summarised (no new ADR needed for this fix)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu