### PR TITLE
resolution: carry a monster action's Reach onto its compiled AttackProfile

### DIFF
--- a/rulebooks/dnd5e/resolution/character_attack.go
+++ b/rulebooks/dnd5e/resolution/character_attack.go
@@ -15,15 +15,22 @@ import (
 
 const (
 	// defaultMeleeReach is the melee reach used when the weapon carries no
-	// Reach property: 1 cell (5 ft), the 5e default and the reach of the
-	// canonical unarmed strike. Mirrors the retired top-level encounter
-	// module's defaultMeleeReachHexes (encounter/range_gate.go).
-	defaultMeleeReach = 1
+	// Reach property: 5 feet, the 5e default and the reach of the
+	// canonical unarmed strike.
+	//
+	// FEET, not cells (Kirk, rpg-project#254 review) — reach and speed are
+	// both authored in feet everywhere in this codebase's data, matching
+	// monster.ActionData.Reach and monster.SpeedData; a cell is 5 feet, and
+	// the ONE place that needs cells (session's reach gate, and the
+	// monster-turn's movement budget) converts once, at the point of
+	// comparison against Distance, rather than this compiler guessing at a
+	// conversion the gate is better placed to own.
+	defaultMeleeReach = 5
 
 	// reachPropertyReach is the melee reach a weapon with the Reach
-	// property grants: 2 cells (10 ft — glaive, halberd, spear-with-reach-
-	// variant, pike). Mirrors reachWeaponHexes in the same retired file.
-	reachPropertyReach = 2
+	// property grants: 10 feet (glaive, halberd, spear-with-reach-variant,
+	// pike) — see defaultMeleeReach's doc for the feet-not-cells note.
+	reachPropertyReach = 10
 )
 
 // CharacterAttackInput names which swing to compile.

--- a/rulebooks/dnd5e/resolution/character_attack_test.go
+++ b/rulebooks/dnd5e/resolution/character_attack_test.go
@@ -663,28 +663,30 @@ func (s *CharacterAttackTestSuite) TestACorruptSlotStaysErrBadAttack() {
 }
 
 // TestReach pins rpg-toolkit#1010's compiler half: a plain melee weapon
-// reaches 1 cell, a weapon carrying the Reach property reaches 2, and an
-// unarmed strike reaches 1 — the same numbers the retired top-level
+// reaches 5 feet, a weapon carrying the Reach property reaches 10, and an
+// unarmed strike reaches 5 — the same numbers the retired top-level
 // encounter module's checkReach enforced (encounter/range_gate.go) before
-// this rewrite dropped the check everywhere.
+// this rewrite dropped the check everywhere. Feet, not cells (Kirk,
+// rpg-project#254 review) — see [defaultMeleeReach]'s doc for why the
+// conversion to cells lives at the reach gate instead of here.
 func (s *CharacterAttackTestSuite) TestReach() {
-	s.Run("a plain melee weapon reaches 1 cell", func() {
+	s.Run("a plain melee weapon reaches 5 feet", func() {
 		profile := s.compile(s.martialHero(), s.mainHand())
-		s.Equal(1, profile.Reach)
+		s.Equal(5, profile.Reach)
 	})
 
-	s.Run("a weapon with the Reach property reaches 2 cells", func() {
+	s.Run("a weapon with the Reach property reaches 10 feet", func() {
 		sheet := s.heroSheet(
 			[]proficiencies.Weapon{proficiencies.WeaponMartial},
 			map[character.InventorySlot]string{character.SlotMainHand: string(weapons.Glaive)},
 		)
 		profile := s.compile(sheet, s.mainHand())
-		s.Equal(2, profile.Reach)
+		s.Equal(10, profile.Reach)
 	})
 
-	s.Run("an unarmed strike reaches 1 cell", func() {
+	s.Run("an unarmed strike reaches 5 feet", func() {
 		profile := s.compile(s.heroSheet(nil, nil), s.mainHand())
-		s.Equal(1, profile.Reach)
+		s.Equal(5, profile.Reach)
 	})
 }
 

--- a/rulebooks/dnd5e/resolution/monster_attack_test.go
+++ b/rulebooks/dnd5e/resolution/monster_attack_test.go
@@ -58,7 +58,7 @@ func (s *MonsterAttackTestSuite) TestMeleePreservesCanonicalPoolsAndIntrinsicBon
 				Name:        "enchanted scimitar",
 				AttackBonus: 4,
 				Damage:      want,
-				Reach:       1,
+				Reach:       5,
 			})
 
 			profile, err := AttackFromMonsterAction(action)
@@ -70,7 +70,7 @@ func (s *MonsterAttackTestSuite) TestMeleePreservesCanonicalPoolsAndIntrinsicBon
 			s.Zero(profile.AbilityModifier)
 			s.Nil(profile.Gate)
 			s.Nil(profile.Imposes)
-			s.Equal(1, profile.Reach, "the action's own authored Reach carries onto the profile")
+			s.Equal(5, profile.Reach, "the action's own authored Reach (feet) carries onto the profile")
 		})
 	}
 }
@@ -78,20 +78,20 @@ func (s *MonsterAttackTestSuite) TestMeleePreservesCanonicalPoolsAndIntrinsicBon
 // TestMeleeReachCarriesTheAuthoredValue pins the fix: a generic melee
 // action's Reach was silently dropped — AttackProfile.Reach stayed zero
 // regardless of what the stat block authored, meaning nothing gated a
-// monster's melee attack by reach at all. A reach weapon (Reach: 2, e.g.
-// a spear-wielding monster) must compile to Reach 2, not the plain-weapon
-// default.
+// monster's melee attack by reach at all. A reach weapon (Reach: 10 feet,
+// e.g. a spear-wielding monster) must compile to Reach 10, not the
+// plain-weapon default.
 func (s *MonsterAttackTestSuite) TestMeleeReachCarriesTheAuthoredValue() {
 	action := s.action(refs.MonsterActions.Melee(), monsterActions.MeleeConfig{
 		Name:        "spear",
 		AttackBonus: 4,
 		Damage:      []damage.Damage{{Dice: "1d6", Type: damage.Piercing}},
-		Reach:       2,
+		Reach:       10,
 	})
 
 	profile, err := AttackFromMonsterAction(action)
 	s.Require().NoError(err)
-	s.Equal(2, profile.Reach)
+	s.Equal(10, profile.Reach)
 }
 
 // TestBiteReachIsTheFixedMeleeDefault pins that a bite — which has no

--- a/rulebooks/dnd5e/resolution/monster_attack_test.go
+++ b/rulebooks/dnd5e/resolution/monster_attack_test.go
@@ -70,8 +70,44 @@ func (s *MonsterAttackTestSuite) TestMeleePreservesCanonicalPoolsAndIntrinsicBon
 			s.Zero(profile.AbilityModifier)
 			s.Nil(profile.Gate)
 			s.Nil(profile.Imposes)
+			s.Equal(1, profile.Reach, "the action's own authored Reach carries onto the profile")
 		})
 	}
+}
+
+// TestMeleeReachCarriesTheAuthoredValue pins the fix: a generic melee
+// action's Reach was silently dropped — AttackProfile.Reach stayed zero
+// regardless of what the stat block authored, meaning nothing gated a
+// monster's melee attack by reach at all. A reach weapon (Reach: 2, e.g.
+// a spear-wielding monster) must compile to Reach 2, not the plain-weapon
+// default.
+func (s *MonsterAttackTestSuite) TestMeleeReachCarriesTheAuthoredValue() {
+	action := s.action(refs.MonsterActions.Melee(), monsterActions.MeleeConfig{
+		Name:        "spear",
+		AttackBonus: 4,
+		Damage:      []damage.Damage{{Dice: "1d6", Type: damage.Piercing}},
+		Reach:       2,
+	})
+
+	profile, err := AttackFromMonsterAction(action)
+	s.Require().NoError(err)
+	s.Equal(2, profile.Reach)
+}
+
+// TestBiteReachIsTheFixedMeleeDefault pins that a bite — which has no
+// configurable Reach field at all (BiteConfig carries none) — compiles to
+// the same fixed melee reach a plain weapon or an unarmed strike does, not
+// zero (which would refuse every monster bite at any distance once Reach
+// starts being gated).
+func (s *MonsterAttackTestSuite) TestBiteReachIsTheFixedMeleeDefault() {
+	action := s.action(refs.MonsterActions.Bite(), monsterActions.BiteConfig{
+		AttackBonus: 4,
+		Damage:      []damage.Damage{{Dice: "2d4", Type: damage.Piercing}},
+	})
+
+	profile, err := AttackFromMonsterAction(action)
+	s.Require().NoError(err)
+	s.Equal(defaultMeleeReach, profile.Reach)
 }
 
 func (s *MonsterAttackTestSuite) TestBitePreservesCanonicalDamageAndGate() {

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -72,17 +72,19 @@ type AttackProfile struct {
 	// AttackBonus is added to the d20.
 	AttackBonus int
 
-	// Reach is how far this melee attack reaches, in grid cells: 1 (the 5e
-	// default, and the unarmed strike's own reach) or 2 for a weapon
-	// carrying the Reach property (rpg-toolkit#1010). Ported from the
-	// retired top-level encounter module's checkReach/meleeReachForWeapon
-	// (encounter/range_gate.go), which enforced exactly this distinction
-	// before the rewrite dropped it — see that file's own history for the
-	// QA walk that found it missing everywhere.
+	// Reach is how far this melee attack reaches, in FEET: 5 (the 5e
+	// default, and the unarmed strike's own reach) or 10 for a weapon
+	// carrying the Reach property (rpg-toolkit#1010). Feet, not cells
+	// (Kirk, rpg-project#254 review) — the same unit monster.ActionData's
+	// own Reach field and monster.SpeedData already use; a cell is 5 feet,
+	// and the one place that needs cells (the reach gate, the monster
+	// turn's movement budget) converts once, at the point of comparison,
+	// rather than every producer of this field guessing at the conversion.
 	//
-	// Zero from [AttackFromMonsterAction] today, the same scope note
-	// [AttackProfile.Name] carries: a monster attacker does not yet reach a
-	// caller that gates on this (v1 compiles CHARACTER attackers only).
+	// Populated by both compilers now — [AttackFromCharacter] via
+	// [defaultMeleeReach]/[reachPropertyReach], [AttackFromMonsterAction]
+	// via the action's own authored Reach (rpg-project#254; previously
+	// silently zero for every monster action, since nothing read it).
 	// Meaningless for a ranged attack, which never compiles a profile at
 	// all (IsRanged refuses before one is built).
 	Reach int

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -746,6 +746,13 @@ func attackFromMelee(action monster.ActionData) (AttackProfile, error) {
 		Ref:         &ref,
 		AttackBonus: config.AttackBonus,
 		Damage:      copyDamagePools(config.Damage),
+		// The stat block's own authored reach, in cells — carried through
+		// faithfully rather than clamped or defaulted here: this compiler
+		// trusts the content the same way it already trusts AttackBonus and
+		// Damage. Previously dropped entirely (AttackProfile.Reach stayed
+		// zero for every monster melee action), which was harmless only
+		// because nothing gated a monster's attack by reach yet.
+		Reach: config.Reach,
 	}
 	if err := profile.validate(); err != nil {
 		return AttackProfile{}, err
@@ -770,6 +777,10 @@ func attackFromBite(action monster.ActionData) (AttackProfile, error) {
 		AttackBonus: config.AttackBonus,
 		Damage:      copyDamagePools(config.Damage),
 		Gate:        config.SaveGate,
+		// BiteConfig carries no configurable reach — a bite is always the
+		// fixed melee reach, the same default a plain weapon or an unarmed
+		// strike compiles to (character_attack.go's defaultMeleeReach).
+		Reach: defaultMeleeReach,
 	}
 
 	// A bite's gate is a KNOCKDOWN — that is what the stat block's


### PR DESCRIPTION
## Summary

Closes #1184 — slice of rpg-project#254 (the monster's turn). The toolkit brief's item 2: "resolution: only if Striker needs an export that doesn't exist (AttackFromMonsterAction exists; reach from ActionData.Reach)."

`AttackFromMonsterAction`/`attackFromMelee` never populated `AttackProfile.Reach` from `ActionData`'s `Reach` field (confirmed by reading `strike.go` before touching it). `attackFromBite` had nothing to read from — `BiteConfig` carries no `Reach` field. Both meant every monster attack's `AttackProfile.Reach` was silently zero, so nothing could gate a monster's attack by distance the way `session.Attack` already gates a character's.

The monster's-turn drive loop needs `Reach` populated to execute an `Attack` intent correctly — a monster whose driver returns an attack against an out-of-reach target should be refused (`ErrBadIntent`), and the tomb fixture needs a skeleton to close distance before attacking.

- `attackFromMelee` now carries the action's own authored `Reach` through faithfully, the same way it already trusts `AttackBonus` and `Damage`.
- `attackFromBite` sets the fixed melee default (`defaultMeleeReach`, the same constant a plain weapon or an unarmed strike already compiles to) — a bite has no configurable reach to author.

## Units correction (Kirk, rpg-project#254 review)

This PR's constants (`defaultMeleeReach`, `reachPropertyReach`, both carried over from #1010) and `AttackProfile.Reach`'s own doc comment claimed reach was measured "in cells"/"in hexes". That was wrong: reach and speed are authored in **feet** everywhere in this codebase's data — matching `monster.ActionData.Reach` and `monster.SpeedData` — and always were. The doc comment was the bug, not the data.

- `defaultMeleeReach`: 1 → 5, `reachPropertyReach`: 2 → 10 (both now feet, with doc comments explaining why)
- `AttackProfile.Reach`'s field doc fixed to feet, and its stale "zero from `AttackFromMonsterAction` today" note removed — this PR's own earlier commit already populates it for monster actions (see Copilot thread below)
- `TestReach` and the monster-action reach tests updated to feet values (5/10 instead of 1/2), with more realistic fixtures (a "spear" example at 10 ft, a real reach weapon)
- A cell is 5 feet. The one place that needs cells — the reach gate in `session`, and the monster turn's movement budget — converts once, at the point of comparison against grid `Distance`, rather than every producer of this field guessing at a conversion. That helper lands in a follow-up PR (encounter/session modules).

This is a companion correction to #1183, which **reverts** an earlier "fix" to skeleton.go's `Reach: 5` (that PR briefly changed it to `Reach: 1` under the same wrong cells/hexes assumption this PR just corrected) — the data was right all along; only the doc comments were wrong.

## Test

`TestMeleeReachCarriesTheAuthoredValue`, `TestBiteReachIsTheFixedMeleeDefault`; `TestMeleePreservesCanonicalPoolsAndIntrinsicBonuses` gains a `Reach` assertion (it was passing a `Reach` fixture without ever checking it landed anywhere). `TestReach` (character weapon compiler, #1010) updated to feet values.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race -count=1 ./...` — all green
- `golangci-lint run ./...` — 0 issues
- `gorelease` — backward compatible, suggests `v0.11.6`
- `./scripts/check-decisions.sh` — all 45 ADRs summarised (no new ADR needed)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu