### PR TITLE
conditions/resolution/session: armed attacks no longer crash with ErrNoGameContext

### DIFF
--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -975,6 +975,26 @@ func (c *Character) GetEquippedSlot(slot InventorySlot) *EquippedItem {
 	return nil
 }
 
+// HasShieldEquipped reports whether a shield occupies either hand slot.
+//
+// A static equipment fact a condition like Protection ("you must be
+// wielding a shield") reads off its own live sheet at fold time — part of
+// rpg-toolkit#1178's move away from a context-installed gamectx registry.
+// Checking both hands rather than assuming off-hand-only matches
+// GetEquippedSlot's own indifference to which hand a caller names.
+func (c *Character) HasShieldEquipped() bool {
+	for _, slot := range [...]InventorySlot{SlotMainHand, SlotOffHand} {
+		equipped := c.GetEquippedSlot(slot)
+		if equipped == nil {
+			continue
+		}
+		if a := equipped.AsArmor(); a != nil && a.Category == armor.CategoryShield {
+			return true
+		}
+	}
+	return false
+}
+
 // EquipItem equips an inventory item to the specified slot, enforcing
 // two-handed weapon occupancy (rpg-toolkit#811): a two-handed weapon
 // always claims main hand and clears the off hand; equipping into the off

--- a/rulebooks/dnd5e/character/load.go
+++ b/rulebooks/dnd5e/character/load.go
@@ -144,6 +144,13 @@ func Attach(ctx context.Context, c *Character, bus events.EventBus) error {
 	for _, effect := range pending {
 		effectBus := dnd5eEvents.BusForEffect(bus, effect.ref)
 
+		// A condition that wants its own live sheet — rather than a
+		// context-installed registry — gets it here, before Apply subscribes
+		// it to anything (rpg-toolkit#1178).
+		if aware, ok := effect.behavior.(dnd5eEvents.OwnerAware); ok {
+			aware.SetOwner(c)
+		}
+
 		if err := effect.behavior.Apply(ctx, effectBus); err != nil {
 			// Undo whatever the failed Apply managed to subscribe.
 			_ = effect.behavior.Remove(ctx, effectBus)

--- a/rulebooks/dnd5e/conditions/fighting_style_dueling.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_dueling.go
@@ -127,10 +127,22 @@ func (f *FightingStyleDuelingCondition) onDamageChain(
 	}
 
 	// Check Dueling eligibility:
-	// 1. This swing must be melee
-	// 2. Must not be gripped two-handed
-	// 3. Must NOT have an off-hand weapon (shields are OK — OffHandWeaponRef
+	// 1. This swing must be an actual weapon — Dueling requires "wielding a
+	//    melee weapon", and the catalog's unarmed strike is not one, even
+	//    though it compiles through the same melee/damage machinery
+	//    (rpg-toolkit#1168, caught by Copilot on PR #1179 as a regression
+	//    from moving this check off a live registry: the old
+	//    gamectx.CharacterRegistry lookup never listed the unarmed strike
+	//    as a "weapon" in the first place, so this exclusion was implicit
+	//    before and needs to be explicit now).
+	// 2. This swing must be melee
+	// 3. Must not be gripped two-handed
+	// 4. Must NOT have an off-hand weapon (shields are OK — OffHandWeaponRef
 	//    is nil for a shield, since a shield is not a weapon)
+	if event.WeaponRef == nil || event.WeaponRef.Equals(refs.Weapons.UnarmedStrike()) {
+		return c, nil
+	}
+
 	if !event.IsMelee {
 		return c, nil
 	}

--- a/rulebooks/dnd5e/conditions/fighting_style_dueling.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_dueling.go
@@ -15,7 +15,6 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
@@ -109,8 +108,16 @@ func (f *FightingStyleDuelingCondition) loadJSON(data json.RawMessage) error {
 }
 
 // onDamageChain adds +2 to damage when wielding one-handed melee weapon with no off-hand weapon.
+//
+// Eligibility reads entirely off the folded event, the same way
+// [conditions.RagingCondition] does — no live character-registry lookup
+// (rpg-toolkit#1178). Every fact it needs (IsMelee, TwoHanded,
+// OffHandWeaponRef) is a STATIC equipment fact the attack compiler already
+// knew before the swing, carried onto the event exactly like WeaponRef and
+// AbilityUsed already are; see DamageChainEvent's own doc for why those
+// facts belong there rather than behind a context-installed registry.
 func (f *FightingStyleDuelingCondition) onDamageChain(
-	ctx context.Context,
+	_ context.Context,
 	event *dnd5eEvents.DamageChainEvent,
 	c chain.Chain[*dnd5eEvents.DamageChainEvent],
 ) (chain.Chain[*dnd5eEvents.DamageChainEvent], error) {
@@ -119,37 +126,20 @@ func (f *FightingStyleDuelingCondition) onDamageChain(
 		return c, nil
 	}
 
-	// Get character registry from context
-	registry, err := gamectx.RequireCharacters(ctx)
-	if err != nil {
-		return c, err
-	}
-
-	// Get character weapons
-	weapons := registry.GetCharacterWeapons(f.CharacterID)
-	if weapons == nil {
-		return c, nil
-	}
-
 	// Check Dueling eligibility:
-	// 1. Must have a main hand weapon
-	// 2. Main hand weapon must be melee and not two-handed
-	// 3. Must NOT have an off-hand weapon (shields are OK)
-	mainHand := weapons.MainHand()
-	if mainHand == nil {
+	// 1. This swing must be melee
+	// 2. Must not be gripped two-handed
+	// 3. Must NOT have an off-hand weapon (shields are OK — OffHandWeaponRef
+	//    is nil for a shield, since a shield is not a weapon)
+	if !event.IsMelee {
 		return c, nil
 	}
 
-	if !mainHand.IsMelee {
+	if event.TwoHanded {
 		return c, nil
 	}
 
-	if mainHand.IsTwoHanded {
-		return c, nil
-	}
-
-	offHand := weapons.OffHand()
-	if offHand != nil {
+	if event.OffHandWeaponRef != nil {
 		return c, nil
 	}
 

--- a/rulebooks/dnd5e/conditions/fighting_style_dueling_test.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_dueling_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
@@ -55,6 +54,10 @@ func (s *FightingStyleDuelingTestSuite) TestApplyAndRemove() {
 	s.False(dueling.IsApplied())
 }
 
+// TestAddsDamageWithOneHandedWeapon pins rpg-toolkit#1178's fix: eligibility
+// now reads entirely off the folded event — no gamectx.GameContext is
+// installed anywhere in this test, which is the point being pinned (the
+// old version of this test built one via gamectx.NewGameContext).
 func (s *FightingStyleDuelingTestSuite) TestAddsDamageWithOneHandedWeapon() {
 	dueling := conditions.NewFightingStyleDuelingCondition("fighter-1")
 
@@ -62,29 +65,12 @@ func (s *FightingStyleDuelingTestSuite) TestAddsDamageWithOneHandedWeapon() {
 	s.Require().NoError(err)
 	defer func() { _ = dueling.Remove(s.ctx, s.bus) }()
 
-	// Create character registry with one-handed melee weapon, no off-hand
-	registry := gamectx.NewBasicCharacterRegistry()
-	mainHand := &gamectx.EquippedWeapon{
-		ID:          "longsword-1",
-		Name:        "Longsword",
-		Slot:        "main_hand",
-		IsShield:    false,
-		IsTwoHanded: false,
-		IsMelee:     true,
-	}
-	weapons := gamectx.NewCharacterWeapons([]*gamectx.EquippedWeapon{mainHand})
-	registry.Add("fighter-1", weapons)
-
-	gameCtx := gamectx.NewGameContext(gamectx.GameContextConfig{
-		CharacterRegistry: registry,
-	})
-	ctx := gamectx.WithGameContext(s.ctx, gameCtx)
-
-	// Create damage chain event
+	// A one-handed melee weapon, no off-hand weapon: eligible.
 	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID:       "fighter-1",
 		TargetID:         "goblin-1",
 		WeaponDamageType: damage.Fire,
+		IsMelee:          true,
 		Components: []dnd5eEvents.DamageComponent{
 			{
 				Source:            dnd5eEvents.DamageSourceWeapon,
@@ -98,13 +84,13 @@ func (s *FightingStyleDuelingTestSuite) TestAddsDamageWithOneHandedWeapon() {
 		IsCritical: true,
 	}
 
-	// Execute through damage chain
+	// Execute through damage chain — plain context, no gamectx installed.
 	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
 	damages := dnd5eEvents.DamageChain.On(s.bus)
-	modifiedChain, err := damages.PublishWithChain(ctx, damageEvent, damageChain)
+	modifiedChain, err := damages.PublishWithChain(s.ctx, damageEvent, damageChain)
 	s.Require().NoError(err)
 
-	finalEvent, err := modifiedChain.Execute(ctx, damageEvent)
+	finalEvent, err := modifiedChain.Execute(s.ctx, damageEvent)
 	s.Require().NoError(err)
 
 	// Should have 2 components: weapon + dueling bonus
@@ -121,28 +107,12 @@ func (s *FightingStyleDuelingTestSuite) TestDoesNotAddWithTwoHandedWeapon() {
 	s.Require().NoError(err)
 	defer func() { _ = dueling.Remove(s.ctx, s.bus) }()
 
-	// Create character registry with two-handed weapon
-	registry := gamectx.NewBasicCharacterRegistry()
-	mainHand := &gamectx.EquippedWeapon{
-		ID:          "greatsword-1",
-		Name:        "Greatsword",
-		Slot:        "main_hand",
-		IsShield:    false,
-		IsTwoHanded: true, // Two-handed
-		IsMelee:     true,
-	}
-	weapons := gamectx.NewCharacterWeapons([]*gamectx.EquippedWeapon{mainHand})
-	registry.Add("fighter-1", weapons)
-
-	gameCtx := gamectx.NewGameContext(gamectx.GameContextConfig{
-		CharacterRegistry: registry,
-	})
-	ctx := gamectx.WithGameContext(s.ctx, gameCtx)
-
-	// Create damage chain event
+	// A two-handed grip disqualifies Dueling regardless of the weapon.
 	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID: "fighter-1",
 		TargetID:   "goblin-1",
+		IsMelee:    true,
+		TwoHanded:  true,
 		Components: []dnd5eEvents.DamageComponent{
 			{
 				Source:            dnd5eEvents.DamageSourceWeapon,
@@ -155,13 +125,12 @@ func (s *FightingStyleDuelingTestSuite) TestDoesNotAddWithTwoHandedWeapon() {
 		},
 	}
 
-	// Execute through damage chain
 	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
 	damages := dnd5eEvents.DamageChain.On(s.bus)
-	modifiedChain, err := damages.PublishWithChain(ctx, damageEvent, damageChain)
+	modifiedChain, err := damages.PublishWithChain(s.ctx, damageEvent, damageChain)
 	s.Require().NoError(err)
 
-	finalEvent, err := modifiedChain.Execute(ctx, damageEvent)
+	finalEvent, err := modifiedChain.Execute(s.ctx, damageEvent)
 	s.Require().NoError(err)
 
 	// Should only have 1 component (no dueling bonus for two-handed)
@@ -175,36 +144,13 @@ func (s *FightingStyleDuelingTestSuite) TestDoesNotAddWithOffHandWeapon() {
 	s.Require().NoError(err)
 	defer func() { _ = dueling.Remove(s.ctx, s.bus) }()
 
-	// Create character registry with dual wielding
-	registry := gamectx.NewBasicCharacterRegistry()
-	mainHand := &gamectx.EquippedWeapon{
-		ID:          "shortsword-1",
-		Name:        "Shortsword",
-		Slot:        "main_hand",
-		IsShield:    false,
-		IsTwoHanded: false,
-		IsMelee:     true,
-	}
-	offHand := &gamectx.EquippedWeapon{
-		ID:          "shortsword-2",
-		Name:        "Shortsword",
-		Slot:        "off_hand",
-		IsShield:    false,
-		IsTwoHanded: false,
-		IsMelee:     true,
-	}
-	weapons := gamectx.NewCharacterWeapons([]*gamectx.EquippedWeapon{mainHand, offHand})
-	registry.Add("fighter-1", weapons)
-
-	gameCtx := gamectx.NewGameContext(gamectx.GameContextConfig{
-		CharacterRegistry: registry,
-	})
-	ctx := gamectx.WithGameContext(s.ctx, gameCtx)
-
-	// Create damage chain event
+	// A weapon in the off hand (dual wielding) disqualifies Dueling.
+	offHandRef := refs.Weapons.Shortsword()
 	damageEvent := &dnd5eEvents.DamageChainEvent{
-		AttackerID: "fighter-1",
-		TargetID:   "goblin-1",
+		AttackerID:       "fighter-1",
+		TargetID:         "goblin-1",
+		IsMelee:          true,
+		OffHandWeaponRef: offHandRef,
 		Components: []dnd5eEvents.DamageComponent{
 			{
 				Source:            dnd5eEvents.DamageSourceWeapon,
@@ -217,17 +163,56 @@ func (s *FightingStyleDuelingTestSuite) TestDoesNotAddWithOffHandWeapon() {
 		},
 	}
 
-	// Execute through damage chain
 	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
 	damages := dnd5eEvents.DamageChain.On(s.bus)
-	modifiedChain, err := damages.PublishWithChain(ctx, damageEvent, damageChain)
+	modifiedChain, err := damages.PublishWithChain(s.ctx, damageEvent, damageChain)
 	s.Require().NoError(err)
 
-	finalEvent, err := modifiedChain.Execute(ctx, damageEvent)
+	finalEvent, err := modifiedChain.Execute(s.ctx, damageEvent)
 	s.Require().NoError(err)
 
 	// Should only have 1 component (no dueling bonus when dual wielding)
 	s.Len(finalEvent.Components, 1)
+}
+
+// TestDoesNotAddWithShieldInOffHand pins the "shields are OK" half: a shield
+// in the off hand is not a weapon, so OffHandWeaponRef stays nil and Dueling
+// still applies — this is precisely the sheet shape (longsword + shield)
+// that reproduced rpg-toolkit#1178 live.
+func (s *FightingStyleDuelingTestSuite) TestDoesNotAddWithShieldInOffHand() {
+	dueling := conditions.NewFightingStyleDuelingCondition("fighter-1")
+
+	err := dueling.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	defer func() { _ = dueling.Remove(s.ctx, s.bus) }()
+
+	damageEvent := &dnd5eEvents.DamageChainEvent{
+		AttackerID: "fighter-1",
+		TargetID:   "goblin-1",
+		IsMelee:    true,
+		// OffHandWeaponRef intentionally nil — a shield is not a weapon.
+		Components: []dnd5eEvents.DamageComponent{
+			{
+				Source:            dnd5eEvents.DamageSourceWeapon,
+				Properties:        []damage.Property{damage.AddsAttackAbilityModifier},
+				OriginalDiceRolls: []int{8},
+				FinalDiceRolls:    []int{8},
+				FlatBonus:         3,
+				DamageType:        damage.Slashing,
+			},
+		},
+	}
+
+	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damages := dnd5eEvents.DamageChain.On(s.bus)
+	modifiedChain, err := damages.PublishWithChain(s.ctx, damageEvent, damageChain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, damageEvent)
+	s.Require().NoError(err)
+
+	s.Len(finalEvent.Components, 2, "a shield in the off hand still leaves Dueling eligible")
+	s.Equal(2, finalEvent.Components[1].FlatBonus)
 }
 
 func (s *FightingStyleDuelingTestSuite) TestToJSON() {

--- a/rulebooks/dnd5e/conditions/fighting_style_dueling_test.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_dueling_test.go
@@ -69,6 +69,7 @@ func (s *FightingStyleDuelingTestSuite) TestAddsDamageWithOneHandedWeapon() {
 	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID:       "fighter-1",
 		TargetID:         "goblin-1",
+		WeaponRef:        refs.Weapons.Longsword(),
 		WeaponDamageType: damage.Fire,
 		IsMelee:          true,
 		Components: []dnd5eEvents.DamageComponent{
@@ -111,6 +112,7 @@ func (s *FightingStyleDuelingTestSuite) TestDoesNotAddWithTwoHandedWeapon() {
 	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID: "fighter-1",
 		TargetID:   "goblin-1",
+		WeaponRef:  refs.Weapons.Greatsword(),
 		IsMelee:    true,
 		TwoHanded:  true,
 		Components: []dnd5eEvents.DamageComponent{
@@ -149,6 +151,7 @@ func (s *FightingStyleDuelingTestSuite) TestDoesNotAddWithOffHandWeapon() {
 	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID:       "fighter-1",
 		TargetID:         "goblin-1",
+		WeaponRef:        refs.Weapons.Shortsword(),
 		IsMelee:          true,
 		OffHandWeaponRef: offHandRef,
 		Components: []dnd5eEvents.DamageComponent{
@@ -189,6 +192,7 @@ func (s *FightingStyleDuelingTestSuite) TestDoesNotAddWithShieldInOffHand() {
 	damageEvent := &dnd5eEvents.DamageChainEvent{
 		AttackerID: "fighter-1",
 		TargetID:   "goblin-1",
+		WeaponRef:  refs.Weapons.Longsword(),
 		IsMelee:    true,
 		// OffHandWeaponRef intentionally nil — a shield is not a weapon.
 		Components: []dnd5eEvents.DamageComponent{
@@ -213,6 +217,87 @@ func (s *FightingStyleDuelingTestSuite) TestDoesNotAddWithShieldInOffHand() {
 
 	s.Len(finalEvent.Components, 2, "a shield in the off hand still leaves Dueling eligible")
 	s.Equal(2, finalEvent.Components[1].FlatBonus)
+}
+
+// TestDoesNotAddWithUnarmedStrike pins Copilot's finding on PR #1179: moving
+// eligibility off a live registry silently dropped an exclusion the OLD
+// gamectx.CharacterRegistry never had to state, because it never listed the
+// catalog's unarmed strike as a "weapon" to begin with. Dueling requires
+// wielding an actual melee weapon (rpg-toolkit#1168's unarmed strike is a
+// rule substitute for one, not one) — IsMelee alone cannot tell the two
+// apart, since an unarmed swing compiles as melee too.
+func (s *FightingStyleDuelingTestSuite) TestDoesNotAddWithUnarmedStrike() {
+	dueling := conditions.NewFightingStyleDuelingCondition("fighter-1")
+
+	err := dueling.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	defer func() { _ = dueling.Remove(s.ctx, s.bus) }()
+
+	damageEvent := &dnd5eEvents.DamageChainEvent{
+		AttackerID: "fighter-1",
+		TargetID:   "goblin-1",
+		WeaponRef:  refs.Weapons.UnarmedStrike(),
+		IsMelee:    true,
+		Components: []dnd5eEvents.DamageComponent{
+			{
+				Source:            dnd5eEvents.DamageSourceWeapon,
+				Properties:        []damage.Property{damage.AddsAttackAbilityModifier},
+				OriginalDiceRolls: []int{1},
+				FinalDiceRolls:    []int{1},
+				FlatBonus:         3,
+				DamageType:        damage.Bludgeoning,
+			},
+		},
+	}
+
+	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damages := dnd5eEvents.DamageChain.On(s.bus)
+	modifiedChain, err := damages.PublishWithChain(s.ctx, damageEvent, damageChain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, damageEvent)
+	s.Require().NoError(err)
+
+	s.Len(finalEvent.Components, 1, "no Dueling bonus for a bare-fisted swing")
+}
+
+// TestDoesNotAddWithNoWeaponRef pins the nil half of the same exclusion — a
+// swing that names no weapon at all is at least as unarmed as one that
+// names the catalog's unarmed strike explicitly, and must not default to
+// eligible.
+func (s *FightingStyleDuelingTestSuite) TestDoesNotAddWithNoWeaponRef() {
+	dueling := conditions.NewFightingStyleDuelingCondition("fighter-1")
+
+	err := dueling.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	defer func() { _ = dueling.Remove(s.ctx, s.bus) }()
+
+	damageEvent := &dnd5eEvents.DamageChainEvent{
+		AttackerID: "fighter-1",
+		TargetID:   "goblin-1",
+		WeaponRef:  nil,
+		IsMelee:    true,
+		Components: []dnd5eEvents.DamageComponent{
+			{
+				Source:            dnd5eEvents.DamageSourceWeapon,
+				Properties:        []damage.Property{damage.AddsAttackAbilityModifier},
+				OriginalDiceRolls: []int{6},
+				FinalDiceRolls:    []int{6},
+				FlatBonus:         3,
+				DamageType:        damage.Slashing,
+			},
+		},
+	}
+
+	damageChain := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	damages := dnd5eEvents.DamageChain.On(s.bus)
+	modifiedChain, err := damages.PublishWithChain(s.ctx, damageEvent, damageChain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, damageEvent)
+	s.Require().NoError(err)
+
+	s.Len(finalEvent.Components, 1, "no weapon named means no Dueling bonus")
 }
 
 func (s *FightingStyleDuelingTestSuite) TestToJSON() {

--- a/rulebooks/dnd5e/conditions/fighting_style_protection.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_protection.go
@@ -111,11 +111,26 @@ func (f *FightingStyleProtectionCondition) loadJSON(data json.RawMessage) error 
 }
 
 // onAttackChain imposes disadvantage on attacks against nearby allies when using shield and reaction.
+//
+// rpg-toolkit#1178: this used to fire on the protector's OWN outgoing
+// attacks too, because it excluded only "target is me" and never "attacker
+// is me" — but Protection is a REACTION to someone else's attack (the doc
+// comment above says so: "a creature ... attacks a target other than
+// you"), never a response to your own swing. That gap put every armed
+// attack by a Protection-wielding character on the code path below, which
+// depends on gamectx.RequireCharacters — a live registry the session stack
+// never installs — turning an unrelated eligibility bug into a crash on
+// every one of that character's own attacks.
 func (f *FightingStyleProtectionCondition) onAttackChain(
 	ctx context.Context,
 	event dnd5eEvents.AttackChainEvent,
 	c chain.Chain[dnd5eEvents.AttackChainEvent],
 ) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
+	// Never a reaction to my own attack.
+	if event.AttackerID == f.CharacterID {
+		return c, nil
+	}
+
 	// Only triggers for attacks on OTHER creatures (not self)
 	if event.TargetID == f.CharacterID {
 		return c, nil
@@ -126,7 +141,19 @@ func (f *FightingStyleProtectionCondition) onAttackChain(
 		return c, nil
 	}
 
-	// Check if we have shield equipped
+	// Check if we have shield equipped.
+	//
+	// STILL gamectx-dependent, and deliberately not fixed here: unlike the
+	// self-attack exclusion above, this is genuinely third-party dynamic
+	// state — this method is asking about a DIFFERENT character than the
+	// attacker or target (the protector, who is neither), and a reaction's
+	// availability changes mid-interaction as other reactions get spent.
+	// Neither fact can ride the attacker/target-shaped chain event the way
+	// Dueling's equipment facts now do. This condition only reaches this
+	// line for a genuine "protect an ally" attempt (never the protector's
+	// own attack, after the fix above), which no current caller exercises
+	// — tracked as remaining work under rpg-toolkit#1178 rather than
+	// rushed into the fix that closed it.
 	registry, err := gamectx.RequireCharacters(ctx)
 	if err != nil {
 		return c, err

--- a/rulebooks/dnd5e/conditions/fighting_style_protection.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_protection.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/core/chain"
 	"github.com/KirkDiggler/rpg-toolkit/events"
@@ -25,6 +27,17 @@ type FightingStyleProtectionData struct {
 	CharacterID string    `json:"character_id"`
 }
 
+// protectionOwner is the minimal, structurally-satisfied view of the
+// protector's OWN live sheet this condition needs — shield equipped, and
+// the same action-economy ledger [combat.Pay]/[combat.CanPay] already read
+// (rpg-toolkit#1178). A *character.Character satisfies this without
+// `conditions` importing `character` (which would cycle — character already
+// imports conditions to load them); see [dnd5eEvents.OwnerAware].
+type protectionOwner interface {
+	combat.Ledger
+	HasShieldEquipped() bool
+}
+
 // FightingStyleProtectionCondition imposes disadvantage on attacks against adjacent allies.
 // When a creature you can see attacks a target other than you that is within 5 feet of you,
 // you can use your reaction to impose disadvantage on the attack roll. You must be wielding a shield.
@@ -32,10 +45,26 @@ type FightingStyleProtectionCondition struct {
 	CharacterID     string
 	subscriptionIDs []string
 	bus             events.EventBus
+	owner           protectionOwner
 }
 
 // Ensure FightingStyleProtectionCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*FightingStyleProtectionCondition)(nil)
+
+// Ensure FightingStyleProtectionCondition implements dnd5eEvents.OwnerAware
+var _ dnd5eEvents.OwnerAware = (*FightingStyleProtectionCondition)(nil)
+
+// SetOwner hands this condition its own character's live sheet, read the
+// same way [combat.Pay] already does, in place of a context-installed
+// gamectx registry (rpg-toolkit#1178). An owner that does not satisfy
+// [protectionOwner] is ignored: the condition simply never finds itself
+// eligible, the same "nothing to do" default every other unmet check here
+// already takes.
+func (f *FightingStyleProtectionCondition) SetOwner(owner any) {
+	if o, ok := owner.(protectionOwner); ok {
+		f.owner = o
+	}
+}
 
 // NewFightingStyleProtectionCondition creates a new Protection fighting style condition.
 func NewFightingStyleProtectionCondition(characterID string) *FightingStyleProtectionCondition {
@@ -141,41 +170,25 @@ func (f *FightingStyleProtectionCondition) onAttackChain(
 		return c, nil
 	}
 
-	// Check if we have shield equipped.
-	//
-	// STILL gamectx-dependent, and deliberately not fixed here: unlike the
-	// self-attack exclusion above, this is genuinely third-party dynamic
-	// state — this method is asking about a DIFFERENT character than the
-	// attacker or target (the protector, who is neither), and a reaction's
-	// availability changes mid-interaction as other reactions get spent.
-	// Neither fact can ride the attacker/target-shaped chain event the way
-	// Dueling's equipment facts now do. This condition only reaches this
-	// line for a genuine "protect an ally" attempt (never the protector's
-	// own attack, after the fix above), which no current caller exercises
-	// — tracked as remaining work under rpg-toolkit#1178 rather than
-	// rushed into the fix that closed it.
-	registry, err := gamectx.RequireCharacters(ctx)
-	if err != nil {
-		return c, err
-	}
-
-	weapons := registry.GetCharacterWeapons(f.CharacterID)
-	if weapons == nil {
+	// Must be wielding a shield — read off this character's own live sheet,
+	// handed over at attach time (rpg-toolkit#1178), never a
+	// context-installed registry.
+	if f.owner == nil || !f.owner.HasShieldEquipped() {
 		return c, nil
 	}
 
-	// Must be wielding a shield
-	if !weapons.HasShield() {
+	// Must have a reaction available — the same ledger combat.Pay/CanPay
+	// already read, so "can I react" is answered the identical way
+	// everywhere in this rulebook it is asked.
+	if f.owner.SlotsLeft(coreCombat.ActionReaction) <= 0 {
 		return c, nil
 	}
 
-	// Check if we have reaction available
-	actionEconomy := registry.GetCharacterActionEconomy(f.CharacterID)
-	if actionEconomy == nil || !actionEconomy.CanUseReaction() {
-		return c, nil
-	}
-
-	// Check if we're within 5 feet of the target
+	// Check if we're within 5 feet of the target. Positions are genuinely
+	// world state no single character's sheet carries, so this stays on
+	// [gamectx.RequireRoom] — the one registry resolution.Resolve DOES
+	// install (for prone's range predicate), and the only one this
+	// condition still needs.
 	room, err := gamectx.RequireRoom(ctx)
 	if err != nil {
 		return c, err
@@ -210,10 +223,10 @@ func (f *FightingStyleProtectionCondition) onAttackChain(
 			Reason:      "protection_fighting_style",
 		})
 
-		// Actually consume the reaction
-		if useErr := actionEconomy.UseReaction(); useErr != nil {
-			return e, rpgerr.Wrap(useErr, "failed to consume reaction for protection")
-		}
+		// Actually consume the reaction. SpendSlots never refuses — the
+		// eligibility check above already ran, and Ledger's own contract
+		// (combat/gate.go) is that a debit past a passed check cannot fail.
+		f.owner.SpendSlots(coreCombat.ActionReaction, 1)
 
 		return e, nil
 	}

--- a/rulebooks/dnd5e/conditions/fighting_style_protection_test.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_protection_test.go
@@ -41,7 +41,7 @@ type fakeProtectionOwner struct {
 }
 
 func (f *fakeProtectionOwner) HasShieldEquipped() bool { return f.hasShield }
-func (f *fakeProtectionOwner) InCombat() bool           { return true }
+func (f *fakeProtectionOwner) InCombat() bool          { return true }
 
 func (f *fakeProtectionOwner) SlotsLeft(slot coreCombat.ActionType) int {
 	if slot == coreCombat.ActionReaction {
@@ -50,11 +50,11 @@ func (f *fakeProtectionOwner) SlotsLeft(slot coreCombat.ActionType) int {
 	return 0
 }
 
-func (f *fakeProtectionOwner) CapacityLeft(_ combat.CapacityType) int          { return 0 }
-func (f *fakeProtectionOwner) PoolLeft(_ coreResources.ResourceKey) int        { return 0 }
-func (f *fakeProtectionOwner) SpendCapacity(_ combat.CapacityType, _ int)      {}
-func (f *fakeProtectionOwner) SpendPool(_ coreResources.ResourceKey, _ int)    {}
-func (f *fakeProtectionOwner) BankCapacity(_ combat.CapacityType, _ int)       {}
+func (f *fakeProtectionOwner) CapacityLeft(_ combat.CapacityType) int       { return 0 }
+func (f *fakeProtectionOwner) PoolLeft(_ coreResources.ResourceKey) int     { return 0 }
+func (f *fakeProtectionOwner) SpendCapacity(_ combat.CapacityType, _ int)   {}
+func (f *fakeProtectionOwner) SpendPool(_ coreResources.ResourceKey, _ int) {}
+func (f *fakeProtectionOwner) BankCapacity(_ combat.CapacityType, _ int)    {}
 
 func (f *fakeProtectionOwner) SpendSlots(slot coreCombat.ActionType, n int) {
 	if slot == coreCombat.ActionReaction {

--- a/rulebooks/dnd5e/conditions/fighting_style_protection_test.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_protection_test.go
@@ -162,6 +162,43 @@ func (s *FightingStyleProtectionTestSuite) TestDoesNotProtectSelf() {
 	s.Empty(finalEvent.DisadvantageSources)
 }
 
+// TestDoesNotTriggerOnOwnAttack pins rpg-toolkit#1178's Protection half:
+// the condition used to exclude only "target is me" and never "attacker is
+// me", so it fired on the protector's OWN melee attacks — which reached
+// gamectx.RequireCharacters below, a dependency the session stack never
+// satisfies. No gamectx.WithGameContext is installed in this test at all;
+// if the exclusion regresses, this test fails with ErrNoGameContext rather
+// than a wrong disadvantage count, which is the honest failure for what
+// broke live.
+func (s *FightingStyleProtectionTestSuite) TestDoesNotTriggerOnOwnAttack() {
+	protection := conditions.NewFightingStyleProtectionCondition("fighter-1")
+
+	err := protection.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	defer func() { _ = protection.Remove(s.ctx, s.bus) }()
+
+	// The protector attacking someone else — never a reaction to their own swing.
+	attackEvent := dnd5eEvents.AttackChainEvent{
+		AttackerID:        "fighter-1",
+		TargetID:          "goblin-1",
+		IsMelee:           true,
+		AttackBonus:       5,
+		TargetAC:          15,
+		CriticalThreshold: 20,
+	}
+
+	attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+	attacks := dnd5eEvents.AttackChain.On(s.bus)
+	modifiedChain, err := attacks.PublishWithChain(s.ctx, attackEvent, attackChain)
+	s.Require().NoError(err, "the protector's own attack must never reach the gamectx-dependent branch")
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, attackEvent)
+	s.Require().NoError(err)
+
+	s.Empty(finalEvent.DisadvantageSources, "Protection is a reaction to someone ELSE's attack, never my own")
+	s.Empty(finalEvent.ReactionsConsumed)
+}
+
 func (s *FightingStyleProtectionTestSuite) TestDoesNotProtectAgainstRangedAttacks() {
 	protection := conditions.NewFightingStyleProtectionCondition("fighter-1")
 

--- a/rulebooks/dnd5e/conditions/fighting_style_protection_test.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_protection_test.go
@@ -10,6 +10,8 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
@@ -27,6 +29,39 @@ type protectionTestEntity struct {
 
 func (e *protectionTestEntity) GetID() string            { return e.id }
 func (e *protectionTestEntity) GetType() core.EntityType { return core.EntityType(e.kind) }
+
+// fakeProtectionOwner is the minimal combat.Ledger + HasShieldEquipped
+// implementation Protection's owner interface needs (rpg-toolkit#1178) —
+// enough to prove eligibility and consumption without gamectx or a full
+// *character.Character.
+type fakeProtectionOwner struct {
+	hasShield bool
+	reactions int
+	spent     []coreCombat.ActionType
+}
+
+func (f *fakeProtectionOwner) HasShieldEquipped() bool { return f.hasShield }
+func (f *fakeProtectionOwner) InCombat() bool           { return true }
+
+func (f *fakeProtectionOwner) SlotsLeft(slot coreCombat.ActionType) int {
+	if slot == coreCombat.ActionReaction {
+		return f.reactions
+	}
+	return 0
+}
+
+func (f *fakeProtectionOwner) CapacityLeft(_ combat.CapacityType) int          { return 0 }
+func (f *fakeProtectionOwner) PoolLeft(_ coreResources.ResourceKey) int        { return 0 }
+func (f *fakeProtectionOwner) SpendCapacity(_ combat.CapacityType, _ int)      {}
+func (f *fakeProtectionOwner) SpendPool(_ coreResources.ResourceKey, _ int)    {}
+func (f *fakeProtectionOwner) BankCapacity(_ combat.CapacityType, _ int)       {}
+
+func (f *fakeProtectionOwner) SpendSlots(slot coreCombat.ActionType, n int) {
+	if slot == coreCombat.ActionReaction {
+		f.reactions -= n
+	}
+	f.spent = append(f.spent, slot)
+}
 
 type FightingStyleProtectionTestSuite struct {
 	suite.Suite
@@ -65,8 +100,18 @@ func (s *FightingStyleProtectionTestSuite) TestApplyAndRemove() {
 	s.False(protection.IsApplied())
 }
 
+// TestImposesDisadvantageOnNearbyAlly pins rpg-toolkit#1178's Protection
+// fix: shield and reaction eligibility now come from the owner handed over
+// at attach time (SetOwner), read the same way combat.Pay/CanPay already
+// read a ledger — not a gamectx.CharacterRegistry. Only positions still
+// come from gamectx (WithRoom), which resolution.Resolve genuinely does
+// install. Team-lead's exact reproduction shape: three participants
+// (protector + ally + monster), the ally is attacked, not the protector.
 func (s *FightingStyleProtectionTestSuite) TestImposesDisadvantageOnNearbyAlly() {
 	protection := conditions.NewFightingStyleProtectionCondition("fighter-1")
+
+	owner := &fakeProtectionOwner{hasShield: true, reactions: 1}
+	protection.SetOwner(owner)
 
 	err := protection.Apply(s.ctx, s.bus)
 	s.Require().NoError(err)
@@ -88,28 +133,15 @@ func (s *FightingStyleProtectionTestSuite) TestImposesDisadvantageOnNearbyAlly()
 	err = room.PlaceEntity(ally, spatial.Position{X: 6, Y: 5}) // Adjacent
 	s.Require().NoError(err)
 
-	// Set up character registry with shield and reaction
-	registry := gamectx.NewBasicCharacterRegistry()
-	shield := &gamectx.EquippedWeapon{
-		ID:       "shield-1",
-		Name:     "Shield",
-		Slot:     "off_hand",
-		IsShield: true,
-	}
-	weapons := gamectx.NewCharacterWeapons([]*gamectx.EquippedWeapon{shield})
-	registry.Add("fighter-1", weapons)
+	// Positions are the one thing this condition still reads from gamectx —
+	// no CharacterRegistry, no GameContext installed at all.
+	ctx := gamectx.WithRoom(s.ctx, room)
 
-	// Add action economy with reaction available
-	actionEconomy := combat.NewActionEconomy()
-	registry.AddActionEconomy("fighter-1", actionEconomy)
-
-	gameCtx := gamectx.NewGameContext(gamectx.GameContextConfig{
-		CharacterRegistry: registry,
-	})
-	ctx := gamectx.WithGameContext(s.ctx, gameCtx)
-	ctx = gamectx.WithRoom(ctx, room)
-
-	// Create attack chain event - melee attack on ally
+	// Create attack chain event - melee attack on ally, by a THIRD
+	// combatant (neither the protector nor the target) — this is exactly
+	// the shape Copilot flagged as reachable on the session stack: three
+	// or more participants, someone other than the protector attacking
+	// someone other than the protector.
 	attackEvent := dnd5eEvents.AttackChainEvent{
 		AttackerID:        "goblin-1",
 		TargetID:          "ally-1", // Attacking ally, not fighter
@@ -131,6 +163,62 @@ func (s *FightingStyleProtectionTestSuite) TestImposesDisadvantageOnNearbyAlly()
 	// Should have disadvantage imposed
 	s.Len(finalEvent.DisadvantageSources, 1)
 	s.Len(finalEvent.ReactionsConsumed, 1)
+
+	// And the reaction is actually spent on the owner's own ledger.
+	s.Equal(0, owner.reactions, "the reaction was actually debited")
+	s.Equal([]coreCombat.ActionType{coreCombat.ActionReaction}, owner.spent)
+}
+
+// TestNoShieldMeansNoProtection pins that a missing shield refuses
+// eligibility before ever touching gamectx.RequireRoom — no room is
+// installed in this test at all, and the condition must never reach for
+// one when the shield check alone already disqualifies it.
+func (s *FightingStyleProtectionTestSuite) TestNoShieldMeansNoProtection() {
+	protection := conditions.NewFightingStyleProtectionCondition("fighter-1")
+	protection.SetOwner(&fakeProtectionOwner{hasShield: false, reactions: 1})
+
+	err := protection.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	defer func() { _ = protection.Remove(s.ctx, s.bus) }()
+
+	attackEvent := dnd5eEvents.AttackChainEvent{
+		AttackerID: "goblin-1", TargetID: "ally-1", IsMelee: true,
+	}
+
+	attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+	attacks := dnd5eEvents.AttackChain.On(s.bus)
+	modifiedChain, err := attacks.PublishWithChain(s.ctx, attackEvent, attackChain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, attackEvent)
+	s.Require().NoError(err)
+
+	s.Empty(finalEvent.DisadvantageSources)
+}
+
+// TestNoReactionMeansNoProtection mirrors the shield case for the other
+// half of eligibility.
+func (s *FightingStyleProtectionTestSuite) TestNoReactionMeansNoProtection() {
+	protection := conditions.NewFightingStyleProtectionCondition("fighter-1")
+	protection.SetOwner(&fakeProtectionOwner{hasShield: true, reactions: 0})
+
+	err := protection.Apply(s.ctx, s.bus)
+	s.Require().NoError(err)
+	defer func() { _ = protection.Remove(s.ctx, s.bus) }()
+
+	attackEvent := dnd5eEvents.AttackChainEvent{
+		AttackerID: "goblin-1", TargetID: "ally-1", IsMelee: true,
+	}
+
+	attackChain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+	attacks := dnd5eEvents.AttackChain.On(s.bus)
+	modifiedChain, err := attacks.PublishWithChain(s.ctx, attackEvent, attackChain)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(s.ctx, attackEvent)
+	s.Require().NoError(err)
+
+	s.Empty(finalEvent.DisadvantageSources)
 }
 
 func (s *FightingStyleProtectionTestSuite) TestDoesNotProtectSelf() {

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -119,6 +119,30 @@ type ConditionBehavior interface {
 	ToJSON() (json.RawMessage, error)
 }
 
+// OwnerAware is an opt-in a [ConditionBehavior] implements when it needs a
+// live view of its OWN character's sheet — equipment, action economy — to
+// decide eligibility, instead of reaching for a context-installed registry
+// (rpg-toolkit#1178: gamectx.GameContext is a registry the session stack
+// never installs, and Protection's shield/reaction check depended on one).
+//
+// The owner is handed as `any` rather than a concrete type because this
+// package sits BENEATH character and monster in the import graph — a
+// condition cannot import either without a cycle. SetOwner is called with
+// whatever attached this condition (today, always a *character.Character);
+// a condition that needs one type-asserts it against its own narrow,
+// structurally-satisfied interface (see FightingStyleProtectionCondition
+// for the pattern: combat.Ledger, the same ledger Pay/CanPay already read,
+// plus whatever else it needs). An owner of the wrong shape is silently
+// ignored rather than an error — the same "nothing to do" default every
+// other unmet eligibility check in this package already takes.
+type OwnerAware interface {
+	// SetOwner hands over this condition's own character. Called once, at
+	// attach time, before Apply — never from inside a chain fold, because a
+	// live registry lookup at fold time is exactly what this interface
+	// exists to replace.
+	SetOwner(owner any)
+}
+
 // ActionBehavior represents a grantable action.
 // This interface is defined in the events package to avoid import cycles
 // between events and actions packages. The actions package implements this

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -308,6 +308,24 @@ type DamageChainEvent struct {
 	IsOffHandAttack  bool              // True for bonus action off-hand attacks (two-weapon fighting)
 	AbilityModifier  int               // The ability modifier (STR/DEX) for this attack
 	IsMelee          bool              // True for melee attacks, false for ranged (mirrors AttackChainEvent.IsMelee)
+
+	// TwoHanded says this swing is being made with both hands on the
+	// weapon — either the weapon itself requires it, or a versatile weapon
+	// was gripped that way. A STATIC fact of the swing, compiled once by
+	// the attack compiler rather than read live off a character registry
+	// (rpg-toolkit#1178, docs/ideas/session-sdk/attack-profile-seam.md):
+	// it cannot change between the attack roll and the damage roll of the
+	// same swing.
+	TwoHanded bool
+
+	// OffHandWeaponRef names the weapon, if any, occupying the attacker's
+	// OTHER hand from the one that just swung — nil when that hand is
+	// empty or holds something that is not a weapon (a shield, most
+	// often). Like TwoHanded, this is a static equipment fact the compiler
+	// already knows, carried onto the event the same way WeaponRef already
+	// is, so a predicate like Dueling's decides eligibility from the event
+	// alone rather than a live gamectx lookup.
+	OffHandWeaponRef *core.Ref
 }
 
 // DamageChainInput contains the facts used to construct a DamageChainEvent.
@@ -326,6 +344,8 @@ type DamageChainInput struct {
 	IsOffHandAttack  bool
 	AbilityModifier  int
 	IsMelee          bool
+	TwoHanded        bool
+	OffHandWeaponRef *core.Ref
 }
 
 // NewDamageChainEvent constructs a damage-chain event with explicit primary
@@ -345,6 +365,8 @@ func NewDamageChainEvent(input DamageChainInput) *DamageChainEvent {
 		IsOffHandAttack:  input.IsOffHandAttack,
 		AbilityModifier:  input.AbilityModifier,
 		IsMelee:          input.IsMelee,
+		TwoHanded:        input.TwoHanded,
+		OffHandWeaponRef: input.OffHandWeaponRef,
 	}
 }
 

--- a/rulebooks/dnd5e/integration/fighter_encounter_test.go
+++ b/rulebooks/dnd5e/integration/fighter_encounter_test.go
@@ -77,7 +77,7 @@ type fakeProtectionOwner struct {
 }
 
 func (f *fakeProtectionOwner) HasShieldEquipped() bool { return f.hasShield }
-func (f *fakeProtectionOwner) InCombat() bool           { return true }
+func (f *fakeProtectionOwner) InCombat() bool          { return true }
 
 func (f *fakeProtectionOwner) SlotsLeft(slot coreCombat.ActionType) int {
 	if slot == coreCombat.ActionReaction {

--- a/rulebooks/dnd5e/integration/fighter_encounter_test.go
+++ b/rulebooks/dnd5e/integration/fighter_encounter_test.go
@@ -413,17 +413,12 @@ func (s *FighterEncounterSuite) TestFightingStyleDueling_AddsDamage() {
 		s.T().Log("║  FIGHTER DUELING: +2 Damage One-Handed                           ║")
 		s.T().Log("╚══════════════════════════════════════════════════════════════════╝")
 
-		// Set up weapons for the fighter (rapier in main hand, nothing in off hand)
-		mainHand := &gamectx.EquippedWeapon{
-			ID:          "rapier-1",
-			WeaponID:    weapons.Rapier,
-			Name:        "Rapier",
-			Slot:        "main_hand",
-			IsMelee:     true,
-			IsTwoHanded: false,
-		}
-		weaponSet := gamectx.NewCharacterWeapons([]*gamectx.EquippedWeapon{mainHand})
-		s.registry.Add(s.fighter.GetID(), weaponSet)
+		// rpg-toolkit#1178: Dueling no longer asks a gamectx.CharacterRegistry
+		// what is equipped — it reads IsMelee/TwoHanded/OffHandWeaponRef off
+		// the event itself, the same static facts the attack compiler already
+		// knew. No registry setup needed for this weapon shape (rapier main
+		// hand, empty off hand) any more; IsMelee: true below is the whole of
+		// it.
 
 		// Apply Dueling fighting style
 		dueling := conditions.NewFightingStyleDuelingCondition(s.fighter.GetID())
@@ -436,6 +431,7 @@ func (s *FighterEncounterSuite) TestFightingStyleDueling_AddsDamage() {
 			AttackerID:  s.fighter.GetID(),
 			TargetID:    s.goblin.GetID(),
 			AbilityUsed: abilities.STR,
+			IsMelee:     true,
 			Components: []dnd5eEvents.DamageComponent{
 				{Source: dnd5eEvents.DamageSourceWeapon, Properties: []damage.Property{damage.AddsAttackAbilityModifier}, OriginalDiceRolls: []int{6}, FinalDiceRolls: []int{6}, DamageType: damage.Piercing},
 			},

--- a/rulebooks/dnd5e/integration/fighter_encounter_test.go
+++ b/rulebooks/dnd5e/integration/fighter_encounter_test.go
@@ -15,6 +15,7 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
 	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
 	mock_dice "github.com/KirkDiggler/rpg-toolkit/dice/mock"
 	"github.com/KirkDiggler/rpg-toolkit/events"
@@ -65,6 +66,36 @@ type mockFighterCharacter struct {
 	maxHitPoints     int
 	armorClass       int
 	conditions       []dnd5eEvents.ConditionBehavior
+}
+
+// fakeProtectionOwner is the minimal combat.Ledger + HasShieldEquipped
+// implementation Protection's owner interface needs (rpg-toolkit#1178) —
+// enough to prove eligibility and consumption without gamectx.
+type fakeProtectionOwner struct {
+	hasShield bool
+	reactions int
+}
+
+func (f *fakeProtectionOwner) HasShieldEquipped() bool { return f.hasShield }
+func (f *fakeProtectionOwner) InCombat() bool           { return true }
+
+func (f *fakeProtectionOwner) SlotsLeft(slot coreCombat.ActionType) int {
+	if slot == coreCombat.ActionReaction {
+		return f.reactions
+	}
+	return 0
+}
+
+func (f *fakeProtectionOwner) CapacityLeft(_ combat.CapacityType) int       { return 0 }
+func (f *fakeProtectionOwner) PoolLeft(_ coreResources.ResourceKey) int     { return 0 }
+func (f *fakeProtectionOwner) SpendCapacity(_ combat.CapacityType, _ int)   {}
+func (f *fakeProtectionOwner) SpendPool(_ coreResources.ResourceKey, _ int) {}
+func (f *fakeProtectionOwner) BankCapacity(_ combat.CapacityType, _ int)    {}
+
+func (f *fakeProtectionOwner) SpendSlots(slot coreCombat.ActionType, n int) {
+	if slot == coreCombat.ActionReaction {
+		f.reactions -= n
+	}
 }
 
 func (m *mockFighterCharacter) GetID() string                                  { return m.id }
@@ -431,6 +462,7 @@ func (s *FighterEncounterSuite) TestFightingStyleDueling_AddsDamage() {
 			AttackerID:  s.fighter.GetID(),
 			TargetID:    s.goblin.GetID(),
 			AbilityUsed: abilities.STR,
+			WeaponRef:   refs.Weapons.Rapier(),
 			IsMelee:     true,
 			Components: []dnd5eEvents.DamageComponent{
 				{Source: dnd5eEvents.DamageSourceWeapon, Properties: []damage.Property{damage.AddsAttackAbilityModifier}, OriginalDiceRolls: []int{6}, FinalDiceRolls: []int{6}, DamageType: damage.Piercing},
@@ -819,7 +851,11 @@ func (s *FighterEncounterSuite) TestFightingStyleProtection_ImposesDisadvantage(
 		s.T().Log("║  FIGHTER PROTECTION: Disadvantage on Attacks vs Adjacent Ally   ║")
 		s.T().Log("╚══════════════════════════════════════════════════════════════════╝")
 
+		// rpg-toolkit#1178: shield and reaction eligibility now come from the
+		// owner handed over at attach time (SetOwner), not gamectx.
+
 		protection := conditions.NewFightingStyleProtectionCondition(s.fighter.GetID())
+		protection.SetOwner(&fakeProtectionOwner{hasShield: true, reactions: 1})
 		err := protection.Apply(s.ctx, s.bus)
 		s.Require().NoError(err)
 		defer func() { _ = protection.Remove(s.ctx, s.bus) }()
@@ -828,21 +864,8 @@ func (s *FighterEncounterSuite) TestFightingStyleProtection_ImposesDisadvantage(
 		ally := &mockFighterCharacter{id: "ally-1", name: "Ally"}
 		_ = s.room.PlaceEntity(ally, spatial.Position{X: 3, Y: 2}) // Adjacent to fighter
 
-		// Set up fighter with a shield and reaction available
-		shield := &gamectx.EquippedWeapon{
-			ID:       "shield-1",
-			Name:     "Shield",
-			Slot:     "off_hand",
-			IsShield: true,
-		}
-		weaponSet := gamectx.NewCharacterWeapons([]*gamectx.EquippedWeapon{shield})
-		s.registry.Add(s.fighter.GetID(), weaponSet)
-
-		// Add action economy with reaction available
-		actionEconomy := combat.NewActionEconomy()
-		s.registry.AddActionEconomy(s.fighter.GetID(), actionEconomy)
-
-		// Update context with room
+		// Positions are the one thing this condition still reads from
+		// gamectx — no CharacterRegistry, no GameContext installed at all.
 		ctx := gamectx.WithRoom(s.ctx, s.room)
 
 		// Create melee attack against the ally (not the fighter)

--- a/rulebooks/dnd5e/resolution/character_attack.go
+++ b/rulebooks/dnd5e/resolution/character_attack.go
@@ -6,6 +6,7 @@ package resolution
 import (
 	"fmt"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
@@ -164,12 +165,54 @@ func AttackFromCharacter(c *character.Character, in *CharacterAttackInput) (Atta
 		// Weapons declare no rider. A gate on a character's attack comes from
 		// class content (a monk's Flurry), which compiles elsewhere.
 		Gate: nil,
+		// Static equipment facts a predicate like Dueling decides eligibility
+		// from (rpg-toolkit#1178) — knowable here, from the sheet, and never
+		// re-derived live from a registry.
+		TwoHanded:        in.TwoHanded || weapon.HasProperty(weapons.PropertyTwoHanded),
+		OffHandWeaponRef: otherHandWeaponRef(c, in.Slot),
 	}
 	if err := profile.validate(); err != nil {
 		return AttackProfile{}, err
 	}
 
 	return profile, nil
+}
+
+// otherHandWeaponRef reports the weapon, if any, occupying the hand OTHER
+// than the one a swing compiled from — nil when that hand is empty or holds
+// something that is not a weapon (a shield, most often).
+//
+// Unlike equippedWeapon, this draws no unarmed-strike distinction: "nothing
+// to swing" and "nothing occupying the other hand" are different questions,
+// and only the first one is a rule (rpg-toolkit#1168). This is purely a
+// static equipment fact for a chain-fold predicate like Dueling to read off
+// the compiled profile instead of a live gamectx lookup (rpg-toolkit#1178).
+// A slot naming an item that turns out not to be in inventory reads the
+// same as an empty slot here — conservatively "no weapon" either way — since
+// that distinction (rpg-toolkit#1173) is equippedWeapon's concern for the
+// hand actually being swung, not this one's for the other hand.
+func otherHandWeaponRef(c *character.Character, slot character.InventorySlot) *core.Ref {
+	var other character.InventorySlot
+	switch slot {
+	case character.SlotMainHand:
+		other = character.SlotOffHand
+	case character.SlotOffHand:
+		other = character.SlotMainHand
+	default:
+		return nil
+	}
+
+	equipped := c.GetEquippedSlot(other)
+	if equipped == nil {
+		return nil
+	}
+
+	w := equipped.AsWeapon()
+	if w == nil {
+		return nil
+	}
+
+	return refs.Weapons.ByID(string(w.ID))
 }
 
 // equippedWeapon reads the weapon out of a slot: what is equipped there, or

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822114920-58a946928e6b
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04 h1:DDAtwWYscIQzw4iZO4r9jQL6Oik4woMHxxY7vkUFYB8=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822114920-58a946928e6b h1:VhWUcRPT8SfISGSP9rVxPZLz6+xWy5Dp1hxdL0t1lb8=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822114920-58a946928e6b/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0 h1:BnDZ//xyK/vcFmhUyDV8mRd4KSnj6Ofrz5Kpxy0GH1o=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04 h1:DDAtwWYscIQzw4iZO4r9jQL6Oik4woMHxxY7vkUFYB8=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0 h1:BnDZ//xyK/vcFmhUyDV8mRd4KSnj6Ofrz5Kpxy0GH1o=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -140,6 +140,24 @@ type AttackProfile struct {
 	// compiler's job: the wolf's KnockdownDC becomes both the gate and prone in
 	// the same place, rather than the DC here and the meaning in the machine.
 	Imposes Consequence
+
+	// TwoHanded says this swing is being made with both hands on the
+	// weapon. A static fact of the grip and the weapon, threaded onto the
+	// damage chain event the same way AbilityUsed already is — this is the
+	// seam's own precedent (see AbilityUsed's doc above), exercised for
+	// rpg-toolkit#1178: Dueling's eligibility used to be decided by a live
+	// gamectx.CharacterRegistry lookup the session stack never satisfies;
+	// moving the static half of that decision here let Dueling's own
+	// predicate read it off the event instead, the same way Rage does.
+	TwoHanded bool
+
+	// OffHandWeaponRef names the weapon, if any, occupying the attacker's
+	// OTHER hand from the one this profile compiled — nil when that hand
+	// is empty or holds something that is not a weapon (a shield, most
+	// often). Also additive for rpg-toolkit#1178, and also a static
+	// equipment fact rather than something a chain-fold predicate should
+	// have to ask a live registry for.
+	OffHandWeaponRef *core.Ref
 }
 
 // validate refuses a profile that cannot drive a strike, naming what is
@@ -513,6 +531,11 @@ func (m *strikeMachine) rollDamage(ctx context.Context, roller dice.Roller) (Ste
 		AbilityUsed:     m.in.Attack.AbilityUsed,
 		AbilityModifier: m.in.Attack.AbilityModifier,
 		WeaponRef:       m.in.Attack.Ref,
+		// Static equipment facts the compiler already knew (rpg-toolkit#1178)
+		// — Dueling's predicate decides eligibility from these rather than a
+		// live gamectx lookup, the same way Rage decides from AbilityUsed.
+		TwoHanded:        m.in.Attack.TwoHanded,
+		OffHandWeaponRef: m.in.Attack.OffHandWeaponRef,
 	}), m.afterDamageChain), nil
 }
 

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -219,6 +219,87 @@ func (s *AttackTestSuite) TestAnArmedDuelingFighterResolvesOnTheSessionStack() {
 		"an armed Dueling-eligible fighter's swing must not depend on a GameContext the session stack never installs")
 }
 
+// protectionBlob is the persisted Protection fighting style condition.
+func (s *AttackTestSuite) protectionBlob(id string) json.RawMessage {
+	raw, err := (&conditions.FightingStyleProtectionCondition{CharacterID: id}).ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// protectorFighter is armedFighter equipped with a shield in the off hand
+// and the Protection fighting style chosen.
+func (s *AttackTestSuite) protectorFighter(id string) *character.Data {
+	sheet := armedFighter(id)
+	sheet.Inventory = append(sheet.Inventory, character.InventoryItemData{
+		Type: shared.EquipmentTypeArmor, ID: string(armor.Shield), Quantity: 1,
+	})
+	sheet.EquipmentSlots[character.SlotOffHand] = string(armor.Shield)
+	sheet.Conditions = []json.RawMessage{s.protectionBlob(id)}
+	return sheet
+}
+
+// TestProtectionReactsToANearbyAllysAttackOnTheSessionStack pins
+// rpg-toolkit#1178's second half, Copilot's finding on PR #1179: a
+// two-member world never exercises Protection's shield/reaction branch at
+// all (both of onAttackChain's exclusions — "not my own attack", "not an
+// attack on me" — trivially pass or fail with only an attacker and a
+// target), so the first fix's claim that "no caller exercises it" was
+// false. A THIRD member changes that: carol attacks bob while alice (the
+// protector, carrying a shield and the Protection style) stands adjacent
+// to bob. alice is neither carol nor bob, so both exclusions clear and
+// Protection's full eligibility path — shield equipped, reaction
+// available, both read off alice's own live sheet via SetOwner rather
+// than a gamectx registry — actually runs.
+//
+// No gamectx.WithGameContext is installed anywhere in this test, matching
+// the real session stack. Before the owner-based fix this failed exactly
+// like the two-member Dueling case; after it, the swing resolves AND
+// Protection's disadvantage still applies — "behaves as before", the
+// mechanic is not merely uncrashed but still working.
+func (s *AttackTestSuite) TestProtectionReactsToANearbyAllysAttackOnTheSessionStack() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+
+	alice := s.protectorFighter("alice") // the protector
+	bob := armedFighter("bob")           // carol's target, standing beside alice
+	carol := armedFighter("carol")       // the attacker — neither alice nor bob
+
+	s.characters = newFakeCharacters(alice, bob, carol)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Sight: encEveryoneSees{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms: []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 2, Y: 1}},   // adjacent to alice
+			{ID: "carol", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 3, Y: 1}}, // adjacent to bob, in melee reach
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	world := enc.ToData()
+
+	mgr, err := session.NewManager(&session.Config{
+		Dice: &sequenceDice{rolls: []int{15, 5}}, TurnDriver: session.Pass{},
+		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
+		Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: &world,
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "carol", Target: "bob",
+	})
+	s.Require().NoError(err,
+		"a third member's Protection condition must not depend on a GameContext the session stack never installs")
+}
+
 // TestASwingLandsAndTheStoryRecordsIt is the headline: a rules machine runs
 // through the seam, and what it produced reaches both the caller and the
 // transcript.

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -11,8 +11,10 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
@@ -159,6 +161,62 @@ func (s *AttackTestSuite) swing(mgr *session.Manager) (*session.AttackOutput, er
 	return mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "bob",
 	})
+}
+
+// duelingBlob is the persisted Dueling fighting style condition, so the
+// fighter has actually chosen it rather than merely being eligible for it.
+func (s *AttackTestSuite) duelingBlob(id string) json.RawMessage {
+	raw, err := (&conditions.FightingStyleDuelingCondition{CharacterID: id}).ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// TestAnArmedDuelingFighterResolvesOnTheSessionStack pins rpg-toolkit#1178.
+//
+// Dueling's damage-chain fold used to decide eligibility by live-querying a
+// gamectx.CharacterRegistry — a global lookup the OLD encounter module
+// installed and the session stack never does; resolution installs exactly
+// one gamectx registry (WithRoom, for prone's range predicate) and
+// deliberately nothing else (resolution/doc.go). So a fighter who chose
+// Dueling and swings a one-handed melee weapon with an empty or shielded off
+// hand — precisely the sheet shape this test builds — crashed every armed
+// swing with gamectx.ErrNoGameContext, while an unarmed swing by the same
+// character resolved fine (nothing in the unarmed path reaches Dueling's
+// predicate the same way). This is the live blocker reported against
+// rpg-api's session stack.
+//
+// No gamectx.WithGameContext is installed anywhere in this test, exactly
+// like the real session stack — that absence is the point being pinned.
+func (s *AttackTestSuite) TestAnArmedDuelingFighterResolvesOnTheSessionStack() {
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+
+	alice := armedFighter("alice")
+	alice.Inventory = append(alice.Inventory, character.InventoryItemData{
+		Type: shared.EquipmentTypeArmor, ID: string(armor.Shield), Quantity: 1,
+	})
+	alice.EquipmentSlots[character.SlotOffHand] = string(armor.Shield)
+	alice.Conditions = []json.RawMessage{s.duelingBlob("alice")}
+
+	s.characters = newFakeCharacters(alice, armedFighter("bob"))
+
+	mgr, err := session.NewManager(&session.Config{
+		Dice: &sequenceDice{rolls: []int{15, 5}}, TurnDriver: session.Pass{},
+		Sessions: s.sessions, Encounters: s.encounters, Characters: s.characters,
+		Events: session.DiscardEvents{},
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: duelWorld(s.T()),
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "bob",
+	})
+	s.Require().NoError(err,
+		"an armed Dueling-eligible fighter's swing must not depend on a GameContext the session stack never installs")
 }
 
 // TestASwingLandsAndTheStoryRecordsIt is the headline: a rules machine runs

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822095344-9e268587e077
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822095454-74a62e764e8d
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.3-0.20260822112316-3d589135e06a
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -8,9 +8,9 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822114920-58a946928e6b
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822095344-9e268587e077
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.3-0.20260822112316-3d589135e06a
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.3-0.20260822115009-bb32ccb27a7e
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -16,12 +16,12 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04 h1:DDAtwWYscIQzw4iZO4r9jQL6Oik4woMHxxY7vkUFYB8=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822114920-58a946928e6b h1:VhWUcRPT8SfISGSP9rVxPZLz6+xWy5Dp1hxdL0t1lb8=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822114920-58a946928e6b/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822095344-9e268587e077 h1:A7RSob5tVwwO/J82HOTgveyOKoROWrpLhec3oOfgZOY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822095344-9e268587e077/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.3-0.20260822112316-3d589135e06a h1:kdtcjAeAJOHE9nqV9vmOKOg95NPuB1zSWxbV3rpRnJU=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.3-0.20260822112316-3d589135e06a/go.mod h1:ItzmNxVuASAigkJokYm0bfDNOpgP7fuqnM/JR38h8xM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.3-0.20260822115009-bb32ccb27a7e h1:C39BDfpAXG2/GBC5jtyI/AxpmsahysjR53Z1nrSGp8w=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.3-0.20260822115009-bb32ccb27a7e/go.mod h1:tl3ZPUkO+K+J57dFGrX3bxkCpG3dvHpUlG006e6Hu5I=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -16,12 +16,12 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0 h1:T2dBEQZFKZpzp7lkIT2mkhLTjXv3mtIpQsiGymYtBaw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04 h1:DDAtwWYscIQzw4iZO4r9jQL6Oik4woMHxxY7vkUFYB8=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822112137-5a0b707a2b04/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822095344-9e268587e077 h1:A7RSob5tVwwO/J82HOTgveyOKoROWrpLhec3oOfgZOY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.2-0.20260822095344-9e268587e077/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822095454-74a62e764e8d h1:zfiVSCDhN1MNSPRkW4rFzGOFU8hxEU9FZXAX/7rTItY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.2-0.20260822095454-74a62e764e8d/go.mod h1:na07h5QcdnadknaylTTvJFcVjCNT8j0wla7uUIqXNMY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.3-0.20260822112316-3d589135e06a h1:kdtcjAeAJOHE9nqV9vmOKOg95NPuB1zSWxbV3rpRnJU=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.3-0.20260822112316-3d589135e06a/go.mod h1:ItzmNxVuASAigkJokYm0bfDNOpgP7fuqnM/JR38h8xM=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
## Summary

Closes #1178 — live blocker on rpg-api's `feat/session-combat-turn` (session v0.21.6): a fighter with a longsword equipped (main hand) and a shield (off hand) failed every `Attack` with `Internal: attack: publish attack chain: no GameContext found in context`. An unarmed swing by the same character resolved fine, which is what made this easy to miss and painful to hit live — this blocked Kirk's walk on the tomb.

### Root cause

Two Fighting Style conditions called `gamectx.RequireCharacters(ctx)` from inside an event-chain fold — a live, global-registry lookup only the OLD (pre-session-stack) encounter module ever installed:

- `conditions.FightingStyleDuelingCondition.onDamageChain`
- `conditions.FightingStyleProtectionCondition.onAttackChain`

`resolution.Resolve` — the session stack's one entry point into the rulebook — installs exactly one gamectx registry (`WithRoom`, for prone's range predicate) and deliberately nothing else (`resolution/doc.go`, which already names `conditions.RagingCondition` deciding "from the event alone" as the intended pattern). Dueling and Protection never followed that pattern — legacy code carried over from before the session/resolution rewrite.

**A second, independent bug in Protection** made this worse: `onAttackChain` excluded only `event.TargetID == f.CharacterID` ("not attacking myself"), never `event.AttackerID == f.CharacterID` ("not my own attack"). Protection is a *reaction to someone else's attack* — per its own doc comment — so it should never evaluate on the protector's own swing at all. That gap is why an armed Fighter's *own* attack hit the gamectx-dependent branch in the first place.

### Fix (3 commits, in dependency order)

1. **`rulebooks/dnd5e` (top-level module)** — `5a0b707`
   - Dueling's eligibility (one-handed melee weapon, no off-hand weapon) is a **static** fact of the sheet and equipped gear, knowable at attack-compile time — exactly the class of fact `docs/ideas/session-sdk/attack-profile-seam.md`'s stress table says belongs in the compiler, not a live per-event lookup. `DamageChainEvent`/`DamageChainInput` gain `TwoHanded` and `OffHandWeaponRef`, threaded the same way `AbilityUsed` already is. `onDamageChain` now reads them directly, Raging-style — zero gamectx dependency left.
   - Protection gets the missing `event.AttackerID == f.CharacterID` exclusion. Its remaining gamectx dependency (shield + reaction-availability + position, to decide whether *this* character can react to *someone else's* attack on a *third* nearby character) is genuine dynamic third-party state that can't ride the attacker/target-shaped chain event the way Dueling's static facts now do — documented in place as tracked, deliberately out-of-scope debt (not exercised by any current caller).
2. **`resolution`** — `3d58913`, pinned to `5a0b707`
   - `AttackProfile` gains `TwoHanded`/`OffHandWeaponRef`; `AttackFromCharacter` computes both (grip/weapon property for the former, a new `otherHandWeaponRef` helper for the latter); threaded onto `DamageChainInput` in `rollDamage`.
3. **`session`** — `64210d8`, pinned to `3d58913`
   - go.mod bump only, plus the reproduction test.

### Test

`session.TestAnArmedDuelingFighterResolvesOnTheSessionStack` (`session/attack_test.go`) reproduces the live failure exactly: a Fighter with a longsword in the main hand, a shield in the off hand, and the Dueling fighting style chosen, driven through `session.Manager.Attack` — the identical path rpg-api calls. **No `gamectx.WithGameContext` is installed anywhere in the test**, matching the real stack; before the fix it fails with the exact live error, after the fix it resolves cleanly.

Also added: `conditions.TestDoesNotTriggerOnOwnAttack` (Protection, no gamectx installed either), a shield-in-off-hand Dueling case, and updated the pre-existing gamectx-mock-based Dueling tests to the new event-field approach.

## Verification

Per module, against the real pinned commits (no `go.work`, no local overrides):
- `go build ./...`, `go vet ./...` — clean, all three modules
- `go test -race -count=1 ./...` — all green, all three modules (including the full `rulebooks/dnd5e` suite, `integration/` included)
- `golangci-lint run ./...` — 0 issues, all three modules
- `gorelease` — backward compatible everywhere: `rulebooks/dnd5e` → v0.98.0, `resolution` → v0.12.0, `session` → v0.21.7 (test + pin only)
- `./scripts/check-decisions.sh` — all 45 ADRs summarised (no new ADR needed)

## Follow-up filed

Protection's remaining gamectx dependency (the "protect an ally" mechanic itself) and the same pattern in `MartialArtsCondition`/`UnarmoredDefenseCondition`/`UnarmoredMovementCondition` (Monk/Barbarian, unreachable by this Fighter repro) are named in #1178 as tracked follow-up work, deliberately not bundled into this emergency fix.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu