### PR TITLE
monster: fix MeleeConfig.Reach's doc comment — it's feet, not hexes

### DIFF
--- a/rulebooks/dnd5e/monster/actions/melee.go
+++ b/rulebooks/dnd5e/monster/actions/melee.go
@@ -20,7 +20,12 @@ type MeleeConfig struct {
 	Name        string          `json:"name"`         // e.g., "shortsword", "greataxe"
 	AttackBonus int             `json:"attack_bonus"` // e.g., +4
 	Damage      []damage.Damage `json:"damage"`
-	Reach       int             `json:"reach"` // in hexes, typically 1 (5ft) or 2 (10ft reach)
+	// Reach is in FEET (Kirk, rpg-project#254 review) — typically 5 (one
+	// cell, the standard melee reach) or 10 (the Reach property, two
+	// cells). This comment previously said "in hexes", which was the
+	// actual bug: the data (skeleton's shortsword at 5, for instance) was
+	// always authored correctly, in feet.
+	Reach int `json:"reach"`
 }
 
 // MeleeAction implements a generic melee weapon attack.

--- a/rulebooks/dnd5e/monster/monsters/skeleton.go
+++ b/rulebooks/dnd5e/monster/monsters/skeleton.go
@@ -36,7 +36,7 @@ func NewSkeleton(id string) *monster.Monster {
 		Name:        "shortsword",
 		AttackBonus: 4, // +2 DEX + 2 proficiency
 		Damage:      []damage.Damage{{Dice: "1d6", Type: damage.Piercing, FlatBonus: 2}},
-		Reach:       1, // one cell (5ft) — a shortsword has no Reach property
+		Reach:       5, // feet — a shortsword has no Reach property
 	})))
 
 	// Shortbow ranged attack

--- a/rulebooks/dnd5e/monster/monsters/skeleton.go
+++ b/rulebooks/dnd5e/monster/monsters/skeleton.go
@@ -36,7 +36,7 @@ func NewSkeleton(id string) *monster.Monster {
 		Name:        "shortsword",
 		AttackBonus: 4, // +2 DEX + 2 proficiency
 		Damage:      []damage.Damage{{Dice: "1d6", Type: damage.Piercing, FlatBonus: 2}},
-		Reach:       5,
+		Reach:       1, // one cell (5ft) — a shortsword has no Reach property
 	})))
 
 	// Shortbow ranged attack

--- a/rulebooks/dnd5e/monster/monsters/skeleton_test.go
+++ b/rulebooks/dnd5e/monster/monsters/skeleton_test.go
@@ -68,6 +68,34 @@ func (s *SkeletonTestSuite) TestNewSkeleton() {
 	s.Assert().True(hasShortbow, "should have shortbow action")
 }
 
+// TestShortswordReachIsOneCell pins the fix for a data bug: the shortsword
+// was authored with Reach: 5 — five CELLS (25 feet, MeleeConfig's own doc
+// comment: "in hexes, typically 1 (5ft) or 2 (10ft reach)") — for a plain,
+// non-reach melee weapon that should be 1 cell (5ft), the same reach every
+// other one-handed weapon compiles to. Harmless while nothing read
+// AttackProfile.Reach for a monster action; live and wrong the moment the
+// monster's turn (rpg-toolkit#254) starts gating attacks by it — a skeleton
+// four cells from its target would attack without ever closing the
+// distance, which is exactly backwards from the tomb fixture's "walks
+// toward you, then attacks."
+func (s *SkeletonTestSuite) TestShortswordReachIsOneCell() {
+	skeleton := NewSkeleton("skeleton-1")
+
+	var shortsword monster.ActionData
+	for _, action := range skeleton.Actions() {
+		if action.GetID() == "shortsword" {
+			shortsword = action.ToData()
+		}
+	}
+	s.Require().NotEmpty(shortsword.Config, "shortsword action must be found")
+
+	var config struct {
+		Reach int `json:"reach"`
+	}
+	s.Require().NoError(json.Unmarshal(shortsword.Config, &config))
+	s.Equal(1, config.Reach)
+}
+
 func (s *SkeletonTestSuite) TestSkeletonTraits() {
 	skeleton := NewSkeleton("skeleton-1")
 	s.Require().NotNil(skeleton)

--- a/rulebooks/dnd5e/monster/monsters/skeleton_test.go
+++ b/rulebooks/dnd5e/monster/monsters/skeleton_test.go
@@ -68,17 +68,13 @@ func (s *SkeletonTestSuite) TestNewSkeleton() {
 	s.Assert().True(hasShortbow, "should have shortbow action")
 }
 
-// TestShortswordReachIsOneCell pins the fix for a data bug: the shortsword
-// was authored with Reach: 5 — five CELLS (25 feet, MeleeConfig's own doc
-// comment: "in hexes, typically 1 (5ft) or 2 (10ft reach)") — for a plain,
-// non-reach melee weapon that should be 1 cell (5ft), the same reach every
-// other one-handed weapon compiles to. Harmless while nothing read
-// AttackProfile.Reach for a monster action; live and wrong the moment the
-// monster's turn (rpg-toolkit#254) starts gating attacks by it — a skeleton
-// four cells from its target would attack without ever closing the
-// distance, which is exactly backwards from the tomb fixture's "walks
-// toward you, then attacks."
-func (s *SkeletonTestSuite) TestShortswordReachIsOneCell() {
+// TestShortswordReachIsStandardMeleeReach pins that the shortsword's
+// authored Reach (5) is correct — it is FEET (Kirk, rpg-project#254
+// review), not cells/hexes as MeleeConfig.Reach's doc comment used to
+// claim (that comment was the actual bug, fixed alongside this test). 5
+// feet is the standard one-handed melee reach every non-reach weapon
+// compiles to; a shortsword has no Reach property, so it gets no more.
+func (s *SkeletonTestSuite) TestShortswordReachIsStandardMeleeReach() {
 	skeleton := NewSkeleton("skeleton-1")
 
 	var shortsword monster.ActionData
@@ -93,7 +89,7 @@ func (s *SkeletonTestSuite) TestShortswordReachIsOneCell() {
 		Reach int `json:"reach"`
 	}
 	s.Require().NoError(json.Unmarshal(shortsword.Config, &config))
-	s.Equal(1, config.Reach)
+	s.Equal(5, config.Reach, "feet, the standard one-handed melee reach")
 }
 
 func (s *SkeletonTestSuite) TestSkeletonTraits() {


### PR DESCRIPTION
## Summary (corrected — see history)

**This PR's original diff was backwards.** Kirk's ruling on review: `MeleeConfig.Reach` is FEET, not hexes/cells. The original commit "fixed" skeleton.go's shortsword from `Reach: 5` to `Reach: 1` — but `5` (feet) was correct all along.

The real bug was `MeleeConfig.Reach`'s own doc comment: *"in hexes, typically 1 (5ft) or 2 (10ft reach)"*. That's what's fixed now — the comment says feet, and skeleton.go is reverted to its original, correct `Reach: 5`.

`TestShortswordReachIsOneCell` → renamed `TestShortswordReachIsStandardMeleeReach`, now pins `5`.

Companion fix, same correction: #1185 (resolution) — `AttackProfile.Reach` and `character_attack.go`'s `defaultMeleeReach`/`reachPropertyReach` constants need the identical feet correction (currently 1/2, i.e. cells). A `feet → cells` conversion helper is landing in `encounter` for the one place that actually needs cells: the reach gate (`session/reach.go`) and the movement budget.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race -count=1 ./...` — all green, full top-level module
- `golangci-lint run ./...` — 0 issues

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu