### PR TITLE
resolution: distinguish a corrupt equipment slot from a genuinely empty one

### DIFF
--- a/rulebooks/dnd5e/resolution/character_attack.go
+++ b/rulebooks/dnd5e/resolution/character_attack.go
@@ -100,7 +100,13 @@ type CharacterAttackInput struct {
 //
 // ErrBadAttack still stands for what it always meant beyond that one case: a
 // sheet the rulebook cannot read — an unknown weapon ref, a slot holding
-// something that is not a weapon at all.
+// something that is not a weapon at all, or a slot whose entry names an item
+// that is not in inventory. That last one matters precisely because it looks
+// like the empty-hand case from the outside: both end with
+// [character.Character.GetEquippedSlot] returning nil. Only one of them is a
+// character choosing to fight bare-handed; the other is a record this
+// rulebook cannot trust, and conflating the two would compile a corrupt
+// sheet into a perfectly ordinary swing. See [equippedWeapon].
 func AttackFromCharacter(c *character.Character, in *CharacterAttackInput) (AttackProfile, error) {
 	if c == nil {
 		return AttackProfile{}, fmt.Errorf("%w: no character to compile", ErrNilInput)
@@ -188,8 +194,20 @@ func equippedWeapon(c *character.Character, slot character.InventorySlot) (weapo
 
 	equipped := c.GetEquippedSlot(slot)
 	if equipped == nil {
-		w := weapons.SpecialWeapons[weapons.UnarmedStrike]
-		return &w, true, nil
+		// GetEquippedSlot returning nil conflates two states this compiler must
+		// not: a slot with no entry at all — a genuinely empty hand, which 5e
+		// says is always an unarmed strike (rpg-toolkit#1168, see "An empty
+		// hand is not a refusal" above) — and a slot whose entry names an item
+		// that is not in inventory, which is an UNREADABLE SHEET, not an empty
+		// hand. Reading the slot entry directly (rather than trusting the
+		// resolved *EquippedItem) is what tells the two apart.
+		itemID := c.ToData().EquipmentSlots.Get(slot)
+		if itemID == "" {
+			w := weapons.SpecialWeapons[weapons.UnarmedStrike]
+			return &w, true, nil
+		}
+		return nil, false, fmt.Errorf(
+			"%w: %q names %q which is not in the inventory", ErrBadAttack, slot, itemID)
 	}
 
 	weapon = equipped.AsWeapon()

--- a/rulebooks/dnd5e/resolution/character_attack_test.go
+++ b/rulebooks/dnd5e/resolution/character_attack_test.go
@@ -644,6 +644,24 @@ func (s *CharacterAttackTestSuite) TestAnEmptyHandThrowsAnUnarmedStrike() {
 	s.Equal(5, profile.AttackBonus)
 }
 
+// TestACorruptSlotStaysErrBadAttack pins the other half of rpg-toolkit#1168's
+// fix: only a slot with NO entry in EquipmentSlots is an empty hand. A slot
+// whose entry NAMES an item that is not in inventory is a sheet this
+// rulebook cannot read, and must stay ErrBadAttack rather than being folded
+// into the same unarmed-strike substitution TestAnEmptyHandThrowsAnUnarmedStrike
+// pins — a corrupt record and a bare fist are not the same fact, even though
+// [character.Character.GetEquippedSlot] returns nil for both (design §2:
+// "ErrBadAttack only for unreadable sheets").
+func (s *CharacterAttackTestSuite) TestACorruptSlotStaysErrBadAttack() {
+	sheet := s.heroSheet(nil, nil)
+	sheet.EquipmentSlots = character.EquipmentSlots{character.SlotMainHand: "phantom-blade"}
+
+	_, err := AttackFromCharacter(s.load(sheet), s.mainHand())
+	s.Require().ErrorIs(err, ErrBadAttack)
+	s.Contains(err.Error(), "phantom-blade", "names what the slot claimed, for whoever debugs the corrupt record")
+	s.Contains(err.Error(), "not in the inventory")
+}
+
 // TestReach pins rpg-toolkit#1010's compiler half: a plain melee weapon
 // reaches 1 cell, a weapon carrying the Reach property reaches 2, and an
 // unarmed strike reaches 1 — the same numbers the retired top-level

--- a/rulebooks/dnd5e/resolution/errors.go
+++ b/rulebooks/dnd5e/resolution/errors.go
@@ -87,9 +87,12 @@ var (
 	// room refuses. The world is the caller's to hand over intact.
 	ErrBadWorld = errors.New("resolution: world data is unusable")
 
-	// ErrBadAttack indicates an action this build cannot read as an attack.
-	// Refused by name rather than treated as a generic swing, because guessing
-	// an attack bonus is how a stat block starts lying again.
+	// ErrBadAttack indicates an action this build cannot read as an attack —
+	// an unknown weapon ref, a slot holding something that is not a weapon,
+	// or an equipment slot whose entry names an item that is not in
+	// inventory (see equippedWeapon in character_attack.go). Refused by
+	// name rather than treated as a generic swing, because guessing an
+	// attack bonus is how a stat block starts lying again.
 	ErrBadAttack = errors.New("resolution: unreadable attack")
 
 	// ErrNoCombatant indicates a strike naming somebody who was not passed in.


### PR DESCRIPTION
## Summary

Follow-up to #1173. `equippedWeapon` treated `character.GetEquippedSlot(slot)
== nil` as a single state and substituted an unarmed strike for it — but
that call returns nil for TWO different sheet states:

1. A slot with no entry at all — a genuinely empty hand, which 5e says is
   always an unarmed strike (rpg-toolkit#1168).
2. A slot whose entry names an item that is not in inventory — an
   unreadable sheet.

Conflating them meant a corrupt record compiled into an ordinary swing
instead of being refused.

- `equippedWeapon` now reads the slot's raw entry via
  `character.ToData().EquipmentSlots.Get(slot)` to tell the two apart:
  empty entry → unarmed strike as before; entry naming a missing item →
  `ErrBadAttack`, formatted `%q names %q which is not in the inventory` so
  a debugger sees what the slot claimed.
- Design §2: "ErrBadAttack only for unreadable sheets."
- New test: `TestACorruptSlotStaysErrBadAttack`, placed beside
  `TestAnEmptyHandThrowsAnUnarmedStrike`.
- `ErrBadAttack`'s own doc comment now names this case explicitly instead
  of leaving it implicit.

This is the fix from the crossed message on #1173 that didn't land before
Kirk merged it (resolution v0.11.2) — reopened here against current `main`
per team-lead's follow-up instruction.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race -count=1 ./...` — all green
- `golangci-lint run ./...` — 0 issues
- `gorelease` — backward compatible, suggests `v0.11.3`
- `./scripts/check-decisions.sh` — all 45 ADRs summarised (no new ADR needed for this fix)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu