### PR TITLE
chore(resolution): re-pin dnd5e to tagged release

### DIFF
--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822114920-58a946928e6b
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822114920-58a946928e6b h1:VhWUcRPT8SfISGSP9rVxPZLz6+xWy5Dp1hxdL0t1lb8=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1-0.20260822114920-58a946928e6b/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1 h1:8KqSUfctVMx0+h0bO71fx/IH/7i9kjtAv6cqa7ZV8wY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0 h1:BnDZ//xyK/vcFmhUyDV8mRd4KSnj6Ofrz5Kpxy0GH1o=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=


### PR DESCRIPTION
## Summary

Pin bump only — no code change.

`resolution/go.mod` pinned `rulebooks/dnd5e` at a pseudo-version (`58a9469`) from PR #1179's own feature branch. #1179 squash-merged as `3c03885`, which orphaned that pseudo-version's commit SHA (unreachable from `main`) — the tag `rulebooks/dnd5e/v0.97.1` was cut from the merge commit instead, so a fresh clone resolving that pseudo-version would fail. Re-pinned to the real tag; identical content, cleaner version string.

Next in the dependency chain: once this tags, `session/go.mod` needs the same treatment for its `rulebooks/dnd5e`, `rulebooks/dnd5e/encounter`, and `rulebooks/dnd5e/resolution` pins — that's a separate PR, queued behind this one merging and tagging.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race -count=1 ./...` — all green
- `golangci-lint run ./...` — 0 issues
- Diff is go.mod/go.sum only (verified via `git diff --stat`)

No Copilot review requested for this one, per instruction — pin bump only.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu