### PR TITLE
encounter: the monster's turn — MonsterView, TurnIntent, Striker

### DIFF
--- a/rulebooks/dnd5e/encounter/arrival_test.go
+++ b/rulebooks/dnd5e/encounter/arrival_test.go
@@ -89,7 +89,7 @@ func (s *ArrivalSuite) arrivalEncounter(filter encounter.MemberID, walker encoun
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field:   arrivalField(),
 		Members: members,
 		Endings: []encounter.EndingInput{

--- a/rulebooks/dnd5e/encounter/atlas_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_test.go
@@ -26,7 +26,7 @@ import (
 // all exercised by the same tests that already cover Cells/Props.
 func validAtlasOrderingSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -66,7 +66,7 @@ func validAtlasOrderingSetup() *encounter.SetupInput {
 // a point off in empty space (#929 T3 fix round item 5).
 func validAtlasVoidGapSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -87,7 +87,7 @@ func validAtlasVoidGapSetup() *encounter.SetupInput {
 // IsValidPosition without any Origin arithmetic in the way.
 func singleRoomSetup(shape spatial.GridShape, width, height int) *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: orientationFor(shape)},
 			Rooms:  []encounter.RoomInput{{ID: "solo", Width: width, Height: height, Grid: shape}},
@@ -400,7 +400,7 @@ func (s *EncounterTestSuite) TestAtlasIdenticalAfterReload() {
 
 	data := enc1.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err)
 
 	atlas2, err := enc2.Atlas()

--- a/rulebooks/dnd5e/encounter/atlascost_test.go
+++ b/rulebooks/dnd5e/encounter/atlascost_test.go
@@ -57,7 +57,7 @@ func TestAtlasReportsRegionsWithoutEnumeratingThem(t *testing.T) {
 
 	t.Run("and reporting them costs O(regions), not O(cells)", func(t *testing.T) {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: budgetField(),
 			Members: []encounter.MemberInput{
 				{ID: alice, Kind: encounter.KindPlayer, Room: "a", Position: spatial.Position{X: 1, Y: 1}},

--- a/rulebooks/dnd5e/encounter/beatorder_test.go
+++ b/rulebooks/dnd5e/encounter/beatorder_test.go
@@ -80,7 +80,7 @@ func (s *BeatOrderTestSuite) beatKinds(enc *encounter.Encounter, audience encoun
 // that has not opened yet.
 func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
 			// Both clear of the wall's span: they see each other at first light.
@@ -102,7 +102,7 @@ func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
 // and the story cannot tell this step apart from any other (rpg-toolkit#1106).
 func (s *BeatOrderTestSuite) TestAStepThroughADoorwayBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -196,7 +196,7 @@ func (s *BeatOrderTestSuite) TestOpenDoorOpensBeforeItFights() {
 	const shutDoor = "shut-door"
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -240,7 +240,7 @@ func (s *BeatOrderTestSuite) blockedScene(decider ...encounter.Decider) *encount
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{wallRoom()}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: beatOrderRoom, Position: spatial.Position{X: 6, Y: 2}},

--- a/rulebooks/dnd5e/encounter/canvas_test.go
+++ b/rulebooks/dnd5e/encounter/canvas_test.go
@@ -138,7 +138,7 @@ func tombAt(origin spatial.Position, x, y int) spatial.Position {
 // them. Nothing about rooms can tell them apart.
 func (s *CanvasSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
@@ -300,7 +300,7 @@ func TestAnOldDialectBlobIsRefusedByName(t *testing.T) {
 		"the old blob still PARSES — that is exactly why the refusal has to be by name")
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data,
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data,
 	})
 	require.Error(t, err, "a room-local placement must not load as an absolute one")
 	require.ErrorIs(t, err, encounter.ErrInvalidData)
@@ -325,7 +325,7 @@ func TestAnOldDialectBlobIsRefusedByName(t *testing.T) {
 func TestASquareFieldMustFitOneGrid(t *testing.T) {
 	setup := func(origin spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms:  []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5, Origin: origin}},
@@ -357,7 +357,7 @@ func TestASquareFieldMustFitOneGrid(t *testing.T) {
 // and this check never rejects one.
 func TestAHexFieldNeedsNoSuchLaw(t *testing.T) {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
@@ -394,7 +394,7 @@ func TestPropsAreCompiledThroughTheirRoomsAnchor(t *testing.T) {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: tombHall,
@@ -421,7 +421,7 @@ func TestPropsAreCompiledThroughTheirRoomsAnchor(t *testing.T) {
 func TestABoundaryThatCannotBeDrawnIsRefusedAtConstruction(t *testing.T) {
 	setup := func(b spatial.Boundary) *encounter.SetupInput {
 		return &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{

--- a/rulebooks/dnd5e/encounter/canvasread_test.go
+++ b/rulebooks/dnd5e/encounter/canvasread_test.go
@@ -57,7 +57,7 @@ func TestCanvasReadSuite(t *testing.T) {
 // point: a map with nothing in the way agrees with any other map.
 func (s *CanvasReadSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -60,7 +60,7 @@ func TestVaultChase(t *testing.T) {
 	// composition's room-shaped topology (rpg-toolkit#1044).
 	pursuit := &pursuitDecider{target: alice}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -134,7 +134,7 @@ func TestVaultChase(t *testing.T) {
 	// INTEL does — beliefs are state and traveled in the aggregate).
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &pursuitDecider{doorways: atlas.Doorways, target: alice},
 		}})
 	require.NoError(t, err, "beat 3: the suspended chase crosses a process boundary")

--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -4,6 +4,7 @@
 package encounter
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -11,6 +12,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/play/clock"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
 	"github.com/KirkDiggler/rpg-toolkit/play/record"
 )
 
@@ -298,35 +300,272 @@ func (e *Encounter) driveMonsterTurns(bubble *clock.Turn) (wrapped bool, lastSeq
 			break
 		}
 
-		outcome, derr := e.turnDriver.Act(activeID)
+		seq, roundWrapped, derr := e.driveOneMonsterTurn(bubble, active, m)
 		if derr != nil {
 			return wrapped, lastSeq, fmt.Errorf("drive monster turns %q: %w", activeID, derr)
 		}
-
-		switch outcome.(type) {
-		case Pass:
-			out, eerr := bubble.End(&clock.EndInput{Actor: active})
-			if eerr != nil {
-				return wrapped, lastSeq, fmt.Errorf("drive monster turns %q: %w", activeID, eerr)
-			}
-			wrapped = wrapped || out.RoundWrapped
-
-			seq, berr := e.appendClockBeat(map[string]interface{}{
-				"beat":   "turn-ended",
-				"member": string(activeID),
-				"next":   out.Next,
-			})
-			if berr != nil {
-				return wrapped, lastSeq, fmt.Errorf("drive monster turns append beat: %w", berr)
-			}
-			lastSeq = seq
-		default:
-			return wrapped, lastSeq, fmt.Errorf(
-				"drive monster turns %q: driver returned %T: %w", activeID, outcome, ErrBadTurnOutcome)
-		}
+		wrapped = wrapped || roundWrapped
+		lastSeq = seq
 	}
 
 	return wrapped, lastSeq, nil
+}
+
+// driveOneMonsterTurn runs ONE unplayed member's whole turn: build view →
+// Act → execute → repeat until [Pass] or the budget is spent, then end the
+// turn. Returns the sequence of the terminating "turn-ended" beat.
+//
+// THE BUDGET IS ONE ATTACK PLUS THE MEMBER'S OWN SPEED, IN FEET (Kirk,
+// rpg-project#254 review). A driver is asked again after every executed
+// intent — an Attack that lands still leaves movement to spend, a Move that
+// only closes half the distance still leaves the attack unspent — and the
+// inner loop is bounded (attacksLeft + movement-in-cells + one terminating
+// call) so a driver that never returns Pass cannot spin this forever.
+//
+// A DRIVER'S OWN Go ERROR ABORTS THE WHOLE CALL, exactly as it always has —
+// see [TurnDriver.Act]'s doc. A syntactically valid but unexecutable intent
+// does NOT: it is [ErrBadIntent], and this member's turn simply ends as
+// [Pass] would, so the caller's own verb (EndTurn, form) still succeeds.
+// This is the asymmetry the brief calls for: a driver malfunction is this
+// module's problem, a bad decision is the driver's own business, and only
+// one of those should cost the whole call.
+func (e *Encounter) driveOneMonsterTurn(
+	bubble *clock.Turn, active core.EntityID, m *memberRecord,
+) (seq uint64, roundWrapped bool, err error) {
+	activeID := MemberID(active)
+
+	round, rerr := bubble.Round()
+	if rerr != nil {
+		return 0, false, fmt.Errorf("round: %w", rerr)
+	}
+
+	budget := TurnBudget{AttacksLeft: 1, MovementFeet: m.SpeedFeet}
+
+	// See the function doc: bounded so a misbehaving driver cannot spin the
+	// caller. +2 covers one attack and the terminating Pass a well-behaved
+	// driver returns once it has nothing left; the rest is however many
+	// cells this member could ever afford to ask for one at a time.
+	innerBound := 2 + CellsFromFeet(budget.MovementFeet)
+
+	for j := 0; j < innerBound; j++ {
+		view, verr := e.buildMonsterView(m, budget, round)
+		if verr != nil {
+			return 0, false, fmt.Errorf("view: %w", verr)
+		}
+
+		intent, derr := e.turnDriver.Act(view)
+		if derr != nil {
+			return 0, false, fmt.Errorf("act: %w", derr)
+		}
+
+		done, dexecerr := e.executeTurnIntent(activeID, m, view, intent, &budget)
+		if dexecerr != nil {
+			return 0, false, fmt.Errorf("execute: %w", dexecerr)
+		}
+		if done {
+			break
+		}
+	}
+
+	out, eerr := bubble.End(&clock.EndInput{Actor: active})
+	if eerr != nil {
+		return 0, false, fmt.Errorf("end: %w", eerr)
+	}
+
+	seq, berr := e.appendClockBeat(map[string]interface{}{
+		"beat":   "turn-ended",
+		"member": string(activeID),
+		"next":   out.Next,
+	})
+	if berr != nil {
+		return 0, false, fmt.Errorf("append beat: %w", berr)
+	}
+	return seq, out.RoundWrapped, nil
+}
+
+// executeTurnIntent runs one Act call's answer and reports whether this
+// member's turn is over — [Pass], an [ErrBadIntent]-refused [Attack] or
+// [Move], or a [Move] that made no progress at all all end the turn the same
+// way; a successful [Attack] or [Move] leaves it running so the driver is
+// asked again against the updated budget and view.
+//
+// budget is mutated in place: the one thing every branch here shares is that
+// what it spends must be visible to the NEXT buildMonsterView call, and a
+// return value the caller has to remember to feed back in is exactly the
+// kind of two-truths bug this composition's own field.go doc warns against
+// elsewhere.
+func (e *Encounter) executeTurnIntent(
+	activeID MemberID, m *memberRecord, view MonsterView, intent TurnIntent, budget *TurnBudget,
+) (done bool, err error) {
+	switch it := intent.(type) {
+	case Pass:
+		return true, nil
+
+	case Attack:
+		if !attackIsInReach(view, it) || budget.AttacksLeft <= 0 {
+			// ErrBadIntent: not a driver malfunction (see the type's own
+			// doc) — this member's turn simply ends, exactly like Pass.
+			return true, nil
+		}
+
+		// context.Background() rather than a threaded caller context: no
+		// verb on this composition accepts one today (EndTurn, form, Step —
+		// see this module's CLAUDE.md, "play/* leaves take no
+		// context.Context"), and Striker is the first capability that does,
+		// by the brief's own design. Plumbing a context through every
+		// verb between a host's request and here is a bigger change than
+		// this slice asks for; the day Striker's own implementation needs
+		// cancellation propagated from the host, that is the day to revisit
+		// this rather than the day to speculatively add it everywhere now.
+		if serr := e.striker.Strike(context.Background(), e, activeID, it.Target, it.Action); serr != nil {
+			return false, fmt.Errorf("strike: %w", serr)
+		}
+		budget.AttacksLeft = 0
+		return false, nil
+
+	case Move:
+		cellsAffordable := CellsFromFeet(budget.MovementFeet)
+		if len(it.Path) == 0 || len(it.Path) > cellsAffordable {
+			// ErrBadIntent: a driver asking for more than its own budget, or
+			// for nothing at all (that is what Pass is for) — this member's
+			// turn ends rather than executing a path it did not fully ask
+			// for.
+			return true, nil
+		}
+
+		at := uint64(e.clock.ToData().HighWater)
+		audience := e.rosterIDs()
+		moved := 0
+		for _, cell := range it.Path {
+			action, stepped := e.stepTo(m, cell)
+			if !stepped {
+				// The same silent-refusal contract stepTo already has for
+				// the pump: a wall stops the WALK, not the turn — whatever
+				// cells succeeded before it are kept (rpg-project#254,
+				// "the same refusals a player's walk meets").
+				break
+			}
+			if _, berr := e.appendMovementBeat(action, audience, at); berr != nil {
+				return false, fmt.Errorf("move beat: %w", berr)
+			}
+			moved++
+		}
+		budget.MovementFeet -= moved * FeetPerCell
+
+		if moved > 0 {
+			// Refreshed once for the whole intent, not per cell — the same
+			// batching Pump uses for its own multi-member tick, and what
+			// makes the NEXT buildMonsterView call in this same turn see
+			// where this member actually ended up. A straggler this move
+			// brings into contact JOINS the running bubble rather than
+			// starting a second one (trigger.go's classify: "a fight
+			// already running is joined, not started again") — the one-
+			// bubble policy is not at risk here.
+			if _, _, serr := e.refreshSight(audience); serr != nil {
+				return false, fmt.Errorf("refresh sight: %w", serr)
+			}
+		}
+
+		// Zero cells succeeded: the driver asked for a path that could not
+		// even start from here. Ending the turn rather than re-asking
+		// avoids spinning on a request that will not succeed differently
+		// next time this same view is built.
+		return moved == 0, nil
+
+	default:
+		return false, fmt.Errorf("driver returned %T: %w", intent, ErrBadTurnOutcome)
+	}
+}
+
+// attackIsInReach reports whether intent's target is a currently Seen,
+// Standing member within intent's own Action's reach.
+//
+// A SINGLE MAP LOOKUP DOES BOTH CHECKS AT ONCE, deliberately: SeenMember's
+// InReach is only ever populated for THIS member's own [MonsterView.Actions]
+// (see [Encounter.buildMonsterView]), so a Ref that does not name one of
+// this member's own actions is simply absent from the map — Go's zero value
+// for a missing key is false, which is exactly "not in reach" for an action
+// this member does not have. No separate "is this even my action" check is
+// needed because there is no way to reach true without it also being true.
+func attackIsInReach(view MonsterView, intent Attack) bool {
+	for _, sm := range view.Seen {
+		if sm.ID != intent.Target {
+			continue
+		}
+		return sm.Standing && sm.InReach[intent.Action]
+	}
+	return false
+}
+
+// buildMonsterView projects member's own static facts, its currently active
+// sight intel, and the turn's remaining budget into the shape a [TurnDriver]
+// is allowed to see — the same anti-wall-hack contract [Decider]'s Snapshot
+// keeps (C2), extended to a turn's own questions.
+func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round int) (MonsterView, error) {
+	ownCell, err := e.cellOf(m)
+	if err != nil {
+		return MonsterView{}, fmt.Errorf("position: %w", err)
+	}
+
+	down, err := e.standingNow()
+	if err != nil {
+		return MonsterView{}, fmt.Errorf("standing: %w", err)
+	}
+
+	// The member's own holdings and nothing else (C2) — the same call
+	// Pump's own Decider consult makes for a Snapshot, one seam over.
+	holdings, err := e.intelLog.HeldBy(&intel.HeldByInput{Observer: m.ID})
+	if err != nil {
+		return MonsterView{}, fmt.Errorf("held by: %w", err)
+	}
+
+	var seen []SeenMember
+	for _, h := range holdings {
+		// Sight channel, ACTIVELY sustained only (intel.Current) — a stale
+		// "held" memory (intel.Held, a ghost: known but not currently
+		// sustained) is not something this member can act on this turn, so
+		// it is excluded here rather than left for a driver to filter.
+		if h.Channel != intel.Sight || h.Status != intel.Current {
+			continue
+		}
+		subjectID := MemberID(h.Subject)
+		other, ok := e.members[subjectID]
+		if !ok {
+			continue
+		}
+		pos, ok := DecodeSightPayload(h.Payload)
+		if !ok {
+			continue
+		}
+
+		dist := e.Distance(ownCell, pos)
+		inReach := make(map[core.Ref]bool, len(m.Actions))
+		for _, a := range m.Actions {
+			inReach[a.Ref] = dist <= float64(CellsFromFeet(a.ReachFeet))
+		}
+
+		seen = append(seen, SeenMember{
+			ID:       subjectID,
+			Kind:     other.Kind,
+			Standing: !down[subjectID],
+			Position: pos,
+			Distance: dist,
+			InReach:  inReach,
+		})
+	}
+	// C8: a driver asked twice against unchanged data must see the same
+	// order, not whatever order the intel map happened to range in.
+	sort.Slice(seen, func(i, j int) bool { return seen[i].ID < seen[j].ID })
+
+	return MonsterView{
+		Self:      m.ID,
+		Position:  ownCell,
+		Actions:   m.Actions,
+		Targeting: m.Targeting,
+		Seen:      seen,
+		Budget:    budget,
+		Round:     round,
+	}, nil
 }
 
 // driveIfStillRunning calls driveMonsterTurns on bubble if it still holds any

--- a/rulebooks/dnd5e/encounter/clocks_internal_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_internal_test.go
@@ -28,7 +28,7 @@ import (
 // save. With it, the defect is loud: ErrInvalidData, never a guess.
 func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 	enc, err := NewEncounter(&SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: FieldInput{
 			Canvas: CanvasInput{Void: VoidIsOpaque()},
 			Rooms:  []RoomInput{{ID: "room-1", Width: 10, Height: 10}},
@@ -72,7 +72,7 @@ func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 func TestFormRejections(t *testing.T) {
 	newEnc := func() *Encounter {
 		enc, err := NewEncounter(&SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: FieldInput{Canvas: CanvasInput{Void: VoidIsOpaque()}, Rooms: []RoomInput{
 				{ID: "r1", Width: 8, Height: 8, Boundaries: sealedSeam(7, 8)},
 				{ID: "r2", Width: 8, Height: 8, Origin: spatial.Position{X: 8, Y: 0}},
@@ -187,7 +187,7 @@ func sealedSeam(atX, height int) []spatial.Boundary {
 // form directly, the same white-box reason TestFormRejections does.
 func TestFormRefusesAPlayerFreeBubble(t *testing.T) {
 	enc, err := NewEncounter(&SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: FieldInput{Canvas: CanvasInput{Void: VoidIsOpaque()}, Rooms: []RoomInput{
 			{ID: "r1", Width: 8, Height: 8},
 		}},
@@ -201,4 +201,47 @@ func TestFormRefusesAPlayerFreeBubble(t *testing.T) {
 
 	_, err = enc.form(&FormInput{Order: []MemberID{"goblin", "wolf"}})
 	require.ErrorIs(t, err, ErrNoPlayerInBubble)
+}
+
+// rogueTurnIntent is a TurnIntent this package's own switch cannot possibly
+// have a case for — constructible only from inside this package, since
+// TurnIntent is sealed on an unexported method (ADR-0038's practice for
+// sealed vocabularies at this seam). It exists to reach ErrBadTurnOutcome's
+// one white-box path, the same reason rogueTurnOutcome-style fixtures exist
+// beside every other sealed vocabulary in this module.
+type rogueTurnIntent struct{}
+
+func (rogueTurnIntent) isTurnIntent() {}
+
+// rogueDriver always returns the sealed vocabulary's own defect.
+type rogueDriver struct{}
+
+func (rogueDriver) Act(MonsterView) (TurnIntent, error) {
+	return rogueTurnIntent{}, nil
+}
+
+// TestADriverReturningAnUnrecognisedIntentIsErrBadTurnOutcome pins the
+// sealed vocabulary's own defensive net: TurnIntent is sealed so nothing
+// OUTSIDE this package can construct a fourth case, but a value satisfying
+// the interface from INSIDE it (a future case added here without every call
+// site catching up) must fail loudly rather than silently fall through
+// driveMonsterTurns' switch.
+func TestADriverReturningAnUnrecognisedIntentIsErrBadTurnOutcome(t *testing.T) {
+	enc, err := NewEncounter(&SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: rogueDriver{}, Striker: passStriker{},
+		Field: FieldInput{
+			Canvas: CanvasInput{Void: VoidIsOpaque()},
+			Rooms:  []RoomInput{{ID: "room-1", Width: 8, Height: 8}},
+		},
+		Members: []MemberInput{
+			{ID: "alice", Kind: KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "goblin", Kind: KindMonster, Room: "room-1", Position: spatial.Position{X: 2, Y: 1}},
+		},
+		Endings: []EndingInput{{Key: "called", Trigger: TriggerExternal{}}},
+	})
+	require.NoError(t, err)
+
+	_, err = enc.EndTurn(&EndTurnInput{Member: "alice"})
+	require.ErrorIs(t, err, ErrBadTurnOutcome)
 }

--- a/rulebooks/dnd5e/encounter/clocks_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_test.go
@@ -26,7 +26,7 @@ type ClocksTestSuite struct {
 // monster in one room.
 func (s *ClocksTestSuite) twoMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			// The goblin waits in the NEXT ROOM, which is how real content is
@@ -139,7 +139,7 @@ func (s *ClocksTestSuite) TestABubbleRoundTripsAndIsReachedThroughItsMembers() {
 	}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err)
 
 	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -193,7 +193,7 @@ func (s *ClocksTestSuite) TestAMemberOutsideTheFightKeepsFreeRoamingWhileItRuns(
 	}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err)
 
 	fighting, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -227,7 +227,7 @@ func (s *ClocksTestSuite) TestMutatingTheReturnedOrderCannotCorruptTheEncounter(
 	data.Bubbles = []clock.TurnData{{Order: []core.EntityID{goblin, alice}, ActiveIdx: 0, Round: 1}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err)
 
 	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -251,7 +251,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAMemberOnTwoClocks() {
 		data.Bubbles = []clock.TurnData{{Order: []core.EntityID{goblin, alice}, ActiveIdx: 0, Round: 1}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -267,7 +267,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAMemberOnTwoClocks() {
 		}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -293,7 +293,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		data.Clock.Budgets["ghost"] = 0
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -307,7 +307,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -320,7 +320,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -340,7 +340,7 @@ func (s *ClocksTestSuite) TestABlobFromBeforeClockMembershipLoadsEveryoneOntoThe
 	data.Bubbles = nil
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err)
 
 	for _, id := range []core.EntityID{alice, goblin} {
@@ -366,7 +366,7 @@ const (
 // monster in one room, plus an external ending so closure is reachable.
 func (s *ClocksTestSuite) fiveMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -412,7 +412,7 @@ func (s *ClocksTestSuite) assertR6(enc *encounter.Encounter, members ...core.Ent
 		s.Require().NoError(err, "member %q must be on exactly one clock", id)
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc.ToData()})
 	s.Require().NoError(err, "the persisted shape must pass the trust boundary (R6)")
 }
 
@@ -716,7 +716,7 @@ func (s *ClocksTestSuite) TestTheActiveFightMemberCanStep() {
 func (s *ClocksTestSuite) TestPumpDoesNotThinkForAFightMonster() {
 	wanderer := &patrolDecider{positions: []spatial.Position{{X: 5, Y: 5}, {X: 6, Y: 5}}}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
@@ -789,7 +789,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAnIdleBubble() {
 	data.Bubbles = []clock.TurnData{{}}
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.ErrorIs(err, encounter.ErrInvalidData)
 }
@@ -809,7 +809,7 @@ func (s *ClocksTestSuite) TestAMidFightBlobRoundTrips() {
 	enc := s.fiveMemberEncounter()
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	// Reached through a member of the fight — bob is exploring next door.
@@ -907,7 +907,7 @@ func (r monstersBeforePlayers) RollInitiative(members []core.EntityID) ([]core.E
 // EndTurn (see form's own doc).
 func (s *ClocksTestSuite) TestFightStartDrivesAnUnplayedMemberFirstInInitiative() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Initiative: monstersBeforePlayers{kinds: map[core.EntityID]encounter.MemberKind{
 			alice: encounter.KindPlayer, goblin: encounter.KindMonster,
 		}},

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -34,7 +34,9 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strconv"
@@ -103,7 +105,7 @@ func solidPillar(x, y float64) encounter.PropInput {
 func dungeonSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: torchAndDarkvision{}, Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{},
-		TurnDriver: passUnplayedTurns{},
+		TurnDriver: encounter.PassDriver{}, Striker: noAttacksExpected{},
 		Field: encounter.FieldInput{
 			// You cannot see across the space the crypt's two chambers do not
 			// cover — the fiction is the mountain they were cut from, and the
@@ -553,7 +555,7 @@ func main() {
 				continue
 			}
 			loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Sight: torchAndDarkvision{}, Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{}, TurnDriver: passUnplayedTurns{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+				Sight: torchAndDarkvision{}, Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{}, TurnDriver: encounter.PassDriver{}, Striker: noAttacksExpected{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 					"goblin": goblinPatrol(),
 				}})
 			if err != nil {
@@ -619,14 +621,16 @@ func (rollAllStanding) Standing([]encounter.MemberID) ([]encounter.MemberID, err
 	return nil, nil
 }
 
-// passUnplayedTurns is the workbench's TurnDriver capability: an unplayed
-// member's turn ends with no other effect. The workbench demonstrates free
-// roam and sight, not monster behaviour, so this says the least interesting
-// true thing rather than the module defaulting it (rpg-toolkit#1162).
-type passUnplayedTurns struct{}
+// noAttacksExpected is the workbench's Striker capability. The workbench
+// demonstrates free roam and sight, not combat — its TurnDriver is
+// [encounter.PassDriver], which never returns an Attack intent — so this is
+// never actually called; it exists only because the capability is required
+// (rpg-toolkit#1033, rpg-project#254) and says so honestly rather than
+// returning a fabricated hit.
+type noAttacksExpected struct{}
 
-func (passUnplayedTurns) Act(encounter.MemberID) (encounter.TurnOutcome, error) {
-	return encounter.Pass{}, nil
+func (noAttacksExpected) Strike(context.Context, *encounter.Encounter, encounter.MemberID, encounter.MemberID, core.Ref) error {
+	return errors.New("workbench: no driver here ever attacks")
 }
 
 // torchAndDarkvision is the workbench's Sight capability, and it is the one

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -119,7 +119,7 @@ func vaultChaseHexSetup() *encounter.SetupInput {
 	}
 	pursuit := &pursuitDecider{doorways: doorwaysFrom(field), target: alice}
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: "corridor", Position: spatial.Position{X: 6, Y: 5}},
@@ -336,7 +336,7 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	beforeReload := alicePath[len(alicePath)-1]
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &pursuitDecider{doorways: doorwaysFrom(vaultChaseHexSetup().Field), target: alice},
 		}})
 	require.NoError(t, err, "the suspended chase crosses a process boundary")

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -585,9 +585,12 @@ func (e *Encounter) ToData() EncounterData {
 // later handed to ToData while holding GridShapeGridless). The default
 // case already returns "" for it, same as any other unreachable value.
 // actionViewDataFrom converts a member's runtime [ActionView] facts to their
-// persisted twin. A nil slice stays nil rather than becoming an empty one —
-// the same "omitempty means it, not a zero-length placeholder" convention
-// every other optional slice on this data shape follows.
+// persisted twin. A nil slice stays nil rather than becoming an allocated
+// empty one (Copilot, PR #1187 review: `omitempty` already treats the two
+// identically on the wire — len()==0 either way — so this is not a wire
+// distinction; it is a plain no-op-for-the-common-case allocation avoidance,
+// and keeps a round-tripped nil equal to its original by reflect.DeepEqual
+// rather than becoming a spurious non-nil empty slice).
 func actionViewDataFrom(actions []ActionView) []ActionViewData {
 	if actions == nil {
 		return nil

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -359,10 +359,26 @@ func convertDoorDataToDoorInput(doors []DoorData) ([]DoorInput, error) {
 // no installed base — only a hand-kept fixture, which is exactly what should be
 // recreated rather than reinterpreted.
 type MemberData struct {
-	ID   MemberID      `json:"id"`
-	Kind MemberKind    `json:"kind"`
-	Name string        `json:"name,omitempty"`
-	Cell *PositionData `json:"cell"`
+	ID        MemberID         `json:"id"`
+	Kind      MemberKind       `json:"kind"`
+	Name      string           `json:"name,omitempty"`
+	Cell      *PositionData    `json:"cell"`
+	SpeedFeet int              `json:"speed_feet,omitempty"`
+	SightFeet int              `json:"sight_feet,omitempty"`
+	Actions   []ActionViewData `json:"actions,omitempty"`
+	Targeting string           `json:"targeting,omitempty"`
+}
+
+// ActionViewData is the persistent representation of an [ActionView] — a
+// member's static fact about one action, round-tripped verbatim (Kirk,
+// rpg-project#254 review: "round-tripped through ToData/LoadEncounter, as
+// encounter-owned primitives"). core.Ref already carries its own JSON tags
+// and needs no persisted twin of its own.
+type ActionViewData struct {
+	Ref       core.Ref `json:"ref"`
+	Name      string   `json:"name,omitempty"`
+	ReachFeet int      `json:"reach_feet,omitempty"`
+	Kind      string   `json:"kind,omitempty"`
 }
 
 // EndingData is the persistent representation of a declared ending.
@@ -396,10 +412,14 @@ func (e *Encounter) ToData() EncounterData {
 			continue // Not placed (shouldn't happen in valid encounter)
 		}
 		membersData = append(membersData, MemberData{
-			ID:   m.ID,
-			Kind: m.Kind,
-			Name: m.Name,
-			Cell: &PositionData{X: cell.X, Y: cell.Y},
+			ID:        m.ID,
+			Kind:      m.Kind,
+			Name:      m.Name,
+			Cell:      &PositionData{X: cell.X, Y: cell.Y},
+			SpeedFeet: m.SpeedFeet,
+			SightFeet: m.SightFeet,
+			Actions:   actionViewDataFrom(m.Actions),
+			Targeting: m.Targeting,
 		})
 	}
 
@@ -564,6 +584,34 @@ func (e *Encounter) ToData() EncounterData {
 // own doc comment. Either way, a room is never stored in fieldInput and
 // later handed to ToData while holding GridShapeGridless). The default
 // case already returns "" for it, same as any other unreachable value.
+// actionViewDataFrom converts a member's runtime [ActionView] facts to their
+// persisted twin. A nil slice stays nil rather than becoming an empty one —
+// the same "omitempty means it, not a zero-length placeholder" convention
+// every other optional slice on this data shape follows.
+func actionViewDataFrom(actions []ActionView) []ActionViewData {
+	if actions == nil {
+		return nil
+	}
+	out := make([]ActionViewData, len(actions))
+	for i, a := range actions {
+		out[i] = ActionViewData(a)
+	}
+	return out
+}
+
+// actionViewsFrom is actionViewDataFrom's inverse, restoring a member's
+// runtime [ActionView] facts from their persisted twin.
+func actionViewsFrom(data []ActionViewData) []ActionView {
+	if data == nil {
+		return nil
+	}
+	out := make([]ActionView, len(data))
+	for i, a := range data {
+		out[i] = ActionView(a)
+	}
+	return out
+}
+
 func gridShapeToData(shape spatial.GridShape) string {
 	switch shape {
 	case spatial.GridShapeHex:
@@ -642,6 +690,14 @@ type LoadEncounterInput struct {
 	// as a Setup without one (rpg-toolkit#1162, ADR-0043). Refused at the
 	// door, never guarded at the use site, and never defaulted.
 	TurnDriver TurnDriver
+
+	// Striker resolves and records a member's attack when a TurnDriver
+	// returns an Attack intent. REQUIRED, exactly as it is on SetupInput and
+	// for the same reason (rpg-project#254): a loaded encounter's bubble can
+	// land on an unplayed member ready to swing the moment it is
+	// reconstituted. Refused at the door, never guarded at the use site, and
+	// never defaulted.
+	Striker Striker
 }
 
 // Validate reports whether the input is usable. It checks only the input's own
@@ -667,6 +723,9 @@ func (in *LoadEncounterInput) Validate() error {
 	}
 	if in.TurnDriver == nil {
 		return fmt.Errorf("load encounter: TurnDriver is required: %w", ErrNoTurnDriver)
+	}
+	if in.Striker == nil {
+		return fmt.Errorf("load encounter: Striker is required: %w", ErrNoStriker)
 	}
 
 	return nil
@@ -1057,6 +1116,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		standing:    input.Standing,
 		sight:       input.Sight,
 		turnDriver:  input.TurnDriver,
+		striker:     input.Striker,
 		endings:     nil,
 		retention:   normalizeRetention(data.Retention),
 		logFloor:    logFloorOf(data.Log),
@@ -1095,9 +1155,13 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		}
 
 		member := &memberRecord{
-			ID:   m.ID,
-			Kind: m.Kind,
-			Name: m.Name,
+			ID:        m.ID,
+			Kind:      m.Kind,
+			Name:      m.Name,
+			SpeedFeet: m.SpeedFeet,
+			SightFeet: m.SightFeet,
+			Actions:   actionViewsFrom(m.Actions),
+			Targeting: m.Targeting,
 		}
 		e.members[m.ID] = member
 		e.everMembers[m.ID] = true

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -76,7 +76,7 @@ type DataTestSuite struct {
 // for g1's pass, and next_seq incremented to match.
 func (s *DataTestSuite) TestGoldenJSONRich() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
@@ -141,7 +141,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 // ending order changes which outcome the campaign receives.
 func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
@@ -154,7 +154,7 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	enc1, err := encounter.NewEncounter(setup)
 	s.Require().NoError(err)
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: enc1.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc1.ToData()})
 	s.Require().NoError(err)
 
 	out, err := enc2.Step(&encounter.StepInput{Member: "p1", To: spatial.Position{X: 3, Y: 3}})
@@ -184,7 +184,7 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 // origin simultaneously.
 func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -216,7 +216,7 @@ func (s *DataTestSuite) TestConnectionsSurviveReload() {
 	s.Equal(expected, data1.Field.Connections, "connections persist sorted by ID with endpoints intact")
 
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1})
 	s.Require().NoError(err)
 
 	data2 := enc2.ToData()
@@ -260,7 +260,7 @@ func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 	}
 
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err)
 
 	got := enc.ToData().Field.Connections
@@ -286,7 +286,7 @@ func (s *DataTestSuite) TestLoadSortsUnsortedConnections() {
 func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 	s.Run("square", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -307,7 +307,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		s.Equal("", data1.Field.Rooms[0].Grid, "square is the zero value — omitted, not the literal \"square\"")
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1})
 		s.Require().NoError(err)
 
 		data2 := enc2.ToData()
@@ -316,7 +316,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 
 	s.Run("hex", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Rooms: []encounter.RoomInput{
@@ -337,7 +337,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 		s.Equal(spatial.GridTypeHex, data1.Field.Rooms[0].Grid)
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1})
 		s.Require().NoError(err)
 
 		data2 := enc2.ToData()
@@ -364,7 +364,7 @@ func (s *DataTestSuite) TestRoomGridShapeSurvivesReload() {
 // square grid starts at (0,0) — W5, rpg-toolkit#1106.
 func (s *DataTestSuite) TestSetupInputNotAliased() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -407,7 +407,7 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 	// And the corrupted-input snapshot must still LOAD (the M4 symptom
 	// was an encounter that became permanently unsavable).
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err)
 }
 
@@ -421,7 +421,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 	s.Run("post-setup open encounter survives round-trip", func() {
 		// Create a simple encounter
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -473,7 +473,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 
 		// Load from data (without decider for goblin)
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Convert to data again
@@ -494,7 +494,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 	s.Run("mid-fade ghost survives reload still Held", func() {
 		// Create encounter with a wall that will cause a ghost to form
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -565,7 +565,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 
 		// Load and verify ghost is still there
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Get holdings - ghost should still be Held (not Current)
@@ -590,7 +590,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 func (s *DataTestSuite) TestRoundTripPostExit() {
 	s.Run("exited member persists in everMembers and can Story", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -637,7 +637,7 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 
 		// Load and verify everMembers includes the exited player
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Story should work for the exited member
@@ -652,7 +652,7 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 func (s *DataTestSuite) TestRoundTripClosed() {
 	s.Run("closed encounter with ending outcome round-trips", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -707,7 +707,7 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 
 		// Load and verify outcome matches
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		status2, _ := enc2.Status()
@@ -723,7 +723,7 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 func (s *DataTestSuite) TestPumpContinuesTick() {
 	s.Run("Pump continues tick sequence post-reload", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -773,7 +773,7 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 		s.Require().Equal(2, data1.Clock.HighWater, "precondition: two ticks persisted")
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1})
 		s.Require().NoError(err)
 
 		out, err := enc2.Pump(&encounter.PumpInput{})
@@ -786,7 +786,7 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 func (s *DataTestSuite) TestMoveWorksPostReload() {
 	s.Run("Move works on reloaded encounter", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -829,7 +829,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 
 		// Load
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Move should work
@@ -848,7 +848,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 func (s *DataTestSuite) TestGoldenJSONOpen() {
 	s.Run("small open encounter golden JSON", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -899,7 +899,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 func (s *DataTestSuite) TestGoldenJSONClosed() {
 	s.Run("small closed encounter golden JSON", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -973,7 +973,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 func (s *DataTestSuite) TestAliasImmunityToData() {
 	s.Run("mutating ToData result doesn't affect aggregate", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -1042,7 +1042,7 @@ func (s *DataTestSuite) TestAliasImmunityToData() {
 func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 	s.Run("mutating caller's Data after LoadEncounter doesn't affect loaded aggregate", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -1080,7 +1080,7 @@ func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 		// Load FIRST, then vandalize the caller's Data: the loaded
 		// aggregate must be untouched (load-side deep copy).
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().NoError(err)
 
 		data.Members[0].ID = "mutated"
@@ -1108,7 +1108,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		// persisted holding says Held (a ghost). A load that re-runs
 		// first-light surveil would resurrect it to Current.
 		enc1, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}}},
 			Members: []encounter.MemberInput{
 				{ID: "playerA", Kind: encounter.KindPlayer, Room: "crypt", Position: spatial.Position{X: 1, Y: 1}},
@@ -1129,7 +1129,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		data.Intel.Holdings["playerA"]["goblin"] = holding
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().NoError(err)
 
 		view, err := enc2.View(&encounter.ViewInput{Member: "playerA"})
@@ -1142,7 +1142,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 func (s *DataTestSuite) TestDeciderReattachment() {
 	s.Run("reload with decider resumes monster decision", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -1197,7 +1197,7 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 			},
 		}
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 				encounter.MemberID("goblin"): decider,
 			}})
 		s.Require().NoError(err)
@@ -1217,7 +1217,7 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 	s.Run("reload without decider makes monster hold", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -1267,7 +1267,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 
 		// Load WITHOUT goblin's decider
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Pump should succeed (goblin holds)
@@ -1287,7 +1287,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 // nil entry is equivalent to an absent one: the monster simply holds.
 func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "crypt", Width: 10, Height: 10}},
@@ -1305,7 +1305,7 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	data1 := enc1.ToData()
 
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 			"goblin": nil,
 		}})
 	s.Require().NoError(err, "a present-but-nil reattachment entry must load, not reject")
@@ -1322,7 +1322,7 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 // same reattachment map: the real one decides normally, the nil one holds.
 func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1350,7 +1350,7 @@ func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 
 	ratDecider := &testDecider{intent: encounter.IntentMoveTo{To: spatial.Position{X: 3, Y: 8}}}
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 			"goblin": nil,
 			"rat":    ratDecider,
 		}})
@@ -1439,7 +1439,7 @@ func (s *DataTestSuite) TestLoadSquarePropCellFractionalRejected() {
 	data := validEncounterDataWithConnection()
 	data.Field.Rooms[0].Props[0].At = encounter.PositionData{X: 2.5, Y: 2}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1478,7 +1478,7 @@ func (s *DataTestSuite) TestLoadNilInputRejected() {
 // call sites, so it is stated once rather than left implied by them.
 func (s *DataTestSuite) TestLoadNilDecidersIsLegal() {
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Data: validEncounterData(),
 	})
 	s.Require().NoError(err)
@@ -1499,7 +1499,7 @@ func (s *DataTestSuite) TestLoadPropOnBoundaryCellAccepted() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err, "a prop on a room's boundary cell, including a corner, must be legal at Load too")
 }
 
@@ -1520,7 +1520,7 @@ func (s *DataTestSuite) TestLoadPropIDCrossRoomCollisionAccepted() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err, `room "r" prop (-5,4) and room "r-" prop (5,4) must not collide at Load either`)
 }
 
@@ -1539,7 +1539,7 @@ func (s *DataTestSuite) TestLoadTwoPropsOnOneCellRejected() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1561,7 +1561,7 @@ func (s *DataTestSuite) TestLoadDuplicateEndingKeyRejected() {
 		},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoEnding)
@@ -1685,7 +1685,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 			data := validEncounterData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().Contains(err.Error(), tc.fragment,
@@ -1699,7 +1699,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 	// The valid base itself must load — the one-defect discipline only
 	// means something if zero defects pass.
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: validEncounterData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: validEncounterData()})
 	s.Require().NoError(err, "the valid base fixture must load")
 
 	// The valid CONNECTION base must also load. Since FromPosition{9,1} is
@@ -1711,7 +1711,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 	// it would silently swap the values — so the values are re-inspected,
 	// not just the absence of an error).
 	connEnc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: validEncounterDataWithConnection()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: validEncounterDataWithConnection()})
 	s.Require().NoError(err, "the valid connection base fixture must load")
 	connData := connEnc.ToData()
 	s.Require().Len(connData.Field.Connections, 1)
@@ -1763,7 +1763,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 4, Y: 0}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1772,7 +1772,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 0, Y: 3}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1781,7 +1781,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: -1, Y: 0}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1790,7 +1790,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 0, Y: -1}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().ErrorIs(err, encounter.ErrBadConnection)
 		s.Require().Contains(err.Error(), "from-position out of bounds")
 	})
@@ -1799,7 +1799,7 @@ func (s *DataTestSuite) TestConnectionEndpointBoundsBoundariesLoad() {
 		data := connBoundsData()
 		data.Field.Connections[0].FromPosition = &encounter.PositionData{X: 3, Y: 2}
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 		s.Require().NoError(err, "the last valid cell must be accepted")
 	})
 }
@@ -1829,7 +1829,7 @@ func (s *DataTestSuite) TestLoadRoomValidation() {
 			data := validEncounterData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrNoField, tc.name)
@@ -1856,7 +1856,7 @@ func (s *DataTestSuite) TestLoadRoomEmptyIDReportsIDDefectNotOrigin() {
 	data.Field.Rooms[0].Origin = nil
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1903,7 +1903,7 @@ func (s *DataTestSuite) TestHexRoomBoundsLoad() {
 	load := func(cell encounter.PositionData) error {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-			Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: connHexRoomData(cell)})
+			Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: connHexRoomData(cell)})
 		return err
 	}
 
@@ -1981,7 +1981,7 @@ func (s *DataTestSuite) TestHexConnectionEndpointNegativeAxialLoad() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err,
 		"the chambers meet at hex-a's last column and hex-b's first, on the same row")
 }
@@ -2044,7 +2044,7 @@ func (s *DataTestSuite) TestLoadHexIntegralCells() {
 			data := validHexData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			if tc.alsoErr != nil {
@@ -2056,7 +2056,7 @@ func (s *DataTestSuite) TestLoadHexIntegralCells() {
 	}
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: validHexData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: validHexData()})
 	s.Require().NoError(err, "integral cells must be accepted — authored for the connections, absolute for the member")
 }
 
@@ -2116,7 +2116,7 @@ func (s *DataTestSuite) TestLoadRefusesAnAxialDiagonalAsAdjacent() {
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:       data,
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 	})
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
 	s.Contains(err.Error(), "distance 2",
@@ -2199,7 +2199,7 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 			data := validAnchoredHexData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, tc.alsoErr, tc.name)
@@ -2211,7 +2211,7 @@ func (s *DataTestSuite) TestLoadAnchoring() {
 	// The valid base itself must load — the one-defect discipline only
 	// means something if zero defects pass.
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: validAnchoredHexData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: validAnchoredHexData()})
 	s.Require().NoError(err, "the valid anchored base fixture must load")
 }
 
@@ -2238,7 +2238,7 @@ func (s *DataTestSuite) TestLoadAnchoringOverlapNonAdjacentPair() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2268,7 +2268,7 @@ func (s *DataTestSuite) TestLoadAnchoringSquareOriginRejected() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err, "a fractional Origin on a square room is now a defect — origin legality is universal")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2302,7 +2302,7 @@ func (s *DataTestSuite) TestLoadAnchoringHugeSquareOriginRejectedNotFalseOverlap
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2344,7 +2344,7 @@ func (s *DataTestSuite) TestLoadAnchoringFractionalSquareEndpointSubUnitDistance
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2371,7 +2371,7 @@ func (s *DataTestSuite) TestLoadAnchoringOversizedRoomRejectedNotFalseDisjoint()
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2396,7 +2396,7 @@ func (s *DataTestSuite) TestLoadRoomCellBudgetRejectsPanicReproduction() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err, "a 2^30 x 2^30 room from a persisted blob must REJECT, not panic")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2418,7 +2418,7 @@ func (s *DataTestSuite) TestLoadOversizedRoomHeightRejected() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2445,7 +2445,7 @@ func (s *DataTestSuite) TestLoadFieldCellBudgetRejectsIndividuallyLegalRooms() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err, "individually-legal rooms whose SUM exceeds the field budget must reject")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2489,7 +2489,7 @@ func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
 			data := validEndingTriggerData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrNoEnding, tc.name)
@@ -2499,7 +2499,7 @@ func (s *DataTestSuite) TestLoadEndingTriggerValidation() {
 	}
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: validEndingTriggerData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: validEndingTriggerData()})
 	s.Require().NoError(err, "a trigger naming a real room and in-bounds position must validate")
 }
 
@@ -2516,7 +2516,7 @@ func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
 		},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoEnding)
@@ -2531,14 +2531,14 @@ func (s *DataTestSuite) TestLoadEndingTriggerHexNonIntegralRejected() {
 // would not.
 func (s *DataTestSuite) TestOriginRoundTripByteIdentical() {
 	enc1, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: validAnchoredHexData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: validAnchoredHexData()})
 	s.Require().NoError(err)
 	data1 := enc1.ToData()
 	bs1, err := json.Marshal(data1.Field)
 	s.Require().NoError(err)
 
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1})
 	s.Require().NoError(err)
 	data2 := enc2.ToData()
 	bs2, err := json.Marshal(data2.Field)
@@ -2558,7 +2558,7 @@ func (s *DataTestSuite) TestOriginRoundTripByteIdentical() {
 // Origins it didn't in v0.2.
 func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
@@ -2627,7 +2627,7 @@ func (s *DataTestSuite) TestReloadedAnchoredEncounterAcceptsSameTraverse() {
 		}
 	}
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: dataPreCrossing})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: dataPreCrossing})
 	s.Require().NoError(err)
 
 	out2, err := enc2.Step(&encounter.StepInput{Member: "p1", To: farSide})
@@ -2663,7 +2663,7 @@ func (s *DataTestSuite) TestLoadAnchoringSquareEndpointNotAdjacentDistance2() {
 		EverMembers: []encounter.MemberID{"p1"},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2694,7 +2694,7 @@ func (s *DataTestSuite) TestLoadRejectsHostileNonKissingBlob() {
 	s.Require().NoError(json.Unmarshal(hostile, &data))
 
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().Error(err, "a hand-edited blob with a non-kissing doorway must reject")
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrBadConnection)
@@ -2729,7 +2729,7 @@ func connGridlessRoomData(pos encounter.PositionData) encounter.EncounterData {
 func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 	s.Run("gridless grid string rejected regardless of member position", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: connGridlessRoomData(encounter.PositionData{X: 4, Y: 0})})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: connGridlessRoomData(encounter.PositionData{X: 4, Y: 0})})
 		s.Require().Error(err, `a stored "gridless" grid string no longer loads`)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -2739,7 +2739,7 @@ func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 
 	s.Run("still rejected for a position that would also be out of bounds", func() {
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: connGridlessRoomData(encounter.PositionData{X: -1, Y: 0})})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: connGridlessRoomData(encounter.PositionData{X: -1, Y: 0})})
 		s.Require().Error(err)
 		s.Require().ErrorIs(err, encounter.ErrInvalidData)
 		s.Require().ErrorIs(err, encounter.ErrNoField,
@@ -2752,7 +2752,7 @@ func (s *DataTestSuite) TestGridlessRoomInclusiveBoundsLoad() {
 func (s *DataTestSuite) TestLoadRejectsPlayerWithDecider() {
 	data := validEncounterData()
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			"p1": &spyDecider{},
 		}})
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
@@ -2762,7 +2762,7 @@ func (s *DataTestSuite) TestLoadRejectsPlayerWithDecider() {
 func (s *DataTestSuite) TestMutation1ToDataAliases() {
 	s.Run("mutation 1: ToData aliases slices", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -2803,7 +2803,7 @@ func (s *DataTestSuite) TestMutation1ToDataAliases() {
 func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 	s.Run("mutation 2: wire tag renamed", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -2835,7 +2835,7 @@ func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 func (s *DataTestSuite) TestMutation3StowawayField() {
 	s.Run("mutation 3: stowaway field in EncounterData", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -2869,7 +2869,7 @@ func (s *DataTestSuite) TestMutation3StowawayField() {
 func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 	s.Run("mutation 4: leaf data substitution (Intel/Log swapped)", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -2903,7 +2903,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 
 		// Control: loading dataA verbatim, p1 holds p2.
 		ctrl, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: dataA})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: dataA})
 		s.Require().NoError(err)
 		ctrlView, err := ctrl.View(&encounter.ViewInput{Member: "p1"})
 		s.Require().NoError(err)
@@ -2914,7 +2914,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 		// is genuinely consumed, never re-derived from the field.
 		dataA.Intel = dataB.Intel
 		swapped, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: dataA})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: dataA})
 		s.Require().NoError(err)
 		swappedView, err := swapped.View(&encounter.ViewInput{Member: "p1"})
 		s.Require().NoError(err)
@@ -2945,7 +2945,7 @@ func (s *DataTestSuite) TestMutation5MissingRoomCheck() {
 		}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().Error(err)
 		s.True(errors.Is(err, encounter.ErrInvalidData), "must validate member rooms exist")
 	})
@@ -2955,7 +2955,7 @@ func (s *DataTestSuite) TestMutation5MissingRoomCheck() {
 func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 	s.Run("mutation 6: no re-surveil on load (ghost stays ghost)", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -3009,7 +3009,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 
 		data := enc1.ToData()
 		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
 
 		holdings2, _ := enc2.View(&encounter.ViewInput{Member: "playerA"})
 		var goblinStatusAfter intel.Status
@@ -3030,7 +3030,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 	s.Run("mutation 7: tick continuation (clock not reset)", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -3051,7 +3051,7 @@ func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 		tick1 := data1.Clock.HighWater
 
 		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		data2 := enc2.ToData()
 		tick2 := data2.Clock.HighWater
 

--- a/rulebooks/dnd5e/encounter/defeat_internal_test.go
+++ b/rulebooks/dnd5e/encounter/defeat_internal_test.go
@@ -47,7 +47,7 @@ func (d *oneDown) Standing(members []MemberID) ([]MemberID, error) {
 func TestADecidedFightRefusesToCountAGhost(t *testing.T) {
 	rulebook := &oneDown{}
 	enc, err := NewEncounter(&SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: rulebook, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: rulebook, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: FieldInput{Canvas: CanvasInput{Void: VoidIsOpaque()}, Rooms: []RoomInput{{ID: "crypt", Width: 12, Height: 12}}},
 		Members: []MemberInput{
 			{ID: "alice", Kind: KindPlayer, Room: "crypt", Position: spatial.Position{X: 0, Y: 2}},

--- a/rulebooks/dnd5e/encounter/defeat_test.go
+++ b/rulebooks/dnd5e/encounter/defeat_test.go
@@ -381,7 +381,7 @@ func (s *DefeatSuite) TestOnlyTheDecidedFightEnds() {
 
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:       data,
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: &downList{down: []encounter.MemberID{goblin}},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/encounter/dialect_test.go
+++ b/rulebooks/dnd5e/encounter/dialect_test.go
@@ -60,7 +60,7 @@ var dialectOrigin = spatial.Position{X: 30, Y: 10}
 // coordinates.
 func (s *DialectSuite) closedBlob() encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: "hall", Width: 8, Height: 8, Origin: dialectOrigin},
 		}},
@@ -89,7 +89,7 @@ const aRoomBearingSighting = `{"room":"hall","x":2,"y":5}`
 // load is the host's side of the seam: hand the loader a blob and see what it says.
 func (s *DialectSuite) load(data encounter.EncounterData) error {
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 	return err
 }

--- a/rulebooks/dnd5e/encounter/doors_test.go
+++ b/rulebooks/dnd5e/encounter/doors_test.go
@@ -129,7 +129,7 @@ func doorField(height int, state encounter.DoorState, id encounter.DoorID, rows 
 // single-edge door, both players so nothing forms a fight.
 func (s *DoorSuite) doorway(state encounter.DoorState) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: doorField(3, state, theDoor, 1),
 		Members: []encounter.MemberInput{
 			{ID: nessa, Kind: encounter.KindPlayer, Room: doorWest, Position: spatial.Position{X: 2, Y: 1}},
@@ -242,7 +242,7 @@ func (s *DoorSuite) TestAGateIsOneThingNotFour() {
 	gateRows := []int{1, 2, 3, 4}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field:   doorField(6, encounter.DoorIsClosed(), theGate, gateRows...),
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -288,7 +288,7 @@ func (s *DoorSuite) TestADoorMustSayWhatStateItIsIn() {
 	field.Doors[0].State = nil
 
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field:   field,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -320,7 +320,7 @@ func (s *DoorSuite) TestAShutDoorLeavesAGhostRatherThanForgetting() {
 // setup opens a field, or returns why it could not be built.
 func (s *DoorSuite) setup(field encounter.FieldInput) error {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field:   field,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -406,7 +406,7 @@ func (s *DoorSuite) TestAnUndirectedCrossingIsTheSameCrossingEitherWayRound() {
 	field.Doors = []encounter.DoorInput{backwards}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: nessa, Kind: encounter.KindPlayer, Room: doorWest, Position: spatial.Position{X: 2, Y: 1}},
@@ -437,7 +437,7 @@ func (s *DoorSuite) TestDoorsAreReadInStableOrder() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field:   field,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -533,7 +533,7 @@ func (s *DoorSuite) TestABlobWhoseDoorMakesNoSenseIsRefusedByName() {
 
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 				Data:  data,
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			})
 			s.Require().ErrorIs(err, encounter.ErrBadDoor)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData)
@@ -558,7 +558,7 @@ func (s *DoorSuite) TestABlobFromBeforeDoorsExistedLoadsFine() {
 
 	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:  data,
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 	s.Require().NoError(err)
 	s.Empty(back.Doors(), "no doors, and no complaint about it")
@@ -649,7 +649,7 @@ func threeChambers(first, second encounter.DoorState, gate1, gate2 encounter.Doo
 
 func (s *DoorSuite) walkerIn(field encounter.FieldInput) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: nessa, Kind: encounter.KindPlayer, Room: "west", Position: spatial.Position{X: 0, Y: 1}},

--- a/rulebooks/dnd5e/encounter/dungeonspec/capabilities_test.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/capabilities_test.go
@@ -17,7 +17,13 @@ package dungeonspec_test
 // exporting them to share here would put a test-only surface on a published
 // module.
 
-import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+import (
+	"context"
+	"errors"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
 
 // unlimitedSight is far enough that no scene here is bounded by it.
 const unlimitedSight = 1_000_000
@@ -60,6 +66,18 @@ func (orderAsGiven) RollInitiative(members []encounter.MemberID) ([]encounter.Me
 // should do (rpg-toolkit#1162).
 type passDriver struct{}
 
-func (passDriver) Act(encounter.MemberID) (encounter.TurnOutcome, error) {
+func (passDriver) Act(encounter.MonsterView) (encounter.TurnIntent, error) {
 	return encounter.Pass{}, nil
+}
+
+// noAttacksExpected is this package's Striker capability. These scenes are
+// about geometry, not combat, and passDriver never returns an Attack intent
+// — so this is never actually called; it exists only because the
+// capability is required (rpg-toolkit#1033, rpg-project#254).
+type noAttacksExpected struct{}
+
+func (noAttacksExpected) Strike(
+	context.Context, *encounter.Encounter, encounter.MemberID, encounter.MemberID, core.Ref,
+) error {
+	return errors.New("dungeonspec_test: no scene here ever attacks")
 }

--- a/rulebooks/dnd5e/encounter/dungeonspec/tomb_test.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/tomb_test.go
@@ -81,7 +81,7 @@ func (s *TombSuite) SetupTest() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{},
 		Field:   compiled.Field,
 		Members: members,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -199,6 +199,11 @@ type Encounter struct {
 	// standing and sight are, and — unlike deciders — never optional; see
 	// [TurnDriver] and ADR-0043.
 	turnDriver TurnDriver
+
+	// striker resolves and records an [Attack] intent a TurnDriver returns.
+	// Required at both constructors for the same reason turnDriver is; see
+	// [Striker].
+	striker Striker
 	// endings holds declared endings in Setup order. Evaluation is
 	// deterministic (law C8), but NOT globally "first-declared-wins":
 	// for a single action (Step, Join) declaration order is
@@ -1305,6 +1310,14 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		return nil, fmt.Errorf("newencounter: %w", ErrNoTurnDriver)
 	}
 
+	// Required for the same reason again, one seam over: a TurnDriver can
+	// decide to attack the moment a fight forms, so an encounter that
+	// cannot resolve that swing would stall on it or silently drop it
+	// (rpg-project#254). Never defaulted — see [Striker]'s own doc.
+	if in.Striker == nil {
+		return nil, fmt.Errorf("newencounter: %w", ErrNoStriker)
+	}
+
 	// Check ending keys: empty/reserved, and duplicate (#929 hardening
 	// round E — two endings sharing a key both used to load; End scans
 	// in declaration order, so a reached_position twin declared FIRST
@@ -1416,6 +1429,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		standing:         in.Standing,
 		sight:            in.Sight,
 		turnDriver:       in.TurnDriver,
+		striker:          in.Striker,
 		endings:          nil,
 		retention:        normalizeRetention(in.Retention),
 		fieldInput:       deepCopyRoomInputs(in.Field.Rooms),
@@ -1480,9 +1494,13 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		}
 
 		member := &memberRecord{
-			ID:   mi.ID,
-			Kind: mi.Kind,
-			Name: mi.Name,
+			ID:        mi.ID,
+			Kind:      mi.Kind,
+			Name:      mi.Name,
+			SpeedFeet: mi.SpeedFeet,
+			SightFeet: mi.SightFeet,
+			Actions:   mi.Actions,
+			Targeting: mi.Targeting,
 		}
 		e.members[mi.ID] = member
 		e.everMembers[mi.ID] = true // Track in everMembers
@@ -1630,11 +1648,15 @@ func (e *Encounter) placementOf(record *memberRecord) (Member, error) {
 
 	region, _ := e.RegionAt(cell)
 	return Member{
-		ID:       record.ID,
-		Kind:     record.Kind,
-		Name:     record.Name,
-		Region:   region,
-		Position: cell,
+		ID:        record.ID,
+		Kind:      record.Kind,
+		Name:      record.Name,
+		Region:    region,
+		Position:  cell,
+		SpeedFeet: record.SpeedFeet,
+		SightFeet: record.SightFeet,
+		Actions:   record.Actions,
+		Targeting: record.Targeting,
 	}, nil
 }
 
@@ -2411,9 +2433,13 @@ func (e *Encounter) Join(in *JoinInput) (*JoinOutput, error) {
 
 	// Register the member
 	member := &memberRecord{
-		ID:   in.Member,
-		Kind: in.Kind,
-		Name: in.Name,
+		ID:        in.Member,
+		Kind:      in.Kind,
+		Name:      in.Name,
+		SpeedFeet: in.SpeedFeet,
+		SightFeet: in.SightFeet,
+		Actions:   in.Actions,
+		Targeting: in.Targeting,
 	}
 	e.members[in.Member] = member
 	e.everMembers[in.Member] = true // Track in everMembers

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -1351,6 +1351,15 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		if m.Kind == KindPlayer && m.Decider != nil {
 			return nil, fmt.Errorf("newencounter: player %s cannot carry a decider: %w", m.ID, ErrNoMember)
 		}
+
+		// SpeedFeet, SightFeet and each action's ReachFeet are feet-
+		// denominated facts CellsFromFeet divides by FeetPerCell — a
+		// negative one is not a shorter distance, it is a caller defect
+		// (Copilot, PR #1187), and would otherwise produce a nonsense
+		// budget or reach at the exact moment a monster's turn needs one.
+		if err := validateMemberFacts(m.ID, m.SpeedFeet, m.SightFeet, m.Actions); err != nil {
+			return nil, fmt.Errorf("newencounter: %w", err)
+		}
 	}
 
 	// The field must say what its void is. Construction DATA rather than a
@@ -2403,6 +2412,16 @@ func (e *Encounter) Join(in *JoinInput) (*JoinOutput, error) {
 	// Players cannot carry deciders (design law C2)
 	if in.Kind == KindPlayer && in.Decider != nil {
 		return nil, fmt.Errorf("join: player %s cannot carry a decider: %w", in.Member, ErrNoMember)
+	}
+
+	// See NewEncounter's own call to validateMemberFacts for why — ASKED
+	// BEFORE any mutation (canvas.PlaceEntity below is the first one),
+	// unlike NewEncounter's construction-in-a-local-that-only-escapes-on-
+	// success safety net: Join mutates a LIVE *Encounter, so an invalid
+	// fact caught after PlaceEntity would need to roll a placement back
+	// rather than simply never having made one (Copilot, PR #1187).
+	if err := validateMemberFacts(in.Member, in.SpeedFeet, in.SightFeet, in.Actions); err != nil {
+		return nil, fmt.Errorf("join: %w", err)
 	}
 
 	// Hex fields require integral axial cells (interim tools/spatial#926

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -47,7 +47,7 @@ func (s *EncounterTestSuite) TestSetupFirstLight() {
 	s.Run("two members clear line of sight", func() {
 		// Arrange: 10x10 room, alice at (2,2) player, goblin at (7,7) monster
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -127,7 +127,7 @@ func (s *EncounterTestSuite) TestSetupWallBlocksSight() {
 		// around now (spatial v0.9.1, see testwalls_test.go), so a fixture
 		// that wants sight blocked has to build something worth blocking.
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -189,7 +189,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: no field", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms:  []encounter.RoomInput{},
@@ -205,7 +205,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: no endings", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -221,7 +221,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: reserved ending key", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -239,7 +239,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: empty ending key", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -257,7 +257,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: empty member ID", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -278,7 +278,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	s.Run("validation order: duplicate member IDs", func() {
 		alice := core.EntityID("alice")
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -302,7 +302,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	s.Run("atomicity: after error, valid setup works", func() {
 		// First attempt: fails validation
 		setup1 := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field:   encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{}},
 			Members: []encounter.MemberInput{},
 			Endings: []encounter.EndingInput{
@@ -314,7 +314,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 		// Second attempt: valid
 		setup2 := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -355,7 +355,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 // all, so they stay disjoint (W2) regardless of their y overlap.
 func validConnSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -401,7 +401,7 @@ func (s *EncounterTestSuite) TestSetupSquarePropCellFractionalRejected() {
 // interior one.
 func (s *EncounterTestSuite) TestSetupPropOnBoundaryCellAccepted() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -423,7 +423,7 @@ func (s *EncounterTestSuite) TestSetupPropOnBoundaryCellAccepted() {
 // this exact colliding pair must construct without error.
 func (s *EncounterTestSuite) TestSetupPropIDCrossRoomCollisionAccepted() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
@@ -449,7 +449,7 @@ func (s *EncounterTestSuite) TestSetupPropIDCrossRoomCollisionAccepted() {
 // room-list defect vocabulary.
 func (s *EncounterTestSuite) TestSetupTwoPropsOnOneCellRejected() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -472,7 +472,7 @@ func (s *EncounterTestSuite) TestSetupTwoPropsOnOneCellRejected() {
 // forever, the external ending having no other way to fire).
 func (s *EncounterTestSuite) TestSetupDuplicateEndingKeyRejected() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
@@ -566,7 +566,7 @@ func (s *EncounterTestSuite) TestSetupConnectionValidation() {
 // share no x value and so stay disjoint (W2) regardless of y.
 func connBoundsSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -636,7 +636,7 @@ func (s *EncounterTestSuite) TestConnectionEndpointBoundsBoundaries() {
 // and one member — the base for TestSetupRoomValidation's one-defect rows.
 func validRoomSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -725,7 +725,7 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 	// exactly those terms.
 	hexSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Rooms: []encounter.RoomInput{
@@ -797,7 +797,7 @@ func (s *EncounterTestSuite) TestHexRoomBounds() {
 func (s *EncounterTestSuite) TestAHexChambersCellsAreOffsetNotAxial() {
 	build := func(to spatial.Position) error {
 		_, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Rooms: []encounter.RoomInput{
@@ -848,7 +848,7 @@ func (s *EncounterTestSuite) TestAHexChambersCellsAreOffsetNotAxial() {
 // room's own footprint.
 func validHexSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
@@ -928,7 +928,7 @@ func (s *EncounterTestSuite) TestSetupHexIntegralCells() {
 // Pump's IntentMoveTo, so this also covers decider-driven moves).
 func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms:  []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
@@ -964,7 +964,7 @@ func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 // TestJoinHexIntegralAxial is Join's verb-seam counterpart.
 func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms:  []encounter.RoomInput{{ID: "hex-room", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
@@ -1015,7 +1015,7 @@ func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 	gridlessSetup := func(pos spatial.Position) *encounter.SetupInput {
 		return &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -1077,7 +1077,7 @@ func (s *EncounterTestSuite) TestGridlessRoomInclusiveBounds() {
 // touching only through the one declared doorway.
 func validAnchoredHexSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
@@ -1226,7 +1226,7 @@ func (s *EncounterTestSuite) TestSetupAnchoring() {
 // proves it independently for square's own distance formula).
 func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1261,7 +1261,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareDiagonalKiss() {
 // in r2 projects to absolute (4,1) — Chebyshev distance 2, not 1.
 func (s *EncounterTestSuite) TestSetupAnchoringSquareEndpointNotAdjacentDistance2() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1297,7 +1297,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareEndpointNotAdjacentDistance
 // rejection pin that closes that hole.
 func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1330,7 +1330,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringSquareOriginRejected() {
 // message.
 func (s *EncounterTestSuite) TestSetupAnchoringNaNOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.NaN(), Y: 0}}},
@@ -1351,7 +1351,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringNaNOriginRejected() {
 // room legality's OWN message.
 func (s *EncounterTestSuite) TestSetupAnchoringNegativeInfinityOriginRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5, Origin: spatial.Position{X: math.Inf(-1), Y: 0}}},
@@ -1373,7 +1373,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringNegativeInfinityOriginRejected() 
 // direction.
 func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
@@ -1409,7 +1409,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringW1BothDirections() {
 // interval mins.
 func (s *EncounterTestSuite) TestSetupAnchoringOverlapNonAdjacentPair() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1442,7 +1442,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOverlapNonAdjacentPair() {
 // 1.
 func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms: []encounter.RoomInput{
@@ -1482,7 +1482,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringRSpanSeparation() {
 // "close enough"; the strict `!= 1` correctly rejects it.
 func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDistance() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1519,7 +1519,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringFractionalSquareEndpointSubUnitDi
 // before W2 ever sees it, and specifically NOT with a W2 "overlap" message.
 func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1558,7 +1558,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringHugeOriginRejectedNotFalseOverlap
 // rejected — oversized, not evaluated for overlap at all.
 func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisjoint() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1587,7 +1587,7 @@ func (s *EncounterTestSuite) TestSetupAnchoringOversizedRoomRejectedNotFalseDisj
 // with maxRoomCells' message, never construct.
 func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "huge", Width: 1 << 30, Height: 1 << 30}},
@@ -1610,7 +1610,7 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproduction() {
 // an EXPLICIT hex room.
 func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms:  []encounter.RoomInput{{ID: "huge", Grid: spatial.GridShapeHex, Width: 1 << 30, Height: 1 << 30}},
@@ -1641,7 +1641,7 @@ func (s *EncounterTestSuite) TestSetupRoomCellBudgetRejectsPanicReproductionHex(
 // check alone would not.
 func (s *EncounterTestSuite) TestSetupOversizedRoomHeightRejected() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "tall", Width: 5, Height: (1 << 30) + 1}},
@@ -1677,7 +1677,7 @@ func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRoo
 		rooms[i] = encounter.RoomInput{ID: fmt.Sprintf("room-%d", i), Width: 1024, Height: 1024}
 	}
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field:   encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: rooms},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -1694,7 +1694,7 @@ func (s *EncounterTestSuite) TestSetupFieldCellBudgetRejectsIndividuallyLegalRoo
 // thing about (#929 T3 Opus round F5).
 func validEndingTriggerSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 5, Height: 5}},
@@ -1746,7 +1746,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerValidation() {
 // Opus round F5).
 func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
@@ -1770,7 +1770,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexNonIntegralRejected() {
 // NOT over-reach.
 func validTriggerAcceptanceFieldSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1821,7 +1821,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerMustAccept() {
 
 			data := enc.ToData()
 			_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 			s.Require().NoError(err, "%s must survive a ToData/LoadEncounter round trip", tc.name)
 		})
 	}
@@ -1839,7 +1839,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerMustAccept() {
 // that embodies it moved.
 func (s *EncounterTestSuite) TestSetupEndingTriggerHexFarCornerMustAccept() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Rooms:  []encounter.RoomInput{{ID: "crypt", Width: 8, Height: 8, Grid: spatial.GridShapeHex}},
@@ -1853,7 +1853,7 @@ func (s *EncounterTestSuite) TestSetupEndingTriggerHexFarCornerMustAccept() {
 
 	data := enc.ToData()
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err, "must survive a ToData/LoadEncounter round trip")
 }
 
@@ -1861,7 +1861,7 @@ func (s *EncounterTestSuite) TestSetupOpeningBeat() {
 	s.Run("opening beat reaches all members via Story", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -1916,7 +1916,7 @@ func (s *EncounterTestSuite) TestSetupBadPlacementSentinel() {
 	s.Run("member placed in nonexistent room errors with ErrBadPlacement", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -1945,7 +1945,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 	s.Run("three members mutually visible all see each other", func() {
 		// Arrange: ONE room, THREE mutually visible members (alice, bob players; goblin monster)
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -2002,7 +2002,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 func (s *EncounterTestSuite) TestMembers() {
 	s.Run("returns stable order", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -2031,7 +2031,7 @@ func (s *EncounterTestSuite) TestMovePerceptRefreshes() {
 	s.Run("mover's vantage refreshes, others see mover at new position", func() {
 		// Arrange: alice and bob in clear sight
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -2121,7 +2121,7 @@ func (s *EncounterTestSuite) TestMoveGhostForms() {
 		// A wall rather than the single pillar this fixture used to have —
 		// spatial v0.9.1 leans around a lone obstacle (see testwalls_test.go).
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -2186,7 +2186,7 @@ func (s *EncounterTestSuite) TestMoveSequentialConsistency() {
 	s.Run("after sequential moves, spatial index remains valid (CanMoveEntityBetweenRooms-style)", func() {
 		// Arrange: alice in one room
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -2243,7 +2243,7 @@ func (s *EncounterTestSuite) TestMoveEndingFires() {
 	s.Run("player reaching ReachedPosition trigger fires the ending", func() {
 		// Arrange: alice is player, will reach stairs (no member filter = any player)
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -2337,7 +2337,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 	s.Run("validation order and R5 atomicity", func() {
 		s.Run("nil input returns ErrNilInput", func() {
 			setup := &encounter.SetupInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 				Field: encounter.FieldInput{
 					Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 					Rooms: []encounter.RoomInput{
@@ -2360,7 +2360,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("empty member ID returns ErrNoMember", func() {
 			setup := &encounter.SetupInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 				Field: encounter.FieldInput{
 					Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 					Rooms: []encounter.RoomInput{
@@ -2386,7 +2386,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("closed encounter returns ErrClosed", func() {
 			setup := &encounter.SetupInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 				Field: encounter.FieldInput{
 					Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 					Rooms: []encounter.RoomInput{
@@ -2423,7 +2423,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("not a member returns ErrNotMember", func() {
 			setup := &encounter.SetupInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 				Field: encounter.FieldInput{
 					Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 					Rooms: []encounter.RoomInput{
@@ -2449,7 +2449,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("failed move leaves members unchanged", func() {
 			setup := &encounter.SetupInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 				Field: encounter.FieldInput{
 					Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 					Rooms: []encounter.RoomInput{
@@ -2493,7 +2493,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 	s.Run("mutating returned outcome does not affect internal state", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -2549,7 +2549,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 // (19,19).
 func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
@@ -2568,7 +2568,7 @@ func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 // an External ending (for testing End verb).
 func (s *EncounterTestSuite) newBasicEncounterWithExternalEnding() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 20, Height: 20}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
@@ -2639,7 +2639,7 @@ func (s *EncounterTestSuite) TestMoveSpatialRejectionAtomic() {
 // arrival-Current and T3 pins).
 func (s *EncounterTestSuite) newTwoRoomEncounterWithConnection() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -2817,7 +2817,7 @@ func (s *EncounterTestSuite) holdingOf(
 // any other step's destination.
 func (s *EncounterTestSuite) TestACrossingFiresAnEndingOnArrival() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -2860,7 +2860,7 @@ func (s *EncounterTestSuite) TestACrossingFiresAnEndingOnArrival() {
 // unfiltered ending's cell must NOT close the encounter, doorway or not.
 func (s *EncounterTestSuite) TestAMonsterCrossingOntoAnUnfilteredEndingDoesNotClose() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -2975,7 +2975,7 @@ func (s *EncounterTestSuite) TestJoinLateJoinerSeenByIncumbents() {
 	s.Run("late joiner seen by and sees incumbents", func() {
 		// Arrange: setup with alice and bob
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -3133,7 +3133,7 @@ func (s *EncounterTestSuite) TestJoinValidation() {
 func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 	s.Run("join on stairs fires ReachedPosition ending", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -3187,7 +3187,7 @@ func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 func (s *EncounterTestSuite) TestExitCarryForward() {
 	s.Run("exit carry-forward matches final state", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -3284,7 +3284,7 @@ func (s *EncounterTestSuite) TestExitValidation() {
 func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 	s.Run("last member exit closes with abandoned ending", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -3338,7 +3338,7 @@ func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 func (s *EncounterTestSuite) TestExitDepartedGhostFades() {
 	s.Run("remaining member's holdings persist after departure", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -3412,7 +3412,7 @@ func (s *EncounterTestSuite) TestEndExternalOnly() {
 
 	s.Run("End fires External endings", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -3551,7 +3551,7 @@ func (s *EncounterTestSuite) TestQueriesLivePostClose() {
 func (s *EncounterTestSuite) TestStoryForExitedMembers() {
 	s.Run("exited members can still read story", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -285,6 +285,13 @@ var (
 	// turn end without the swing its driver decided on ever landing.
 	ErrNoStriker = errors.New("encounter: no striker capability")
 
+	// ErrRefusingStriker is what [RefusingStriker.Strike] always returns:
+	// a driven turn reached a Striker built for a construction-only world
+	// (rpg-api's placement probes, a template's own acceptance test) — a
+	// host bug, since nothing should ever call EndTurn/form against such a
+	// world, not a legal outcome any caller is meant to recover from.
+	ErrRefusingStriker = errors.New("encounter: RefusingStriker: a driven turn reached a construction-only world")
+
 	// ErrBadIntent indicates a TurnDriver returned a syntactically valid
 	// TurnIntent this composition cannot execute: an Attack naming a target
 	// that is not currently Seen, not Standing, or out of the named

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -272,7 +272,7 @@ var (
 	// this module can detect should say so by name rather than proceed on a
 	// value it does not understand, the day a fourth TurnIntent case is added
 	// here and some call site is not updated to handle it.
-	ErrBadTurnOutcome = errors.New("encounter: turn driver returned an unrecognised outcome")
+	ErrBadTurnOutcome = errors.New("encounter: turn driver returned an unrecognised intent")
 
 	// ErrNoStriker indicates Setup or Load was given no Striker capability.
 	// A member with no player can be handed an Attack intent the moment a

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -261,17 +261,44 @@ var (
 	// invariant is ever broken elsewhere.
 	ErrNoPlayerInBubble = errors.New("encounter: bubble has no player to end on")
 
-	// ErrBadTurnOutcome indicates a TurnDriver returned a TurnOutcome this
-	// version of the module does not recognise.
+	// ErrBadTurnOutcome indicates a TurnDriver returned a TurnIntent this
+	// version of the module does not recognise — a value outside the sealed
+	// Pass/Attack/Move vocabulary.
 	//
-	// Unreachable from any driver outside this package today: TurnOutcome is
+	// Unreachable from any driver outside this package today: TurnIntent is
 	// sealed on an unexported method, so nothing outside encounter can
-	// construct a value satisfying it other than Pass. It exists for the same
-	// reason ErrBadRepository exists beside ErrNotFound — a defect this
-	// module can detect should say so by name rather than proceed on a value
-	// it does not understand, the day a second TurnOutcome case is added here
-	// and some call site is not updated to handle it.
+	// construct a value satisfying it other than these three. It exists for
+	// the same reason ErrBadRepository exists beside ErrNotFound — a defect
+	// this module can detect should say so by name rather than proceed on a
+	// value it does not understand, the day a fourth TurnIntent case is added
+	// here and some call site is not updated to handle it.
 	ErrBadTurnOutcome = errors.New("encounter: turn driver returned an unrecognised outcome")
+
+	// ErrNoStriker indicates Setup or Load was given no Striker capability.
+	// A member with no player can be handed an Attack intent the moment a
+	// fight forms — a turn ending, or a fight forming with an unplayed
+	// member first in initiative — and this module refuses to guess how a
+	// strike resolves, exactly as it refuses to guess who is standing, how
+	// far anyone sees, or what an unplayed member does at all
+	// (rpg-toolkit#1033, rpg-toolkit#1162, rpg-project#254). Never
+	// defaulted: a Striker that silently did nothing would let a monster's
+	// turn end without the swing its driver decided on ever landing.
+	ErrNoStriker = errors.New("encounter: no striker capability")
+
+	// ErrBadIntent indicates a TurnDriver returned a syntactically valid
+	// TurnIntent this composition cannot execute: an Attack naming a target
+	// that is not currently Seen, not Standing, or out of the named
+	// action's reach; an Attack naming an action Ref that is not among the
+	// member's own [MonsterView.Actions]; or a Move whose path this member
+	// cannot afford against its remaining movement budget.
+	//
+	// NOT A DRIVER MALFUNCTION (compare the plain Go error [TurnDriver.Act]
+	// itself can return, which aborts the caller's whole verb). A bad
+	// intent is a bad DECISION, not a broken driver: it simply ends this
+	// member's turn exactly as [Pass] would, and the caller's own verb
+	// (EndTurn, form) still succeeds — see [Encounter.driveMonsterTurns]'s
+	// own doc for why this asymmetry is deliberate (rpg-project#254).
+	ErrBadIntent = errors.New("encounter: turn driver returned an intent this composition cannot execute")
 
 	// ErrReadOnly indicates an attempt to write to the map through the
 	// read-only view [Encounter.Canvas] hands out.

--- a/rulebooks/dnd5e/encounter/example_doorway_test.go
+++ b/rulebooks/dnd5e/encounter/example_doorway_test.go
@@ -60,7 +60,7 @@ func Example_theDoorway() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Room: "hall", Position: spatial.Position{X: 7, Y: 4}},

--- a/rulebooks/dnd5e/encounter/example_dungeon_test.go
+++ b/rulebooks/dnd5e/encounter/example_dungeon_test.go
@@ -31,7 +31,7 @@ func Example_theDungeon() {
 		ToPosition:   spatial.Position{X: 0, Y: 4},
 	}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{

--- a/rulebooks/dnd5e/encounter/example_tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/example_tombwatch_test.go
@@ -45,7 +45,7 @@ func Example_theTombWatch() {
 	// The crypt: a wall across y=6 from x=5 to x=7; alice enters at (2,6); a goblin
 	// stands at (6,10). One way out: the stairs at (11,11).
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
@@ -89,7 +89,7 @@ func Example_theTombWatch() {
 	fmt.Println("-- the table saves and comes back tomorrow --")
 	data := enc.ToData()
 	enc, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	if err != nil {
 		fmt.Println("load:", err)
 		return

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -4,6 +4,8 @@
 package encounter
 
 import (
+	"fmt"
+
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/play/intel"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
@@ -413,6 +415,29 @@ type ActionView struct {
 	// branched on here, the same [AttackIdentity.DamageType] precedent
 	// Name already follows.
 	Kind string
+}
+
+// validateMemberFacts rejects a negative SpeedFeet, SightFeet, or any
+// action's ReachFeet — the three feet-denominated member facts
+// [CellsFromFeet] divides by [FeetPerCell] (Copilot, PR #1187 review). A
+// negative one is not a shorter distance; it is a caller defect that would
+// otherwise produce a nonsense movement budget or reach the moment a
+// monster's turn asks [MonsterView.Budget] or [SeenMember.InReach] for one.
+// Callers ask this BEFORE any mutation — see [Encounter.Join]'s own call for
+// why that ordering matters there specifically.
+func validateMemberFacts(id MemberID, speedFeet, sightFeet int, actions []ActionView) error {
+	if speedFeet < 0 {
+		return fmt.Errorf("member %s: speed %d feet is negative: %w", id, speedFeet, ErrNoMember)
+	}
+	if sightFeet < 0 {
+		return fmt.Errorf("member %s: sight %d feet is negative: %w", id, sightFeet, ErrNoMember)
+	}
+	for _, a := range actions {
+		if a.ReachFeet < 0 {
+			return fmt.Errorf("member %s: action %q reach %d feet is negative: %w", id, a.Ref, a.ReachFeet, ErrNoMember)
+		}
+	}
+	return nil
 }
 
 // Trigger is an interface for ending conditions.

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -343,6 +343,76 @@ type MemberInput struct {
 	// Players must not have a Decider; passing one for a player will fail validation.
 	// Deciders are NOT persisted; they are re-registered at load.
 	Decider Decider
+
+	// SpeedFeet is how far this member can move on their own turn, in FEET
+	// (Kirk, rpg-project#254 review) — a character's walking speed, or a
+	// monster's SpeedData.Walk. Filled for every kind, the same MEMBER fact
+	// [Name] already is, not a monster-only field: a future driver for a
+	// disconnected player shares this exact seam. Zero is legal and means
+	// this member never moves on its own turn — true of every player today,
+	// whose movement is driven by [Encounter.Step] under a live hand, not by
+	// a [TurnDriver]'s Move intent.
+	SpeedFeet int
+
+	// SightFeet is how far this member can see, in FEET, before light and
+	// line-of-sight are applied — 120 for a character (this rulebook's
+	// stated default absent a stated number) or a monster's
+	// SensesData.Darkvision when the stat block sets one. A STATIC base
+	// fact, filled once at Join/Spawn — [Sight] still runs the full
+	// light-and-LOS-aware answer at every percept refresh; this is what a
+	// [Sight] implementation reads instead of reloading the sheet or stat
+	// block on every single refresh, the same static/dynamic split
+	// [Sight]'s own doc draws between "what changed" and "what this
+	// composition was told."
+	SightFeet int
+
+	// Actions are this member's own static facts about what it can do on
+	// its turn: a character's equipped weapon's swing (and the unarmed
+	// strike when no weapon is equipped), or a monster's authored
+	// [monster.ActionData]. Static join-time facts, the same species as
+	// Name (rpg-toolkit#1137) — this module cannot import the rulebook
+	// (C1), so every field on [ActionView] is carried and never
+	// interpreted, exactly as [Member.Name] already is.
+	Actions []ActionView
+
+	// Targeting is a monster's target-selection strategy, in the
+	// rulebook's own words — "closest", "lowest-health", "lowest-ac" — and
+	// the only field on this member fact that is NOT filled for every
+	// kind: empty for a player, who is never asked to choose a target
+	// autonomously (today; a future disconnected-player driver would read
+	// this the same way a monster's does). Opaque here (C1): this
+	// composition carries the string and never branches on it.
+	Targeting string
+}
+
+// ActionView is a static fact about one action a member can take — an
+// encounter-owned primitive, the same species as [Member.Name] and
+// [AttackIdentity.DamageType]: this composition carries it and never
+// interprets it, per C1 (this module's go.mod cannot import the rulebook,
+// so it cannot know what a Ref like "dnd5e:monster_actions:melee" means, or
+// what a Kind string like "melee" means).
+type ActionView struct {
+	// Ref identifies this action's implementation to whoever compiles an
+	// attack from it later — resolution's AttackFromMonsterAction, or a
+	// character's equipped-weapon compiler. Opaque here.
+	Ref core.Ref
+
+	// Name is this action's display name — "Shortsword", "Bite" — carried
+	// forward from the rulebook's own authoring, exactly as [Member.Name]
+	// is.
+	Name string
+
+	// ReachFeet is how far this action reaches, in FEET (Kirk,
+	// rpg-project#254 review — a cell is 5 feet; see [CellsFromFeet]). The
+	// ONE place that compares this against a grid Distance converts once,
+	// via CellsFromFeet, rather than this record guessing at a conversion.
+	ReachFeet int
+
+	// Kind is this action's category, in the rulebook's own words —
+	// "melee", "ranged", "unarmed" — opaque to this composition and never
+	// branched on here, the same [AttackIdentity.DamageType] precedent
+	// Name already follows.
+	Kind string
 }
 
 // Trigger is an interface for ending conditions.
@@ -431,6 +501,15 @@ type SetupInput struct {
 	// — see ADR-0043 for why this capability, unlike Decider, may not be
 	// silently absent.
 	TurnDriver TurnDriver
+
+	// Striker resolves and records a member's attack when a [TurnDriver]
+	// returns an [Attack] intent (rpg-project#254). REQUIRED, for the same
+	// reason TurnDriver is and at the same door: a fight can form with an
+	// unplayed member ready to swing the moment it forms, so an encounter
+	// that cannot resolve that swing would stall or silently drop it.
+	// Refused at construction (ErrNoStriker). There is no default — see
+	// [Striker]'s own doc.
+	Striker Striker
 
 	// Retention is how many story beats the encounter keeps. Older beats are
 	// trimmed after each append, so an encounter's blob does not grow without
@@ -528,10 +607,20 @@ type Member struct {
 	// field IS this frame (rpg-toolkit#1106). Room above names the authored
 	// chamber whose footprint holds this cell.
 	Position spatial.Position
+
+	// SpeedFeet, SightFeet, Actions and Targeting are this member's static
+	// facts, carried forward verbatim from [MemberInput]/[JoinInput] — see
+	// those fields' own docs. Read by a [TurnDriver] through [MonsterView],
+	// which projects the same record plus the turn's own dynamic parts
+	// (Seen, Budget).
+	SpeedFeet int
+	SightFeet int
+	Actions   []ActionView
+	Targeting string
 }
 
-// memberRecord is what the composition stores about a member: identity and
-// kind, and nothing spatial at all.
+// memberRecord is what the composition stores about a member: identity,
+// kind, and the static member facts — never anything spatial.
 //
 // Deliberately NOT their cell — the canvas holds that, and duplicating it here
 // would create a second truth that the verbs would have to keep in step. Not
@@ -539,10 +628,23 @@ type Member struct {
 // chamber a member stands in is a question the field answers from their cell,
 // and the copy this record used to carry had to be mutated by hand on every
 // crossing.
+//
+// SpeedFeet, SightFeet, Actions and Targeting joined Name here for the same
+// reason Name did (rpg-toolkit#1137): static join-time facts, the same
+// species whether the member is a player or a monster (Kirk, rpg-project#254
+// review — "MemberInput/memberRecord carries MEMBER facts, filled for every
+// kind"), round-tripped through ToData/LoadEncounter as encounter-owned
+// primitives (core.Ref, string, int) rather than imported rulebook types
+// (C1). No parallel monster-only struct: Targeting is the only field of the
+// four that is not filled for a player, and it is simply empty for one.
 type memberRecord struct {
-	ID   MemberID
-	Kind MemberKind
-	Name string
+	ID        MemberID
+	Kind      MemberKind
+	Name      string
+	SpeedFeet int
+	SightFeet int
+	Actions   []ActionView
+	Targeting string
 }
 
 // Status represents the encounter's open/closed state.
@@ -771,6 +873,17 @@ type JoinInput struct {
 	// Players must not have a Decider; passing one for a player will fail
 	// validation. Deciders are NOT persisted; they are re-registered at load.
 	Decider Decider
+
+	// SpeedFeet, SightFeet, Actions and Targeting are this member's static
+	// facts — see [MemberInput]'s own fields of the same name for the full
+	// doc. A joiner arriving mid-scene carries them exactly as an authored
+	// one does; the caller who loaded the sheet or spawned the monster
+	// already knows them (rpg-toolkit#1101's own argument for Name, one
+	// field further).
+	SpeedFeet int
+	SightFeet int
+	Actions   []ActionView
+	Targeting string
 }
 
 // JoinOutput reports the results of a successful join.

--- a/rulebooks/dnd5e/encounter/killingblow_test.go
+++ b/rulebooks/dnd5e/encounter/killingblow_test.go
@@ -64,7 +64,7 @@ func (s *KillingBlowSuite) apart(standing encounter.Standing) *encounter.Encount
 	s.T().Helper()
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: standing,
 		Retention: encounter.RetentionUnbounded,
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -473,3 +473,13 @@ func (s *MonsterTurnTestSuite) TestMemberFactsRoundTripThroughToDataAndLoadEncou
 	}
 	s.True(found)
 }
+
+// TestRefusingStrikerFailsLoudly pins the construction-only-world Striker: a
+// driven turn that reaches it is a host bug (an encounter never meant to run
+// EndTurn/form at all — a placement probe, a template's acceptance test),
+// and the honest answer is a named error rather than a silently fabricated
+// hit.
+func (s *MonsterTurnTestSuite) TestRefusingStrikerFailsLoudly() {
+	err := (encounter.RefusingStriker{}).Strike(context.Background(), nil, goblin, alice, testMeleeAction)
+	s.Require().ErrorIs(err, encounter.ErrRefusingStriker)
+}

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -483,3 +483,62 @@ func (s *MonsterTurnTestSuite) TestRefusingStrikerFailsLoudly() {
 	err := (encounter.RefusingStriker{}).Strike(context.Background(), nil, goblin, alice, testMeleeAction)
 	s.Require().ErrorIs(err, encounter.ErrRefusingStriker)
 }
+
+// TestSetupRejectsANegativeMemberFact and TestJoinRejectsANegativeMemberFact
+// pin Copilot's PR #1187 review finding: SpeedFeet, SightFeet and an
+// action's ReachFeet are feet CellsFromFeet divides by FeetPerCell, and a
+// negative one is a caller defect this composition catches at the door
+// rather than letting it produce a nonsense budget or reach later.
+func (s *MonsterTurnTestSuite) TestSetupRejectsANegativeMemberFact() {
+	base := func(mutate func(*encounter.MemberInput)) *encounter.SetupInput {
+		mi := encounter.MemberInput{
+			ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 1, Y: 1},
+			SpeedFeet: 30, SightFeet: 60,
+			Actions: []encounter.ActionView{{Ref: testMeleeAction, Name: "Claw", ReachFeet: 5}},
+		}
+		mutate(&mi)
+		return &encounter.SetupInput{
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+			TurnDriver: passDriver{}, Striker: passStriker{},
+			Field: encounter.FieldInput{
+				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+				Rooms:  []encounter.RoomInput{{ID: room1, Width: 8, Height: 8}},
+			},
+			Members: []encounter.MemberInput{mi},
+			Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+		}
+	}
+
+	s.Run("negative speed", func() {
+		_, err := encounter.NewEncounter(base(func(mi *encounter.MemberInput) { mi.SpeedFeet = -5 }))
+		s.Require().ErrorIs(err, encounter.ErrNoMember)
+	})
+	s.Run("negative sight", func() {
+		_, err := encounter.NewEncounter(base(func(mi *encounter.MemberInput) { mi.SightFeet = -5 }))
+		s.Require().ErrorIs(err, encounter.ErrNoMember)
+	})
+	s.Run("negative action reach", func() {
+		_, err := encounter.NewEncounter(base(func(mi *encounter.MemberInput) { mi.Actions[0].ReachFeet = -5 }))
+		s.Require().ErrorIs(err, encounter.ErrNoMember)
+	})
+}
+
+// TestJoinRejectsANegativeMemberFactBeforeMutating pins that Join validates
+// BEFORE placing the entity — unlike Setup's construct-in-a-local safety
+// net, Join mutates a LIVE encounter, so a rejected Join must leave no
+// half-placed entity behind (Copilot's suppressed PR #1187 comment).
+func (s *MonsterTurnTestSuite) TestJoinRejectsANegativeMemberFactBeforeMutating() {
+	enc := s.adjacentSkeletonEncounter(passDriver{}, passStriker{})
+
+	_, err := enc.Join(&encounter.JoinInput{
+		Member: "wolf", Kind: encounter.KindMonster, Cell: spatial.Position{X: 5, Y: 5},
+		SpeedFeet: -10,
+	})
+	s.Require().ErrorIs(err, encounter.ErrNoMember)
+
+	members, err := enc.Members()
+	s.Require().NoError(err)
+	for _, m := range members {
+		s.NotEqual(core.EntityID("wolf"), m.ID, "the rejected join left no half-placed entity behind")
+	}
+}

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -1,0 +1,475 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// MonsterTurnTestSuite covers the monster's turn (rpg-project#254): the
+// composition side of TurnDriver.Act(MonsterView), Striker, and
+// driveMonsterTurns' build-view/act/execute loop.
+type MonsterTurnTestSuite struct {
+	suite.Suite
+}
+
+func TestMonsterTurnSuite(t *testing.T) {
+	suite.Run(t, new(MonsterTurnTestSuite))
+}
+
+var testMeleeAction = core.Ref{Module: "dnd5e", Type: "monster_actions", ID: "melee"}
+
+// scriptedDriver returns intents from a fixed queue, one per Act call, and
+// records every View it was handed so a test can assert on what this
+// composition told it. Once the queue is exhausted it returns Pass,
+// matching PassDriver's own contract for a well-behaved driver with nothing
+// left to say.
+type scriptedDriver struct {
+	intents []encounter.TurnIntent
+	errs    []error
+	calls   []encounter.MonsterView
+}
+
+func (d *scriptedDriver) Act(view encounter.MonsterView) (encounter.TurnIntent, error) {
+	d.calls = append(d.calls, view)
+	i := len(d.calls) - 1
+	if i < len(d.errs) && d.errs[i] != nil {
+		return nil, d.errs[i]
+	}
+	if i < len(d.intents) {
+		return d.intents[i], nil
+	}
+	return encounter.Pass{}, nil
+}
+
+// scriptedStriker records every Strike call and, unless told to fail,
+// records a fixed outcome via [encounter.Encounter.Record] itself — the same
+// obligation a real Striker implementation carries.
+type scriptedStriker struct {
+	kind encounter.OutcomeKind
+	fail error
+
+	calls []struct {
+		Attacker, Target encounter.MemberID
+		Action           core.Ref
+	}
+}
+
+func (s *scriptedStriker) Strike(
+	_ context.Context, enc *encounter.Encounter, attacker, target encounter.MemberID, action core.Ref,
+) error {
+	s.calls = append(s.calls, struct {
+		Attacker, Target encounter.MemberID
+		Action           core.Ref
+	}{attacker, target, action})
+
+	if s.fail != nil {
+		return s.fail
+	}
+
+	_, err := enc.Record(&encounter.RecordInput{
+		Kind:    s.kind,
+		Actor:   attacker,
+		Targets: []encounter.MemberID{target},
+		Attack:  &encounter.AttackIdentity{Ref: action.String(), Name: "Test Strike", DamageType: "bludgeoning"},
+	})
+	return err
+}
+
+// adjacentSkeletonEncounter builds a one-room fight: alice and a monster
+// standing next to each other (co-located rooms form the bubble at first
+// light — see twoMemberEncounter's own doc, one file over), the monster
+// carrying one melee action at 5 feet reach and a 30-foot walking speed.
+func (s *MonsterTurnTestSuite) adjacentSkeletonEncounter(driver encounter.TurnDriver, striker encounter.Striker) *encounter.Encounter {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: driver, Striker: striker,
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
+			{
+				ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 3, Y: 2},
+				SpeedFeet: 30, Targeting: "closest",
+				Actions: []encounter.ActionView{
+					{Ref: testMeleeAction, Name: "Shortsword", ReachFeet: 5, Kind: "melee"},
+				},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	return enc
+}
+
+// farSkeletonEncounter is the same fight with the monster placed OUT of the
+// melee action's 5-foot reach (one cell) but still within its own sight (an
+// unlimited-sight fixture, so contact still forms the bubble at first light)
+// and within its own movement budget — near enough to close the distance in
+// one Move, far enough that an immediate Attack is [encounter.ErrBadIntent].
+func (s *MonsterTurnTestSuite) farSkeletonEncounter(driver encounter.TurnDriver, striker encounter.Striker) *encounter.Encounter {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: driver, Striker: striker,
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
+			{
+				ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 6, Y: 2},
+				SpeedFeet: 30, Targeting: "closest",
+				Actions: []encounter.ActionView{
+					{Ref: testMeleeAction, Name: "Shortsword", ReachFeet: 5, Kind: "melee"},
+				},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	return enc
+}
+
+// clockBeats returns every "tag":"clock" beat's decoded payload, in story
+// order.
+func (s *MonsterTurnTestSuite) clockBeats(enc *encounter.Encounter, audience core.EntityID) []map[string]interface{} {
+	story, err := enc.Story(&encounter.StoryInput{Audience: audience})
+	s.Require().NoError(err)
+	var out []map[string]interface{}
+	for _, entry := range story {
+		switch entry.Tags["tag"] {
+		case "clock", "outcome", "movement":
+		default:
+			continue
+		}
+		var p map[string]interface{}
+		s.Require().NoError(json.Unmarshal(entry.Payload, &p))
+		out = append(out, p)
+	}
+	return out
+}
+
+// TestMonsterViewCarriesStaticFactsAndSeen pins the shape a TurnDriver is
+// actually handed: its own static facts verbatim (Self, Position, Actions,
+// Targeting), a Seen entry for alice with Distance and InReach computed
+// against the monster's OWN action, and a Budget of one attack plus its own
+// SpeedFeet.
+func (s *MonsterTurnTestSuite) TestMonsterViewCarriesStaticFactsAndSeen() {
+	driver := &scriptedDriver{}
+	enc := s.adjacentSkeletonEncounter(driver, &scriptedStriker{kind: encounter.OutcomeMissed})
+
+	_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	s.Require().Len(driver.calls, 1, "one Pass ends the goblin's turn in a single Act call")
+	view := driver.calls[0]
+
+	s.Equal(goblin, view.Self)
+	s.Equal(spatial.Position{X: 3, Y: 2}, view.Position)
+	s.Equal("closest", view.Targeting)
+	s.Require().Len(view.Actions, 1)
+	s.Equal(testMeleeAction, view.Actions[0].Ref)
+	s.Equal(5, view.Actions[0].ReachFeet)
+	s.Equal(1, view.Budget.AttacksLeft)
+	s.Equal(30, view.Budget.MovementFeet)
+
+	s.Require().Len(view.Seen, 1)
+	seen := view.Seen[0]
+	s.Equal(alice, seen.ID)
+	s.Equal(encounter.KindPlayer, seen.Kind)
+	s.True(seen.Standing)
+	s.Equal(spatial.Position{X: 2, Y: 2}, seen.Position)
+	s.InDelta(1.0, seen.Distance, 0.001, "adjacent cells are 1 cell apart")
+	s.True(seen.InReach[testMeleeAction], "1 cell is within a 5-foot (1-cell) reach")
+}
+
+// TestAttackExecutesAndConsumesTheBudget: an in-reach Attack calls the
+// Striker exactly once, the story carries the recorded outcome, and the
+// NEXT Act call (before the goblin's own Pass) sees AttacksLeft at zero —
+// the same budget object every call in this turn shares.
+func (s *MonsterTurnTestSuite) TestAttackExecutesAndConsumesTheBudget() {
+	driver := &scriptedDriver{intents: []encounter.TurnIntent{
+		encounter.Attack{Target: alice, Action: testMeleeAction},
+	}}
+	striker := &scriptedStriker{kind: encounter.OutcomeMissed}
+	enc := s.adjacentSkeletonEncounter(driver, striker)
+
+	et, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+	s.Equal(alice, et.Next, "the goblin's whole turn — attack, then pass — still hands play back to alice")
+
+	s.Require().Len(striker.calls, 1)
+	s.Equal(goblin, striker.calls[0].Attacker)
+	s.Equal(alice, striker.calls[0].Target)
+	s.Equal(testMeleeAction, striker.calls[0].Action)
+
+	s.Require().Len(driver.calls, 2, "attack, then a second Act call that passes")
+	s.Equal(1, driver.calls[0].Budget.AttacksLeft, "the attack had not executed yet when this view was built")
+	s.Equal(0, driver.calls[1].Budget.AttacksLeft, "the executed attack is reflected in the next view")
+
+	beats := s.clockBeats(enc, alice)
+	var sawMissed bool
+	for _, b := range beats {
+		if b["beat"] == "missed" && b["actor"] == string(goblin) {
+			sawMissed = true
+		}
+	}
+	s.True(sawMissed, "the striker's recorded outcome is in the story: %+v", beats)
+}
+
+// TestAttackOnOutOfReachTargetEndsTheTurnWithoutAborting is the brief's own
+// gate case (c): a driver returning Attack on a target its own action
+// cannot reach is [encounter.ErrBadIntent] internally, but that must never
+// reach the caller — EndTurn still succeeds, and the Striker is never
+// called.
+func (s *MonsterTurnTestSuite) TestAttackOnOutOfReachTargetEndsTheTurnWithoutAborting() {
+	driver := &scriptedDriver{intents: []encounter.TurnIntent{
+		encounter.Attack{Target: alice, Action: testMeleeAction},
+	}}
+	striker := &scriptedStriker{kind: encounter.OutcomeMissed}
+	enc := s.farSkeletonEncounter(driver, striker)
+
+	et, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err, "a bad intent ends the goblin's turn; it does not abort EndTurn")
+	s.Equal(alice, et.Next)
+
+	s.Empty(striker.calls, "an out-of-reach attack never reaches the Striker")
+
+	beats := s.clockBeats(enc, alice)
+	for _, b := range beats {
+		s.NotEqual("missed", b["beat"])
+		s.NotEqual("struck", b["beat"])
+	}
+}
+
+// TestAttackOnAnUnseenTargetEndsTheTurnWithoutAborting: a target this
+// composition never told the driver about (not in Seen) is refused exactly
+// as an out-of-reach one is — a driver cannot attack what it was not shown.
+func (s *MonsterTurnTestSuite) TestAttackOnAnUnseenTargetEndsTheTurnWithoutAborting() {
+	driver := &scriptedDriver{intents: []encounter.TurnIntent{
+		encounter.Attack{Target: bob, Action: testMeleeAction},
+	}}
+	striker := &scriptedStriker{kind: encounter.OutcomeMissed}
+	enc := s.adjacentSkeletonEncounter(driver, striker)
+
+	et, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+	s.Equal(alice, et.Next)
+	s.Empty(striker.calls)
+}
+
+// TestMoveWalksTowardTheTargetAndUpdatesTheView: a Move intent executes cell
+// by cell via the same stepTo mechanism the pump uses, "moved" beats land in
+// the story, and the FOLLOWING Act call in the same turn sees the goblin's
+// new position and the spent movement budget.
+func (s *MonsterTurnTestSuite) TestMoveWalksTowardTheTargetAndUpdatesTheView() {
+	driver := &scriptedDriver{intents: []encounter.TurnIntent{
+		encounter.Move{Path: []spatial.Position{{X: 5, Y: 2}, {X: 4, Y: 2}}},
+	}}
+	enc := s.farSkeletonEncounter(driver, &scriptedStriker{kind: encounter.OutcomeMissed})
+
+	_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	s.Require().Len(driver.calls, 2, "move, then a second Act call that passes")
+	s.Equal(spatial.Position{X: 6, Y: 2}, driver.calls[0].Position, "the view BEFORE the move is the starting cell")
+	s.Equal(spatial.Position{X: 4, Y: 2}, driver.calls[1].Position, "both cells of the path executed")
+	s.Equal(30, driver.calls[0].Budget.MovementFeet)
+	s.Equal(20, driver.calls[1].Budget.MovementFeet, "2 cells at 5 feet each spent from the 30-foot budget")
+
+	members, err := enc.Members()
+	s.Require().NoError(err)
+	var goblinPos spatial.Position
+	for _, m := range members {
+		if m.ID == goblin {
+			goblinPos = m.Position
+		}
+	}
+	s.Equal(spatial.Position{X: 4, Y: 2}, goblinPos)
+
+	beats := s.clockBeats(enc, alice)
+	var moved int
+	for _, b := range beats {
+		if b["beat"] == "moved" {
+			moved++
+		}
+	}
+	s.Equal(2, moved, "one moved beat per executed cell: %+v", beats)
+}
+
+// TestMoveExceedingTheBudgetEndsTheTurnWithoutAborting: a driver asking for
+// more cells than it can afford is [encounter.ErrBadIntent] — the turn ends,
+// EndTurn still succeeds, and NOTHING in the over-budget path executes (not
+// even the affordable prefix): a driver that cannot do arithmetic on its own
+// budget gets its turn ended rather than a partial move it did not ask for.
+func (s *MonsterTurnTestSuite) TestMoveExceedingTheBudgetEndsTheTurnWithoutAborting() {
+	// The goblin's 30-foot speed affords 6 cells; ask for 7.
+	path := make([]spatial.Position, 7)
+	for i := range path {
+		path[i] = spatial.Position{X: float64(6 - i), Y: 2}
+	}
+	driver := &scriptedDriver{intents: []encounter.TurnIntent{encounter.Move{Path: path}}}
+	enc := s.farSkeletonEncounter(driver, &scriptedStriker{kind: encounter.OutcomeMissed})
+
+	et, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+	s.Equal(alice, et.Next)
+
+	members, err := enc.Members()
+	s.Require().NoError(err)
+	for _, m := range members {
+		if m.ID == goblin {
+			s.Equal(spatial.Position{X: 6, Y: 2}, m.Position, "an over-budget move never starts")
+		}
+	}
+}
+
+// TestAnEmptyMoveEndsTheTurnWithoutAborting: an empty path is nonsense (Pass
+// is the way to say "nothing left to do") and is refused the same way.
+func (s *MonsterTurnTestSuite) TestAnEmptyMoveEndsTheTurnWithoutAborting() {
+	driver := &scriptedDriver{intents: []encounter.TurnIntent{encounter.Move{}}}
+	enc := s.farSkeletonEncounter(driver, &scriptedStriker{kind: encounter.OutcomeMissed})
+
+	et, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+	s.Equal(alice, et.Next)
+}
+
+// TestMoveIntoVoidStopsPartwayWithoutEndingTheTurn: a path whose first cell
+// is floor and whose second is not stops there — exactly the refusal a
+// player's own walk would meet — WITHOUT treating the whole intent as bad:
+// the turn keeps running, and the driver is asked again from wherever the
+// walk actually stopped ("the same refusals a player's walk meets").
+func (s *MonsterTurnTestSuite) TestMoveIntoVoidStopsPartwayWithoutEndingTheTurn() {
+	driver := &scriptedDriver{intents: []encounter.TurnIntent{
+		// The room is 10x10 (cells 0..9); (12,2) is outside it — void, not
+		// floor. (5,2) is the one cell of progress this path can make.
+		encounter.Move{Path: []spatial.Position{{X: 5, Y: 2}, {X: 12, Y: 2}}},
+	}}
+	enc := s.farSkeletonEncounter(driver, &scriptedStriker{kind: encounter.OutcomeMissed})
+
+	_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	s.Require().Len(driver.calls, 2, "the partial move does not end the turn; the driver is asked again")
+	s.Equal(spatial.Position{X: 5, Y: 2}, driver.calls[1].Position, "the successful cell was kept")
+	s.Equal(25, driver.calls[1].Budget.MovementFeet, "only the ONE cell that succeeded was spent")
+}
+
+// TestPassDriverAlwaysPasses pins rpg-toolkit#1167: the exported, reusable
+// TurnDriver that always ends an unplayed member's turn with no other
+// effect — the same v1 behaviour every scene got automatically before this
+// capability existed.
+func (s *MonsterTurnTestSuite) TestPassDriverAlwaysPasses() {
+	intent, err := (encounter.PassDriver{}).Act(encounter.MonsterView{Self: goblin})
+	s.Require().NoError(err)
+	s.Equal(encounter.Pass{}, intent)
+}
+
+// TestADriverMalfunctionAbortsTheWholeCall: unlike ErrBadIntent, a driver's
+// own Go error is NOT swallowed — it is a malfunction, and EndTurn reports
+// it.
+func (s *MonsterTurnTestSuite) TestADriverMalfunctionAbortsTheWholeCall() {
+	boom := errors.New("driver malfunction")
+	driver := &scriptedDriver{errs: []error{boom}}
+	enc := s.adjacentSkeletonEncounter(driver, &scriptedStriker{kind: encounter.OutcomeMissed})
+
+	_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().ErrorIs(err, boom)
+}
+
+// TestAStrikerMalfunctionAbortsTheWholeCall: a Striker error is a
+// malfunction too (a resolution failure, a corrupt sheet) — not a miss,
+// which is recorded rather than returned as an error.
+func (s *MonsterTurnTestSuite) TestAStrikerMalfunctionAbortsTheWholeCall() {
+	boom := errors.New("striker malfunction")
+	driver := &scriptedDriver{intents: []encounter.TurnIntent{
+		encounter.Attack{Target: alice, Action: testMeleeAction},
+	}}
+	striker := &scriptedStriker{fail: boom}
+	enc := s.adjacentSkeletonEncounter(driver, striker)
+
+	_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().ErrorIs(err, boom)
+}
+
+// TestSetupRefusesAnEncounterWithNoStriker mirrors
+// TestSetupRefusesAnEncounterWithNoTurnDriver (clocks_test.go) for the new
+// capability: a Striker-less encounter is refused at construction rather
+// than discovered when the first monster decides to attack.
+func (s *MonsterTurnTestSuite) TestSetupRefusesAnEncounterWithNoStriker() {
+	_, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: passDriver{},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: room1, Width: 8, Height: 8}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().ErrorIs(err, encounter.ErrNoStriker)
+}
+
+// TestLoadRefusesAnEncounterWithNoStriker is the other door — see
+// TestSetupRefusesAnEncounterWithNoStriker's own doc.
+func (s *MonsterTurnTestSuite) TestLoadRefusesAnEncounterWithNoStriker() {
+	saved := s.adjacentSkeletonEncounter(passDriver{}, passStriker{}).ToData()
+
+	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data:  saved,
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: passDriver{},
+	})
+	s.Require().ErrorIs(err, encounter.ErrNoStriker)
+}
+
+// TestMemberFactsRoundTripThroughToDataAndLoadEncounter pins the unified
+// member record (Kirk, rpg-project#254 review): SpeedFeet, SightFeet,
+// Actions and Targeting are encounter-owned primitives, persisted and
+// restored verbatim exactly as Name already is.
+func (s *MonsterTurnTestSuite) TestMemberFactsRoundTripThroughToDataAndLoadEncounter() {
+	enc := s.adjacentSkeletonEncounter(passDriver{}, passStriker{})
+	saved := enc.ToData()
+
+	loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data:  saved,
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: passDriver{}, Striker: passStriker{},
+	})
+	s.Require().NoError(err)
+
+	members, err := loaded.Members()
+	s.Require().NoError(err)
+	var found bool
+	for _, m := range members {
+		if m.ID != goblin {
+			continue
+		}
+		found = true
+		s.Equal(30, m.SpeedFeet)
+		s.Equal("closest", m.Targeting)
+		s.Require().Len(m.Actions, 1)
+		s.Equal(testMeleeAction, m.Actions[0].Ref)
+		s.Equal("Shortsword", m.Actions[0].Name)
+		s.Equal(5, m.Actions[0].ReachFeet)
+		s.Equal("melee", m.Actions[0].Kind)
+	}
+	s.True(found)
+}

--- a/rulebooks/dnd5e/encounter/names_test.go
+++ b/rulebooks/dnd5e/encounter/names_test.go
@@ -31,7 +31,7 @@ const namesRoom = "hall"
 func namesScene(members []encounter.MemberInput) (*encounter.Encounter, error) {
 	return encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
@@ -121,7 +121,7 @@ func (s *NamesTestSuite) TestNameRoundTripsThroughPersistence() {
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Initiative: orderAsGiven{}, Standing: everyoneStanding{},
-		Sight: everyoneSeesTheWholeMap{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/encounter/orientation_test.go
+++ b/rulebooks/dnd5e/encounter/orientation_test.go
@@ -91,7 +91,7 @@ func hexTomb(o encounter.Orientation) encounter.FieldInput {
 
 func (s *OrientationSuite) build(field encounter.FieldInput, at spatial.Position, room string) (*encounter.Encounter, error) {
 	return encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: "delve", Kind: encounter.KindPlayer, Room: room, Position: at},
@@ -245,7 +245,7 @@ func (s *OrientationSuite) TestTheOrientationSurvivesASave() {
 
 	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 	s.Require().NoError(err)
 
@@ -258,7 +258,7 @@ func (s *OrientationSuite) TestTheOrientationSurvivesASave() {
 		d.Field.Canvas.Orientation = ""
 		_, lerr := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 			Data: d, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-			Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		})
 		s.Require().ErrorIs(lerr, encounter.ErrNoField)
 		s.Contains(lerr.Error(), "orientation")
@@ -269,7 +269,7 @@ func (s *OrientationSuite) TestTheOrientationSurvivesASave() {
 		d.Field.Canvas.Orientation = "sideways"
 		_, lerr := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 			Data: d, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-			Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		})
 		s.Require().ErrorIs(lerr, encounter.ErrNoField)
 		s.Contains(lerr.Error(), "sideways")
@@ -426,7 +426,7 @@ func (s *OrientationSuite) TestASquareBlobMustNotDeclareAnOrientation() {
 	data.Field.Canvas.Orientation = "pointy"
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Contains(strings.ToLower(err.Error()), "orientation")

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -29,7 +29,7 @@ const outcomeRoom = "yard"
 // other's sight, so nothing forms a fight before a test asks for one.
 func (s *OutcomeTestSuite) scene() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{
 			ID: outcomeRoom, Width: 12, Height: 12, Props: wallRow(6, 4, 8),
 		}}},

--- a/rulebooks/dnd5e/encounter/placement_test.go
+++ b/rulebooks/dnd5e/encounter/placement_test.go
@@ -52,7 +52,7 @@ var gate = encounter.ConnectionInput{
 
 func (s *PlacementSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -326,7 +326,7 @@ func (s *PlacementSuite) TestTheOutcomeSurvivesARoundTripStillAbsolute() {
 	s.Require().NoError(err)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Data: s.enc.ToData(), Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Data: s.enc.ToData(), Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/encounter/props_test.go
+++ b/rulebooks/dnd5e/encounter/props_test.go
@@ -87,7 +87,7 @@ func (s *PropsSuite) chamber(ref string, blocksMovement, blocksSight *bool) *enc
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
@@ -186,7 +186,7 @@ func (s *PropsSuite) TestCandlesAreThereAndInNobodysWay() {
 // as "a pillar and a statue are the same cell".
 func (s *PropsSuite) TestTheMapSaysWHICHThingIsWhere() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
@@ -227,7 +227,7 @@ func (s *PropsSuite) TestTheMapSaysWHICHThingIsWhere() {
 func (s *PropsSuite) TestAPropMustSayWhatItDoes() {
 	build := func(p encounter.PropInput) error {
 		_, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{{
@@ -280,7 +280,7 @@ func (s *PropsSuite) TestAPropSurvivesASave() {
 
 	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 	s.Require().NoError(err)
 
@@ -318,7 +318,7 @@ func (s *PropsSuite) TestAnOldBlobsOccludersAreRefusedLoudly() {
 
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Contains(err.Error(), "occluders",
@@ -341,7 +341,7 @@ func (s *PropsSuite) TestAPersistedPropMustSayWhatItDoesToo() {
 		mutate(&data.Field.Rooms[0])
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 			Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-			Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		})
 		return err
 	}
@@ -373,7 +373,7 @@ func (s *PropsSuite) TestAPersistedPropMustSayWhatItDoesToo() {
 func (s *PropsSuite) TestEditingTheSetupAfterwardsCannotChangeTheSavedDungeon() {
 	solid := true
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -222,7 +222,7 @@ func (p *pursuitDecider) Decide(snap encounter.Snapshot) (encounter.Intent, erro
 // cleanup: an exited monster's decider must never be consulted again.
 func (s *PumpTestSuite) TestPumpDoesNotConsultExitedMonsterDecider() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
@@ -257,7 +257,7 @@ func (s *PumpTestSuite) TestPumpGoblinPatrols() {
 		}
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -357,7 +357,7 @@ func (s *PumpTestSuite) TestPumpDeciderIsolation() {
 		// asymmetric perception (#1020) or a faction model, at which point
 		// this test should grow the positive case again.
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{{
@@ -408,7 +408,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 		errDecider := &errorDecider{err: deciderErr}
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -489,7 +489,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 // NEXT (successful) pump reports reading 1, not 2.
 func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
@@ -514,7 +514,7 @@ func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 // have moved — no partial mutation (R5).
 func (s *PumpTestSuite) TestPumpPartialAbort() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
@@ -559,7 +559,7 @@ func (s *PumpTestSuite) TestPumpPartialAbort() {
 func (s *PumpTestSuite) TestPumpMutatingDeciderCannotCorrupt() {
 	vandal := &vandalDecider{}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
@@ -606,7 +606,7 @@ func (s *PumpTestSuite) TestPumpMonsterOnUnfilteredStairsDontClose() {
 		}
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -673,7 +673,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 		aliceID := core.EntityID("alice")
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -745,7 +745,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 // this seam.
 func (s *PumpTestSuite) TestPumpJoinedMonsterWithNilDeciderHolds() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 0, Y: 0}},
@@ -782,7 +782,7 @@ func (s *PumpTestSuite) TestPumpClosedEncounterViaReachedPosition() {
 		}
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -862,7 +862,7 @@ func (s *PumpTestSuite) TestPumpTickBeatAndMoveBeats() {
 		}
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -948,7 +948,7 @@ func (s *PumpTestSuite) TestPumpClockAdvanceByOne() {
 		goblinID := core.EntityID("goblin")
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -1029,7 +1029,7 @@ func (s *PumpTestSuite) TestPumpPlayerWithDeciderRejected() {
 		aliceID := core.EntityID("alice")
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 				Rooms: []encounter.RoomInput{
@@ -1123,7 +1123,7 @@ func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
 	spyB := &snapshotSpyDecider{}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1175,7 +1175,7 @@ func (s *PumpTestSuite) TestAnIntendedStepCrossesADoorway() {
 	decider := &onceStepDecider{to: spatial.Position{X: 10, Y: 5}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1249,7 +1249,7 @@ func (s *PumpTestSuite) TestPumpReportsMovementOnTheMap() {
 	}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1360,7 +1360,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenAWallIsInTheWay() {
 	decider := &onceStepDecider{to: spatial.Position{X: 10, Y: 2}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1418,7 +1418,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenTheCellIsNowhere() {
 	decider := &onceStepDecider{to: spatial.Position{X: 500, Y: 500}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1471,7 +1471,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAbortsEvenWithTraversableTopology() 
 	deciderErr := errors.New("test decider error")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1517,7 +1517,7 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	goblinID := core.EntityID("goblin")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1627,7 +1627,7 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 	bID := core.EntityID("zzz-goblin")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1731,7 +1731,7 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 
 	s.Run("control: decision order and declaration order agree", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				{ID: aID, Kind: encounter.KindMonster, Room: room1,
@@ -1756,7 +1756,7 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 
 	s.Run("cross: decision order dominates — the SECOND-declared ending wins", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 			Members: []encounter.MemberInput{
 				// Same decision order (aaa first, zzz second), but now each
@@ -1815,7 +1815,7 @@ func (s *PumpTestSuite) TestPumpSurvivesReentrantSelfExitingDecider() {
 	decider := &reentrantSelfExitDecider{self: goblinID}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: room1, Width: 10, Height: 10, Boundaries: twoRoomSealedWall()}, {ID: room2, Width: 10, Height: 10, Origin: spatial.Position{X: 10, Y: 0}}}},
 		Members: []encounter.MemberInput{
 			{ID: aliceID, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 1, Y: 1}},
@@ -1864,7 +1864,7 @@ func (s *PumpTestSuite) TestPumpStopsMovingAMonsterOnceSeen() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -1957,7 +1957,7 @@ func (s *PumpTestSuite) TestPumpDeciderHuntsLastKnownPosition() {
 	hidden := spatial.Position{X: 4, Y: 5}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{

--- a/rulebooks/dnd5e/encounter/pursuit_test.go
+++ b/rulebooks/dnd5e/encounter/pursuit_test.go
@@ -82,7 +82,7 @@ func (s *PursuitSuite) SetupTest() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			// Alice stands at the threshold; the goblin is across the room
@@ -213,7 +213,7 @@ func (s *PursuitSuite) freeRoamWith(decider encounter.Decider) {
 
 	data := s.enc.ToData()
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Data:     data,
 		Deciders: map[encounter.MemberID]encounter.Decider{hunter: decider},
 	})

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -40,7 +40,7 @@ func TestRegionSuite(t *testing.T) {
 // same opening, carol and dave one row up with the seam wall between them.
 func (s *RegionSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
@@ -232,7 +232,7 @@ func (s *RegionSuite) TestAStepChangesTheRegionAMemberIsIn() {
 // reports every member's region, derived from where they each stand.
 func (s *RegionSuite) TestReachingTheTombChamberClosesTheDelve() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: tombHall,
@@ -288,7 +288,7 @@ func (s *RegionSuite) TestTheRegionIsDerivedAcrossPersistenceToo() {
 	s.NotContains(string(blob), `"region"`, "and it did not come back under a new name either")
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err)
 
 	status, err := reloaded.Status()
@@ -347,7 +347,7 @@ func (s *RegionSuite) TestAStaleRegionLabelInABlobCannotChangeTheAnswer() {
 	s.Require().NoError(json.Unmarshal(tampered, &data))
 
 	loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err, "an unknown key is ignored, not a defect to refuse")
 
 	status, err := loaded.Status()
@@ -461,7 +461,7 @@ func (s *RegionSuite) TestAFractionalHexPositionIsNotACell() {
 // from the origin so a local coordinate cannot pass as an absolute one.
 func (s *RegionSuite) oneRoom(shape spatial.GridShape, w, h int, origin spatial.Position) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: orientationFor(shape)},
 			Rooms: []encounter.RoomInput{

--- a/rulebooks/dnd5e/encounter/retention_test.go
+++ b/rulebooks/dnd5e/encounter/retention_test.go
@@ -34,7 +34,7 @@ type RetentionTestSuite struct {
 // with the ending at (4,4).
 func (s *RetentionTestSuite) walkingEncounter(retention int) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{{ID: "r1", Width: 5, Height: 5}}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Room: "r1", Position: spatial.Position{X: 1, Y: 1}},
@@ -242,7 +242,7 @@ func (s *RetentionTestSuite) TestRetentionSurvivesReload() {
 	s.Equal(window, data.Retention, "retention is persisted, not inferred")
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
 	s.Require().NoError(err)
 
 	// The reloaded encounter must still be trimming to the SAME window: keep
@@ -263,7 +263,7 @@ func (s *RetentionTestSuite) TestFloorSurvivesReload() {
 	s.generateBeats(enc, 40)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	_, err = reloaded.Story(&encounter.StoryInput{Audience: "p1", AfterSeq: 33})
@@ -283,7 +283,7 @@ func (s *RetentionTestSuite) TestUntrimmedEncounterHasNoFloor() {
 	s.generateBeats(enc, 5)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	for seq := uint64(1); seq <= 6; seq++ {

--- a/rulebooks/dnd5e/encounter/sight_test.go
+++ b/rulebooks/dnd5e/encounter/sight_test.go
@@ -86,7 +86,7 @@ func cells(from, to spatial.Position) int {
 // thing deciding percepts is sight.
 func (s *SightSuite) theLongRow(sight encounter.Sight) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: sight, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: sight, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
@@ -190,7 +190,7 @@ func (s *SightSuite) TestTheEdgeOfYourSightIsInsideIt() {
 // before it — would pass every other test in this file.
 func (s *SightSuite) TestSightIsStillGeometryFirst() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: &sightList{fallback: darkvision}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: &sightList{fallback: darkvision}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: carol, Kind: encounter.KindPlayer, Room: tombEntrance,
@@ -245,7 +245,7 @@ func (s *SightSuite) TestTheConeStillNarrows() {
 		}}, marks...)
 
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: &sightList{fallback: generous}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: &sightList{fallback: generous}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field:   tombField(),
 			Members: members,
 			Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
@@ -348,7 +348,7 @@ func (s *SightSuite) TestTheFarSightedSpotTheShortSightedAndSurpriseThem() {
 
 	scene := func(sight encounter.Sight) *encounter.Encounter {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: sight, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: sight, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: tombField(),
 			Members: []encounter.MemberInput{
 				{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
@@ -409,7 +409,7 @@ func (s *SightSuite) TestTheFarSightedSpotTheShortSightedAndSurpriseThem() {
 func TestASceneThatDoesNotSayHowFarAnyoneCanSeeIsRefused(t *testing.T) {
 	t.Run("setup", func(t *testing.T) {
 		_, err := encounter.NewEncounter(&encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: tombField(),
 			Members: []encounter.MemberInput{
 				{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
@@ -423,7 +423,7 @@ func TestASceneThatDoesNotSayHowFarAnyoneCanSeeIsRefused(t *testing.T) {
 
 	t.Run("load", func(t *testing.T) {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: tombField(),
 			Members: []encounter.MemberInput{
 				{ID: alice, Kind: encounter.KindPlayer, Room: tombEntrance,
@@ -434,7 +434,7 @@ func TestASceneThatDoesNotSayHowFarAnyoneCanSeeIsRefused(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: enc.ToData(),
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc.ToData(),
 		})
 		require.Error(t, err)
 		require.ErrorIs(t, err, encounter.ErrNoSight)

--- a/rulebooks/dnd5e/encounter/sightdecode_test.go
+++ b/rulebooks/dnd5e/encounter/sightdecode_test.go
@@ -82,7 +82,7 @@ func TestDecodeSightPayloadRefusesTheRoomBearingDialect(t *testing.T) {
 // invented.
 func TestDecodeSightPayloadAgreesWithAViewsOwnPayload(t *testing.T) {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "hall", Width: 8, Height: 8}},

--- a/rulebooks/dnd5e/encounter/standing_test.go
+++ b/rulebooks/dnd5e/encounter/standing_test.go
@@ -61,7 +61,7 @@ func (s *deathScene) scene(standing encounter.Standing, members ...encounter.Mem
 	s.T().Helper()
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: standing,
 		Retention: encounter.RetentionUnbounded,
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
@@ -177,7 +177,7 @@ func (s *deathScene) beatsOf(enc *encounter.Encounter, audience encounter.Member
 // — a default would be this module deciding a rule it is not allowed to know.
 func (s *StandingSuite) TestSetupRefusesAnEncounterThatCannotAskWhoIsDown() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{
 			{ID: cryptID, Width: 12, Height: 12},
 		}},
@@ -198,7 +198,7 @@ func (s *StandingSuite) TestLoadRefusesAnEncounterThatCannotAskWhoIsDown() {
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:       saved,
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 
 	s.Require().ErrorIs(err, encounter.ErrNoStanding)
@@ -213,7 +213,7 @@ func (s *StandingSuite) TestALoadedEncounterAsksToo() {
 	down := &downList{down: []encounter.MemberID{goblin}}
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:       saved,
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: down,
 	})
 	s.Require().NoError(err)
@@ -414,7 +414,7 @@ func (s *StandingSuite) TestTheStorySaysItOnce() {
 // composition still says down).
 func (s *StandingSuite) TestAForgottenDeathIsToldAgain() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: &downList{down: []encounter.MemberID{goblin}},
 		Retention: 4,
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Rooms: []encounter.RoomInput{

--- a/rulebooks/dnd5e/encounter/step_test.go
+++ b/rulebooks/dnd5e/encounter/step_test.go
@@ -102,7 +102,7 @@ func stepField() encounter.FieldInput {
 // the only thing that happens.
 func (s *StepSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
@@ -358,7 +358,7 @@ func (s *StepSuite) TestAStepAndAMonsterStepAgreeOnWhatIsCrossable() {
 // "nobody has seen anybody".
 func (s *StepSuite) sceneWithMonster(at spatial.Position, decider encounter.Decider) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: goblin, Kind: encounter.KindMonster, Room: stepWest,
@@ -389,7 +389,7 @@ func (s *StepSuite) whereIn(enc *encounter.Encounter, id encounter.MemberID) spa
 func (s *StepSuite) TestAStepFiresAReachedPositionEnding() {
 	target := spatial.Position{X: 4, Y: 2}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
@@ -413,7 +413,7 @@ func (s *StepSuite) TestAStepFiresAReachedPositionEnding() {
 // against where the member landed, not where they left.
 func (s *StepSuite) TestACrossingFiresAReachedPositionEndingOnTheFarSide() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
@@ -480,7 +480,7 @@ func (s *StepSuite) TestAStepRefusesAFightMember() {
 	// is Active and the goblin is not: rpg-toolkit#1169 refuses HIS step
 	// now, not hers (see TestAnActiveFightMemberSteps for hers).
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
@@ -502,7 +502,7 @@ func (s *StepSuite) TestAStepRefusesAFightMember() {
 // actually waiting on moves through Step like anyone else.
 func (s *StepSuite) TestAnActiveFightMemberSteps() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Room: stepWest,
@@ -538,7 +538,7 @@ func (s *StepSuite) TestGridReportsTheFieldsFamily() {
 // square case.
 func (s *StepSuite) TestGridReportsAHexFieldAsHex() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Rooms: []encounter.RoomInput{
 			{ID: stepWest, Width: 6, Height: 6, Grid: spatial.GridShapeHex,
 				Origin: stepWestOrigin},

--- a/rulebooks/dnd5e/encounter/testturndriver_internal_test.go
+++ b/rulebooks/dnd5e/encounter/testturndriver_internal_test.go
@@ -3,11 +3,30 @@
 
 package encounter
 
+import (
+	"context"
+	"errors"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+)
+
 // passDriver is the internal-package twin of encounter_test's own — see its
 // doc. A separate type because the internal test package cannot import the
 // external one (and does not need to: this file's whole job is being small).
 type passDriver struct{}
 
-func (passDriver) Act(MemberID) (TurnOutcome, error) {
+func (passDriver) Act(MonsterView) (TurnIntent, error) {
 	return Pass{}, nil
+}
+
+// errPassStrikerNeverAttacks is what passStriker returns if it is ever
+// actually called — see its own doc.
+var errPassStrikerNeverAttacks = errors.New("passStriker: passDriver never returns an Attack intent")
+
+// passStriker is the internal-package twin of encounter_test's own — see its
+// doc.
+type passStriker struct{}
+
+func (passStriker) Strike(context.Context, *Encounter, MemberID, MemberID, core.Ref) error {
+	return errPassStrikerNeverAttacks
 }

--- a/rulebooks/dnd5e/encounter/testturndriver_test.go
+++ b/rulebooks/dnd5e/encounter/testturndriver_test.go
@@ -3,7 +3,13 @@
 
 package encounter_test
 
-import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+import (
+	"context"
+	"errors"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
 
 // passDriver is the TurnDriver capability these tests install by default.
 //
@@ -13,8 +19,28 @@ import "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 // it is the whole point of the capability being required: a scene states what
 // it believes an unplayed member does out loud (capabilities are supplied,
 // never defaulted).
+//
+// A thin wrapper over the production [encounter.PassDriver] (rpg-toolkit#1167)
+// rather than encounter.PassDriver itself, so a test file that wants ITS OWN
+// TurnDriver behaviour can still name this type in a mutate-the-fixture table
+// without reaching for the production one by accident.
 type passDriver struct{}
 
-func (passDriver) Act(encounter.MemberID) (encounter.TurnOutcome, error) {
+func (passDriver) Act(encounter.MonsterView) (encounter.TurnIntent, error) {
 	return encounter.Pass{}, nil
+}
+
+// errPassStrikerNeverAttacks is what passStriker returns if it is ever
+// actually called — see its own doc.
+var errPassStrikerNeverAttacks = errors.New("passStriker: passDriver never returns an Attack intent")
+
+// passStriker is the Striker capability these tests install alongside
+// passDriver. Every fixture using passDriver never returns an Attack
+// intent, so this is never actually called — it exists only because the
+// capability is required (rpg-toolkit#1033, rpg-project#254), and says so
+// honestly rather than fabricating a hit no test asked for.
+type passStriker struct{}
+
+func (passStriker) Strike(context.Context, *encounter.Encounter, encounter.MemberID, encounter.MemberID, core.Ref) error {
+	return errPassStrikerNeverAttacks
 }

--- a/rulebooks/dnd5e/encounter/tombdoor_test.go
+++ b/rulebooks/dnd5e/encounter/tombdoor_test.go
@@ -67,7 +67,7 @@ var (
 
 func (s *TombDoorSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{
@@ -238,7 +238,7 @@ func (s *TombDoorSuite) TestTheDoorSurvivesASave() {
 func (s *TombDoorSuite) reload(data encounter.EncounterData) *encounter.Encounter {
 	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:  data,
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/encounter/tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/tombwatch_test.go
@@ -56,7 +56,7 @@ func TestTombWatch(t *testing.T) {
 	// cannot get through.
 	goblinPatrol := &patrolDecider{positions: []spatial.Position{{X: 7, Y: 10}, {X: 6, Y: 10}}}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{
@@ -133,7 +133,7 @@ func TestTombWatch(t *testing.T) {
 	// does not — beliefs are state and traveled in the aggregate).
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &patrolDecider{positions: []spatial.Position{{X: 7, Y: 10}, {X: 6, Y: 10}}},
 		}})
 	require.NoError(t, err, "beat 4: the suspended scene crosses a process boundary")
@@ -268,7 +268,7 @@ func TestTombWatch(t *testing.T) {
 		})
 	}
 	sequel, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms: []encounter.RoomInput{{

--- a/rulebooks/dnd5e/encounter/turndriver.go
+++ b/rulebooks/dnd5e/encounter/turndriver.go
@@ -242,6 +242,22 @@ func (PassDriver) Act(MonsterView) (TurnIntent, error) {
 	return Pass{}, nil
 }
 
+// RefusingStriker is a Striker for construction-only worlds: an encounter
+// built to hold members and geometry but never actually driven through a
+// turn — rpg-api's placement probes, a template's own acceptance test, any
+// scene a host constructs only to inspect. Calling Strike on one is a HOST
+// BUG, not a legal outcome a caller should ever see recover: a driven turn
+// that reaches this means some TurnDriver decided to attack in a world with
+// nothing that can carry it out, and the honest answer is a named error
+// rather than a silently fabricated hit — the same reasoning [PassDriver]'s
+// own doc gives for existing at all (rpg-toolkit#1167), one capability over.
+type RefusingStriker struct{}
+
+// Strike always fails with ErrRefusingStriker.
+func (RefusingStriker) Strike(context.Context, *Encounter, MemberID, MemberID, core.Ref) error {
+	return ErrRefusingStriker
+}
+
 // Striker resolves and records one member's attack against another.
 //
 // SUPPLIED, NEVER DEFAULTED (rpg-toolkit#1033), for the same reason every

--- a/rulebooks/dnd5e/encounter/turndriver.go
+++ b/rulebooks/dnd5e/encounter/turndriver.go
@@ -3,6 +3,13 @@
 
 package encounter
 
+import (
+	"context"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
 // TurnDriver decides what a member with no player does when a fight's clock
 // lands on their turn.
 //
@@ -14,10 +21,11 @@ package encounter
 // dissolves." That boundary is load-bearing rather than an oversight —
 // Decider's Intent vocabulary (IntentMoveTo, IntentHold) answers WHERE TO BE,
 // and a turn asks a different question, ATTACKING, TARGETING, AND THE ACTION
-// ECONOMY, which nothing in this module can even express yet. Reusing
-// Decider for a turn would blur the exact clock-kind boundary ClockKind
-// exists to keep sharp: the world thinks on the tick, the fight thinks in
-// turns, and now each has its own driver.
+// ECONOMY (rpg-project#254 gives it one: [MonsterView], [TurnIntent]).
+// Reusing Decider for a turn would blur the exact clock-kind boundary
+// ClockKind exists to keep sharp: the world thinks on the tick, the fight
+// thinks in turns, and now each has its own driver, and its own vocabulary —
+// TurnIntent rather than Intent, so the two Go types cannot collide.
 //
 // # Required, never defaulted — and why that differs from Decider
 //
@@ -32,38 +40,230 @@ package encounter
 //
 // # One capability, not one per member
 //
-// Unlike Decider, TurnDriver is asked with a member's ID rather than supplied
-// per member: v1's answer (Pass) is identical for every unplayed member, so
-// there is nothing yet to vary per monster. When a real driver needs to
-// answer differently per monster, that is the driver's own business — it can
-// key off the ID it is handed, the same way any Decider already would — and
-// does not require a second capability shape at this seam.
+// Unlike Decider, TurnDriver is asked with a member's whole [MonsterView]
+// rather than a bare ID: the same driver instance answers for every unplayed
+// member the clock lands on, keying its own decision off View.Self and
+// whatever View tells it, the same way any Decider already keys off the ID
+// it is handed. There is nothing yet that requires a second capability shape
+// at this seam.
 type TurnDriver interface {
-	// Act decides what member does on their turn, or returns an error that
-	// aborts the caller's whole verb — see EndTurn and form, both of which
-	// consult this synchronously and persist nothing until the caller's own
-	// commit, so a driver failure here costs nothing but the retry.
-	Act(member MemberID) (TurnOutcome, error)
+	// Act decides what a member with no player does on its turn, given
+	// everything this composition is willing to tell it about its own
+	// situation (view) — or returns an error that aborts the caller's whole
+	// verb: see EndTurn and form, both of which consult this synchronously
+	// and persist nothing until the caller's own commit, so a driver
+	// failure here costs nothing but the retry.
+	//
+	// A Go error here is a DRIVER MALFUNCTION — compare [ErrBadIntent],
+	// which a syntactically valid but unexecutable TurnIntent earns
+	// instead, and which does NOT abort the caller (see
+	// [Encounter.driveMonsterTurns]).
+	Act(view MonsterView) (TurnIntent, error)
 }
 
-// TurnOutcome is a sealed vocabulary (unexported marker method, the same
-// shape Intent already uses for Decider).
+// MonsterView is what a TurnDriver is told about its own situation on its
+// turn — the anti-wall-hack contract [Decider]'s Snapshot already keeps
+// (C2), extended to a turn's own questions that Snapshot cannot express. A
+// driver receives ONLY this: its own static facts, what it currently holds
+// sight intel on, and the turn's remaining budget — never the full
+// encounter, and never another member's live truth beyond what has actually
+// been seen.
 //
-// ONE CASE TODAY. A driver that could decide to attack or move needs
-// resolution-level machinery (weapons, the action economy) this module does
-// not have and is not allowed to import — so a second TurnOutcome case is
-// real vocabulary growth, arriving with the caller that needs it, the same
-// road Intent travelled from IntentMoveTo to IntentHold. Following this
-// repo's practice for sealed vocabularies at this seam (ADR-0038's rule for
-// Gather | Pose | Request | Done), a second case should probably earn its own
-// ADR rather than being added quietly.
-type TurnOutcome interface {
-	isTurnOutcome()
+// A PROJECTION OF THE MEMBER RECORD PLUS THE TURN'S DYNAMIC PARTS (Kirk,
+// rpg-project#254 review): Self, Position, Actions and Targeting are read
+// straight off this member's own [memberRecord] — the same static facts
+// [Member] itself projects — and Seen, Budget and Round are computed fresh
+// for this call, the same static/dynamic split [Sight]'s own doc draws.
+type MonsterView struct {
+	// Self is who this view is for.
+	Self MemberID
+
+	// Position is where this member stands, DUNGEON-ABSOLUTE — the same
+	// frame every SeenMember.Position and every Move path cell speaks.
+	Position spatial.Position
+
+	// Actions are this member's own static facts about what it can do —
+	// carried forward from [MemberInput.Actions]/[Member.Actions] verbatim.
+	// An [Attack] intent must name one of these.
+	Actions []ActionView
+
+	// Targeting is this member's target-selection strategy, in the
+	// rulebook's own words — carried forward from
+	// [MemberInput.Targeting]/[Member.Targeting]. Opaque here (C1): a
+	// driver that cares what "closest" means already knows, because the
+	// rulebook that authored the string is the one reading it.
+	Targeting string
+
+	// Seen are the OTHER members this monster currently, actively holds
+	// sight intel on — Status == [intel.Current] only. A stale "held"
+	// memory (intel.Held, a ghost: known but not currently sustained) is
+	// not a target this member can act on THIS turn, so it never appears
+	// here; a driver that wants to chase a last-known position needs no
+	// special case for that, because Seen simply will not contain it once
+	// the sighting lapses.
+	Seen []SeenMember
+
+	// Budget is what remains of this member's turn.
+	Budget TurnBudget
+
+	// Round is the fight's own round counter (see play/clock's Turn.Round),
+	// carried through so a driver that wants to vary behaviour by round — a
+	// monster that flees only after round 2, say — has the fact without
+	// this composition growing a second capability to answer it.
+	Round int
 }
 
-// Pass is the only outcome a v1 driver may return: the member's turn ends
-// with no other effect than the clock advancing and a beat being recorded.
+// SeenMember is one other member this monster currently holds active sight
+// intel on, projected for a turn's own questions.
+type SeenMember struct {
+	// ID is the seen member's identifier.
+	ID MemberID
+
+	// Kind is whether they are a player or a monster.
+	Kind MemberKind
+
+	// Standing is false when this composition's last standing consult found
+	// them down (see [Standing]) — a driver should not target a body, and
+	// [Encounter.driveMonsterTurns] refuses an Attack naming one
+	// ([ErrBadIntent]).
+	Standing bool
+
+	// Position is where they were last actively sighted, DUNGEON-ABSOLUTE.
+	Position spatial.Position
+
+	// Distance is the grid distance from this monster's OWN position to
+	// this sighting, in CELLS — the same unit [Encounter.Distance] answers
+	// in, computed once so a driver never needs to ask the encounter for it
+	// directly.
+	Distance float64
+
+	// InReach maps each of THIS MONSTER'S OWN action refs (see
+	// [MonsterView.Actions]) to whether this sighting is within that
+	// action's reach right now — precomputed so a driver never converts
+	// feet to cells itself (see [ActionView.ReachFeet]'s doc for why that
+	// conversion belongs here, once, rather than on every driver).
+	InReach map[core.Ref]bool
+}
+
+// TurnBudget is what remains of a member's turn.
+type TurnBudget struct {
+	// AttacksLeft is how many more attacks this member may declare this
+	// turn — 1 at the start of a v1 turn, 0 once an [Attack] intent has
+	// executed.
+	AttacksLeft int
+
+	// MovementFeet is how much further this member may move this turn, in
+	// FEET (Kirk, rpg-project#254 review — see [ActionView.ReachFeet]'s doc
+	// for the feet/cells split) — [Member.SpeedFeet] at the start of a
+	// turn, decremented by 5 feet per cell as [Move] intents execute.
+	MovementFeet int
+}
+
+// TurnIntent is a sealed vocabulary (unexported marker method) — a
+// TurnDriver's decision for one Act call.
+//
+// A DIFFERENT TYPE FROM Intent, DELIBERATELY (rpg-project#254). [Decider]'s
+// own sealed vocabulary (IntentMoveTo, IntentHold) answers WHERE TO BE in
+// free roam; a turn asks ATTACKING, TARGETING, AND THE ACTION ECONOMY —
+// different questions with different answers — and naming this TurnIntent
+// keeps the two Go types from colliding rather than overloading one
+// vocabulary to mean two things depending which clock a member is on.
+//
+// THREE CASES, following this repo's practice for sealed vocabularies at
+// this seam (ADR-0038's rule for Gather | Pose | Request | Done): Pass,
+// Attack, Move. A fourth case is real vocabulary growth and should probably
+// earn its own ADR rather than being added quietly, the same note the old
+// one-case TurnOutcome carried.
+type TurnIntent interface {
+	isTurnIntent()
+}
+
+// Pass ends this member's turn immediately: the clock advances and a beat
+// is recorded, with no other effect. Returned by a driver with nothing left
+// to do — an empty [MonsterView.Seen], an exhausted [MonsterView.Budget], or
+// simply a decision to do nothing — and the only intent [PassDriver] ever
+// returns.
 type Pass struct{}
 
-// isTurnOutcome marks Pass as a TurnOutcome.
-func (Pass) isTurnOutcome() {}
+// isTurnIntent marks Pass as a TurnIntent.
+func (Pass) isTurnIntent() {}
+
+// Attack declares a strike against Target using Action — one of this
+// member's own [ActionView.Ref] values, from [MonsterView.Actions].
+//
+// Refused with [ErrBadIntent] — the turn simply ends, see
+// [Encounter.driveMonsterTurns] — unless: Target names a member currently in
+// [MonsterView.Seen] AND [SeenMember.Standing]; Action names one of this
+// member's own [MonsterView.Actions]; [SeenMember.InReach] says Target is in
+// reach for Action; and [TurnBudget.AttacksLeft] is greater than zero.
+type Attack struct {
+	// Target is who this member is attacking.
+	Target MemberID
+
+	// Action is which of this member's own actions is doing the attacking.
+	Action core.Ref
+}
+
+// isTurnIntent marks Attack as a TurnIntent.
+func (Attack) isTurnIntent() {}
+
+// Move declares a step-by-step path this member intends to walk this turn,
+// cell by cell, DUNGEON-ABSOLUTE.
+//
+// Each cell executes exactly as [Encounter.Step] would for a player — the
+// same refusals, the same walls, the same doors — via [Encounter.stepTo],
+// and a step the canvas refuses simply stops the walk there, precisely as it
+// would for a player mid-corridor: the turn does not end because of it, and
+// whatever cells DID succeed are kept. What DOES end the turn with
+// [ErrBadIntent] is a Move this member cannot even afford: an empty Path, or
+// one whose length in cells exceeds [TurnBudget.MovementFeet] converted via
+// [CellsFromFeet] — a driver asking for more than its own budget allows is a
+// bad decision, not a wall in the way.
+type Move struct {
+	// Path is the sequence of cells this member intends to step through, in
+	// travel order.
+	Path []spatial.Position
+}
+
+// isTurnIntent marks Move as a TurnIntent.
+func (Move) isTurnIntent() {}
+
+// PassDriver is a TurnDriver that always passes — the same v1 answer every
+// unplayed member's turn used to get automatically before this capability
+// existed, now available as an explicit, reusable supply (rpg-toolkit#1167)
+// rather than every caller hand-rolling one. A hosting seam with nothing
+// smarter to offer yet — or a scene with no monsters at all — can supply
+// this and get exactly the behaviour a fight had before a real driver
+// (rulebooks/dnd5e/behavior's Basic, or a caller's own) existed.
+type PassDriver struct{}
+
+// Act always returns Pass, unconditionally.
+func (PassDriver) Act(MonsterView) (TurnIntent, error) {
+	return Pass{}, nil
+}
+
+// Striker resolves and records one member's attack against another.
+//
+// SUPPLIED, NEVER DEFAULTED (rpg-toolkit#1033), for the same reason every
+// other rulebook-facing capability on this module is: this module's go.mod
+// cannot import the rulebook (C1), so it cannot roll to hit, apply damage,
+// or decide what a "shortsword" is. What it CAN do is hand the capability
+// everything it needs to decide for itself and act — including the live
+// *Encounter, so a successful strike can call [Encounter.Record] itself,
+// the same public verb any other caller uses to put a struck/missed beat in
+// the story (and, through it, the same [Encounter.noticeDown] consult every
+// other route to a beat already runs).
+//
+// REQUIRED AT CONSTRUCTION, exactly as [TurnDriver] is and for the same
+// reason (ADR-0043): a monster's driver can decide to attack the moment a
+// fight forms, so an encounter that cannot resolve one would stall — or
+// worse, silently drop the swing — before its caller does anything.
+type Striker interface {
+	// Strike resolves attacker's attack against target using action — one
+	// of attacker's own [ActionView.Ref] values — and records the outcome
+	// itself via [Encounter.Record]. Errors here are STRIKER MALFUNCTIONS
+	// (a resolution failure, a corrupt sheet) and abort the caller's whole
+	// verb exactly as a [TurnDriver.Act] error does; a miss is not an
+	// error — it is an ordinary [OutcomeMissed] recorded the same as a hit.
+	Strike(ctx context.Context, enc *Encounter, attacker, target MemberID, action core.Ref) error
+}

--- a/rulebooks/dnd5e/encounter/units.go
+++ b/rulebooks/dnd5e/encounter/units.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+// FeetPerCell is the grid's fixed real-world scale: every cell on every grid
+// [tools/spatial] exposes — square (Chebyshev), hex (cube), or gridless — is
+// 5 feet on a side (Kirk, rpg-project#254 review). This has always been true
+// of this codebase's data (a plain melee weapon's reach, a monster's walking
+// speed, a character's darkvision) and used to be re-derived, inconsistently
+// worded, at three separate call sites (conditions' proneReachCells,
+// FightingStyleProtectionCondition, SneakAttackCondition) rather than named
+// once. This constant, and [CellsFromFeet] beside it, are that one place.
+const FeetPerCell = 5
+
+// CellsFromFeet converts a feet-denominated distance to cells, the unit
+// [Encounter.Distance] and every grid Distance call answer in.
+//
+// THE ONE PLACE THIS CONVERSION HAPPENS (Kirk, rpg-project#254 review):
+// "convert feet->cells once, at the point of comparison, in one exported
+// helper" — not at every producer of a feet-denominated fact guessing at a
+// conversion. session's reach gate and this module's own monster-turn
+// movement budget are the two call sites that need it; both compare a
+// feet-denominated authored fact (an action's reach, a member's speed)
+// against a cell-denominated grid Distance, and both call this rather than
+// re-deriving FeetPerCell locally.
+//
+// Rounds down (integer division): 5e's own stat blocks author reach and
+// speed as exact multiples of 5, so this never actually truncates a real
+// value — the floor exists so a caller handed something else (a partial
+// remainder of movement budget, say) gets the conservative answer rather
+// than a cell it cannot fully afford.
+func CellsFromFeet(feet int) int {
+	return feet / FeetPerCell
+}

--- a/rulebooks/dnd5e/encounter/units_test.go
+++ b/rulebooks/dnd5e/encounter/units_test.go
@@ -1,0 +1,39 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/stretchr/testify/suite"
+)
+
+// CellsFromFeetTestSuite pins the ONE feet-to-cells conversion this
+// composition offers (Kirk, rpg-project#254 review: "convert feet->cells
+// once... in one exported helper"), so the reach gate and the monster
+// turn's movement budget both use the same arithmetic rather than each
+// re-deriving it.
+type CellsFromFeetTestSuite struct {
+	suite.Suite
+}
+
+func TestCellsFromFeetSuite(t *testing.T) {
+	suite.Run(t, new(CellsFromFeetTestSuite))
+}
+
+func (s *CellsFromFeetTestSuite) TestExactMultiplesConvertCleanly() {
+	s.Equal(1, encounter.CellsFromFeet(5), "5 feet is one cell — standard melee reach")
+	s.Equal(2, encounter.CellsFromFeet(10), "10 feet is two cells — the Reach property")
+	s.Equal(24, encounter.CellsFromFeet(120), "120 feet is 24 cells — a character's default sight range")
+	s.Equal(12, encounter.CellsFromFeet(60), "60 feet is 12 cells — a common darkvision range")
+}
+
+func (s *CellsFromFeetTestSuite) TestZeroFeetIsZeroCells() {
+	s.Equal(0, encounter.CellsFromFeet(0))
+}
+
+func (s *CellsFromFeetTestSuite) TestFeetPerCellIsFive() {
+	s.Equal(5, encounter.FeetPerCell, "a cell is 5 feet everywhere in this codebase's data")
+}

--- a/rulebooks/dnd5e/encounter/void_test.go
+++ b/rulebooks/dnd5e/encounter/void_test.go
@@ -78,7 +78,7 @@ func gappedField(void encounter.Void) encounter.FieldInput {
 // that nothing forms a fight and sight is the only thing under test.
 func (s *VoidSuite) gapped(void encounter.Void) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: gappedField(void),
 		Members: []encounter.MemberInput{
 			{ID: brenna, Kind: encounter.KindPlayer, Room: voidWest,
@@ -162,7 +162,7 @@ func (s *VoidSuite) TestTransparentVoidIsStillNotFloor() {
 // gap.
 func (s *VoidSuite) TestOpaqueVoidDoesNotBlockSightWithinAChamber() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: gappedField(encounter.VoidIsOpaque()),
 		Members: []encounter.MemberInput{
 			{ID: brenna, Kind: encounter.KindPlayer, Room: voidWest,
@@ -204,7 +204,7 @@ func (s *VoidSuite) TestTheHandedOutCanvasAnswersTheSameWay() {
 // it construction data (rpg-toolkit#1033's law, applied to the map).
 func (s *VoidSuite) TestAFieldMustSayWhatItsVoidIs() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: encounter.FieldInput{
 			Rooms: []encounter.RoomInput{{ID: voidWest, Width: 4, Height: 4}},
 		},
@@ -235,7 +235,7 @@ func (s *VoidSuite) TestTheDeclarationSurvivesASave() {
 
 			back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 				Data:  data,
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			})
 			s.Require().NoError(err)
 
@@ -273,7 +273,7 @@ func (s *VoidSuite) TestAnOldBlobIsRefusedByName() {
 
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:  old,
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Contains(err.Error(), "canvas.void", "the refusal names the field the blob does not carry")
@@ -291,7 +291,7 @@ func (s *VoidSuite) TestAnUnknownVoidIsRefusedByName() {
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:  data,
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 	})
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Contains(err.Error(), "lava", "the refusal quotes the word it does not know")
@@ -317,7 +317,7 @@ func (s *VoidSuite) TestAnUnknownVoidIsRefusedByName() {
 func (s *VoidSuite) TestTheCanvasKeepsItsOwnCopyOfTheChambers() {
 	field := gappedField(encounter.VoidIsOpaque())
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: brenna, Kind: encounter.KindPlayer, Room: voidWest,
@@ -382,7 +382,7 @@ func contiguousField(void encounter.Void) encounter.FieldInput {
 // canvasOf opens a field with nobody in it and hands back its map.
 func (s *VoidSuite) canvasOf(field encounter.FieldInput) spatial.Room {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field:   field,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/encounter/voidcost_internal_test.go
+++ b/rulebooks/dnd5e/encounter/voidcost_internal_test.go
@@ -134,7 +134,7 @@ func benchSightRefreshOn(b *testing.B, field FieldInput, rooms, dim, members int
 	}
 
 	enc, err := NewEncounter(&SetupInput{
-		Sight: benchSight{1 << 20}, Standing: benchStanding{}, Initiative: benchRoller{}, TurnDriver: passDriver{},
+		Sight: benchSight{1 << 20}, Standing: benchStanding{}, Initiative: benchRoller{}, TurnDriver: passDriver{}, Striker: passStriker{},
 		Field:   field,
 		Members: mi,
 		Endings: []EndingInput{{Key: "done", Trigger: TriggerExternal{}}},


### PR DESCRIPTION
## Summary

Closes #1186 — slice 1 of rpg-project#254 (the monster's turn; design rpg-project#252 APPROVED, journey rpg-project#253). The toolkit brief's item 1.

`TurnDriver.Act` changes from `Act(MemberID) (TurnOutcome, error)` to `Act(MonsterView) (TurnIntent, error)`. `TurnIntent` is a new sealed vocabulary — `Pass`, `Attack{Target, Action}`, `Move{Path}` — deliberately named differently from `Decider`'s existing `Intent` (`IntentMoveTo`/`IntentHold`) so the two Go types cannot collide: Decider answers WHERE TO BE in free roam, TurnIntent answers ATTACKING, TARGETING, AND THE ACTION ECONOMY, a different question this module could not express before.

## The pieces

- **`MonsterView`**: what a driver is told about its own turn — static facts (`Self`, `Position`, `Actions`, `Targeting`) read straight off the member record, plus the dynamic parts computed fresh each call: `Seen []SeenMember` (currently, actively sighted members only — `intel.Status == Current`, never a stale "held" ghost), each with `Distance` (cells) and a precomputed `InReach map[core.Ref]bool` keyed by this member's own actions, and `Budget TurnBudget` (`AttacksLeft`, `MovementFeet`). Same anti-wall-hack contract (C2) `Decider`'s `Snapshot` already keeps.

- **`Striker`** (new required capability, `ErrNoStriker`, refused at construction exactly like `TurnDriver`): `Strike(ctx, enc *Encounter, attacker, target, action) error`. This module still cannot import the rulebook (C1) — it hands the capability the live `*Encounter` so a successful strike calls the *existing* `Encounter.Record` itself (the same public verb any other caller already uses for a struck/missed beat, and through it the same `noticeDown` consult). No new beat-emission machinery needed.

- **`driveMonsterTurns` rewrite**: per unplayed member, a bounded inner loop — build view → `Act` → execute → repeat until `Pass` or the budget (one attack + `SpeedFeet` in cells, via the new `CellsFromFeet`) is spent. A driver's own Go error still aborts the whole call (a malfunction). A syntactically valid but unexecutable intent — an `Attack` on an out-of-reach/unseen/down target, a `Move` exceeding its own budget or asking for nothing — is `ErrBadIntent` instead: the member's turn simply ends, exactly like `Pass`, and the caller's own verb (`EndTurn`, `form`) still succeeds. A `Move` that hits a wall partway through stops there without ending the turn — the same refusal a player's own walk meets — and the driver is asked again from wherever it actually stopped.

- **The unified member record** (Kirk, rpg-project#254 review — supersedes the earlier "monster-only" ruling): `MemberInput`/`Member`/`memberRecord`/`JoinInput` all carry `SpeedFeet`, `SightFeet`, `Actions []ActionView{Ref, Name, ReachFeet, Kind}`, `Targeting` — filled for EVERY kind (a character's equipped-weapon swing is `Actions` too; `Targeting` is the only field that stays empty for a player). Static join-time facts, the same species as `Name` (#1137) and `AttackIdentity.DamageType` — encounter-owned primitives (`core.Ref`, `string`, `int`), never imported rulebook types. Round-tripped through `ToData`/`LoadEncounter` via a new `ActionViewData` persisted twin.

- **Units are FEET throughout** (Kirk, rpg-project#254 review — corrects an earlier misreading on the sibling reach PRs, #1183/#1185): reach, speed, sight are all feet, matching `monster.ActionData.Reach`/`monster.SpeedData` exactly. `units.go`'s `FeetPerCell`/`CellsFromFeet` is the ONE place that converts to the cell-denominated grid `Distance` — used here by `buildMonsterView`'s `InReach` computation and the movement budget, and exported for `session`'s reach gate to share rather than re-deriving.

- **`PassDriver`** (closes #1167): the always-pass `TurnDriver`, now an exported production supply instead of every caller hand-rolling a test-only `passDriver`. Alongside it, **`RefusingStriker`** (team-lead review, added before Copilot's round): a `Striker` for construction-only worlds — rpg-api's placement probes, a template's own acceptance test — that always fails loudly (`ErrRefusingStriker`) rather than silently fabricating a hit; a driven turn reaching it is a host bug, the same reasoning `PassDriver` itself rests on.

## For rpg-api / session (the Go shapes you need)

- `encounter.SetupInput.Striker encounter.Striker` and `encounter.LoadEncounterInput.Striker encounter.Striker` — new required fields, same pattern as `TurnDriver`.
- `encounter.SetupInput.TurnDriver` / `LoadEncounterInput.TurnDriver` are still `encounter.TurnDriver`, but the interface's `Act` signature changed — anything implementing it needs updating to `Act(encounter.MonsterView) (encounter.TurnIntent, error)`.
- `encounter.PassDriver{}` (zero-alloc, exported) is a ready-made "no smarter driver yet" supply — import path `github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter`. The Monster AI owner's `rulebooks/dnd5e/behavior.Basic` (not yet built — next slice) will be the real one.
- `encounter.RefusingStriker{}` — pair it with `PassDriver` (or any driver) for a `SetupInput`/`LoadEncounterInput` that will never actually drive a turn: a placement probe, a construction-only acceptance test. Fails loudly with `encounter.ErrRefusingStriker` if a turn is ever driven through it — a signal something is wired wrong, never a hit to render.
- `encounter.Striker` interface: `Strike(ctx context.Context, enc *encounter.Encounter, attacker, target encounter.MemberID, action core.Ref) error`. session's implementation (next slice) binds this to the existing strike machinery against the live `scope.enc`.
- Member facts: `encounter.MemberInput`/`JoinInput` gain `SpeedFeet int`, `SightFeet int`, `Actions []encounter.ActionView`, `Targeting string` — session fills these at Join/Spawn from the sheet/`monster.Data` (next slice).

## Units correction, transparently

This is a companion correction to #1183 (reverted) and #1185 (already corrected): reach and speed are feet, not cells/hexes, everywhere in this codebase's data. `units.go` is the first PRODUCTION consumer of that correction — the conversion those two PRs promised ("the ONE place that needs cells... converts once, at the reach gate, in one exported helper") lands here.

## Verification

- `go build ./...`, `go vet ./...` — clean, whole module including `cmd/freeroam-workbench` and `dungeonspec`
- `go test -race -count=1 ./...` — all green. All 39 pre-existing test files updated for the new `TurnDriver`/`Striker` shapes (mechanical `passDriver`/`passStriker` fixture insertion); every existing test passes UNCHANGED in behaviour — the brief's own bar ("Pass-driver tests keep passing").
- New `monsterturn_test.go` (14 tests) + one internal sealed-vocabulary test: `MonsterView` construction (static facts, `Seen`, `InReach`, `Budget`), `Attack` execution and its `ErrBadIntent` paths (out of reach, unseen target), `Move` execution (full path, partial-into-void, over-budget, empty), budget consumption verified across a multi-`Act` turn, driver/striker malfunction propagation (`errors.Is`), `Striker` construction refusal (Setup and Load), the member-record round-trip through `ToData`/`LoadEncounter`, `PassDriver`, and `ErrBadTurnOutcome`'s own white-box path.
- `golangci-lint run ./...` — 0 issues
- `gorelease` — reports the expected breaking changes only (`TurnDriver.Act`'s new signature, `TurnOutcome` removed, four structs losing comparability from their new slice fields) — all intentional, matching the design brief; no backcompat baggage per policy (pre-1.0, active development). Suggests `v0.31.0`.
- `./scripts/check-decisions.sh` — all 45 ADRs summarised (no new ADR needed — no genuinely open seam fork on this slice)

## What's next

Slice 2: `rulebooks/dnd5e/behavior`'s `Basic` driver (Monster AI owner's starting file). Slice 3: `session` wires `Striker` to the live strike machinery, adapts its own `TurnDriver`, and replaces the flat `sightRangeCells` constant with per-member data. Slice 4: the session-level gate tests (tomb fixture).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu
