### PR TITLE
encounter: MonsterView.PathTo — path helper for the behavior package

### DIFF
--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -545,13 +545,25 @@ func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round i
 			inReach[a.Ref] = dist <= float64(CellsFromFeet(a.ReachFeet))
 		}
 
+		// Path stops ADJACENT rather than walking onto the sighting's own
+		// occupied cell (Kirk, rpg-project#254 review) — the full route
+		// pathTo computes ends AT pos, so dropping its last element is the
+		// nearest cell that route reaches this sighting from. One BFS per
+		// sighting, every Act call — see the field's own doc for why that
+		// cost is accepted rather than deferred behind a lazy capability.
+		var path []spatial.Position
+		if full, ok := e.pathTo(ownCell, pos); ok && len(full) > 0 {
+			path = full[:len(full)-1]
+		}
+
 		seen = append(seen, SeenMember{
-			ID:       subjectID,
-			Kind:     other.Kind,
-			Standing: !down[subjectID],
-			Position: pos,
-			Distance: dist,
-			InReach:  inReach,
+			ID:            subjectID,
+			Kind:          other.Kind,
+			Standing:      !down[subjectID],
+			Position:      pos,
+			DistanceCells: dist,
+			InReach:       inReach,
+			Path:          path,
 		})
 	}
 	// C8: a driver asked twice against unchanged data must see the same
@@ -566,9 +578,6 @@ func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round i
 		Seen:      seen,
 		Budget:    budget,
 		Round:     round,
-		PathTo: func(to spatial.Position) ([]spatial.Position, bool) {
-			return e.pathTo(ownCell, to)
-		},
 	}, nil
 }
 

--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/play/clock"
 	"github.com/KirkDiggler/rpg-toolkit/play/intel"
 	"github.com/KirkDiggler/rpg-toolkit/play/record"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 // ClockKind names which kind of clock a member is on.
@@ -565,7 +566,89 @@ func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round i
 		Seen:      seen,
 		Budget:    budget,
 		Round:     round,
+		PathTo: func(to spatial.Position) ([]spatial.Position, bool) {
+			return e.pathTo(ownCell, to)
+		},
 	}, nil
+}
+
+// pathTo computes the shortest path from `from` to `to` over this
+// composition's own floor and walls — a plain breadth-first search, which
+// is exact (not merely a heuristic) here because every edge this module's
+// grids offer costs exactly one cell (Chebyshev on a square grid, cube
+// distance on a hex one); there is no weighted-edge case for A* to earn its
+// keep over. Returns the path EXCLUDING `from` and INCLUDING `to`, or
+// ok=false when `to` is not floor or no floor-connected route reaches it.
+//
+// DOES NOT CONSULT OCCUPANCY, deliberately: this answers "how would the
+// geometry let me get there", the same question a player planning a route
+// asks before checking whether someone is standing in the doorway. A cell
+// another member currently occupies still refuses at actual step time
+// (stepMember's own CanPlaceEntity gate), and driveMonsterTurns already
+// treats a mid-move refusal as "stop the walk, keep the turn running" —
+// exactly the shape a transient occupant should have, not a permanently
+// unreachable cell a stale path would have to be recomputed around.
+//
+// NEIGHBOURS ARE VISITED IN A FIXED ORDER (C8): map iteration has none, and
+// a driver asked twice against unchanged geometry must get the same answer
+// both times, not merely an equally-short one.
+func (e *Encounter) pathTo(from, to spatial.Position) ([]spatial.Position, bool) {
+	if _, owned := e.RegionAt(to); !owned {
+		return nil, false
+	}
+	if from == to {
+		return nil, true
+	}
+
+	grid := e.canvas.GetGrid()
+	visited := map[spatial.Position]bool{from: true}
+	prev := make(map[spatial.Position]spatial.Position)
+	queue := []spatial.Position{from}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		neighbors := grid.GetNeighbors(cur)
+		sort.Slice(neighbors, func(i, j int) bool {
+			if neighbors[i].X != neighbors[j].X {
+				return neighbors[i].X < neighbors[j].X
+			}
+			return neighbors[i].Y < neighbors[j].Y
+		})
+
+		for _, n := range neighbors {
+			if visited[n] {
+				continue
+			}
+			if _, owned := e.RegionAt(n); !owned {
+				continue
+			}
+			if e.canvas.IsBoundaryMovementBlocked(cur, n) {
+				continue
+			}
+			visited[n] = true
+			prev[n] = cur
+			if n == to {
+				queue = nil
+				break
+			}
+			queue = append(queue, n)
+		}
+	}
+
+	if !visited[to] {
+		return nil, false
+	}
+
+	var path []spatial.Position
+	for at := to; at != from; at = prev[at] {
+		path = append(path, at)
+	}
+	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {
+		path[i], path[j] = path[j], path[i]
+	}
+	return path, true
 }
 
 // driveIfStillRunning calls driveMonsterTurns on bubble if it still holds any

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -193,7 +193,7 @@ func (s *MonsterTurnTestSuite) TestMonsterViewCarriesStaticFactsAndSeen() {
 	s.Equal(encounter.KindPlayer, seen.Kind)
 	s.True(seen.Standing)
 	s.Equal(spatial.Position{X: 2, Y: 2}, seen.Position)
-	s.InDelta(1.0, seen.Distance, 0.001, "adjacent cells are 1 cell apart")
+	s.InDelta(1.0, seen.DistanceCells, 0.001, "adjacent cells are 1 cell apart")
 	s.True(seen.InReach[testMeleeAction], "1 cell is within a 5-foot (1-cell) reach")
 }
 
@@ -543,15 +543,29 @@ func (s *MonsterTurnTestSuite) TestJoinRejectsANegativeMemberFactBeforeMutating(
 	}
 }
 
-// TestPathToWalksAroundAWall pins the new [MonsterView.PathTo] capability
-// (rpg-project#254 follow-up to #1187): behavior.Basic needs "one step along
-// the shortest path toward the target" without computing hex math itself or
-// touching the live *Encounter (the anti-wall-hack contract C2 already
-// enforces for a driver) — so the composition hands it a narrow, view-scoped
-// closure instead. This fixture places a wall between the monster and its
-// target so a straight-line step would fail, and asserts the returned path
-// actually goes AROUND it.
-func (s *MonsterTurnTestSuite) TestPathToWalksAroundAWall() {
+// seenFor finds subject's own SeenMember entry in view.Seen, failing the
+// test if absent.
+func (s *MonsterTurnTestSuite) seenFor(view encounter.MonsterView, subject encounter.MemberID) encounter.SeenMember {
+	s.T().Helper()
+	for _, sm := range view.Seen {
+		if sm.ID == subject {
+			return sm
+		}
+	}
+	s.Require().Fail("not in Seen", "%q", subject)
+	return encounter.SeenMember{}
+}
+
+// TestSeenMemberPathWalksAroundAWall pins [SeenMember.Path] (rpg-project#254
+// review: MonsterView must stay DATA — loggable, replayable,
+// fixture-buildable, per rpg-project#235's Debug Feed journey and the
+// monster-ai brainstorm's "the decision layer never reaches live state" —
+// so this is precomputed per sighting rather than a callback behavior.Basic
+// invokes). This fixture places a wall between the monster and its target
+// so a straight-line step would fail, and asserts the returned path
+// actually goes AROUND it, stopping adjacent rather than on the target's
+// own occupied cell.
+func (s *MonsterTurnTestSuite) TestSeenMemberPathWalksAroundAWall() {
 	// A 5x3 room. A wall spans the room's middle column (x=2) except at
 	// y=0, leaving exactly one gap to route through.
 	//
@@ -587,41 +601,63 @@ func (s *MonsterTurnTestSuite) TestPathToWalksAroundAWall() {
 	s.Require().NoError(err)
 
 	s.Require().Len(driver.calls, 1)
-	view := driver.calls[0]
-	s.Require().NotNil(view.PathTo, "a driver gets a path helper, not raw hex math to do itself")
+	aliceSeen := s.seenFor(driver.calls[0], alice)
+	s.Require().NotEmpty(aliceSeen.Path)
+	s.NotEqual(spatial.Position{X: 4, Y: 2}, aliceSeen.Path[len(aliceSeen.Path)-1],
+		"the path stops ADJACENT to alice, not on her own occupied cell")
 
-	path, ok := view.PathTo(spatial.Position{X: 4, Y: 2})
-	s.Require().True(ok)
-	s.Require().NotEmpty(path)
-	s.Equal(spatial.Position{X: 4, Y: 2}, path[len(path)-1], "the path ends at the requested cell")
-
-	// The path must cross the wall column through its one gap (Copilot, PR
-	// #1189 review: a cell with X==2 is not itself illegal to visit — (2,1)
-	// and (2,2) sit on the near side of the wall and are legal to stand on,
-	// just not to cross FROM at that row — so asserting every X==2 cell has
-	// Y==0 is stricter than the actual rule and would fail a valid shortest
-	// path that happens to touch the near side). What the wall's existence
-	// actually requires is that SOME step in the path uses the gap itself;
-	// assert that positively instead.
+	// The path must cross the wall column through its one gap (a cell with
+	// X==2 is not itself illegal to visit — (2,1) and (2,2) sit on the near
+	// side of the wall and are legal to stand on, just not to cross FROM at
+	// that row — so what the wall's existence actually requires is that
+	// SOME step in the path uses the gap itself).
 	usedTheGap := false
-	for _, p := range path {
+	for _, p := range aliceSeen.Path {
 		if p == (spatial.Position{X: 2, Y: 0}) || p == (spatial.Position{X: 3, Y: 0}) {
 			usedTheGap = true
 		}
 	}
-	s.True(usedTheGap, "the path must cross the wall column through its one gap at y=0: %+v", path)
+	s.True(usedTheGap, "the path must cross the wall column through its one gap at y=0: %+v", aliceSeen.Path)
 }
 
-// TestPathToReportsNoPathWhenTheTargetIsUnreachable pins the ok=false case:
-// a target cell no authored floor holds.
-func (s *MonsterTurnTestSuite) TestPathToReportsNoPathWhenTheTargetIsUnreachable() {
+// TestSeenMemberPathIsEmptyWhenSightedButUnreachable pins the case Sight
+// and walkability disagree on: two floor regions separated by a void gap
+// wide enough that no walkable route bridges them, with the void itself
+// transparent to sight — a sighting nothing in [MonsterView.Seen]'s own
+// InReach/Standing fields would otherwise mark as unusual, and exactly the
+// case Path must be able to say "cannot get there" about without also
+// claiming the sighting itself is bogus.
+func (s *MonsterTurnTestSuite) TestSeenMemberPathIsEmptyWhenSightedButUnreachable() {
 	driver := &scriptedDriver{}
-	enc := s.adjacentSkeletonEncounter(driver, &scriptedStriker{kind: encounter.OutcomeMissed})
-
-	_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed},
+		Field: encounter.FieldInput{
+			// Sight crosses void here (VoidIsTransparent), but a 4-cell gap
+			// of void between the two rooms is still not floor for either
+			// — nothing walkable bridges them.
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsTransparent()},
+			Rooms: []encounter.RoomInput{
+				{ID: room1, Width: 2, Height: 2},
+				{ID: room2, Width: 2, Height: 2, Origin: spatial.Position{X: 6, Y: 0}},
+			},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room2, Position: spatial.Position{X: 0, Y: 0}},
+			{
+				ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 0, Y: 0},
+				SpeedFeet: 30, Targeting: "closest",
+				Actions: []encounter.ActionView{{Ref: testMeleeAction, Name: "Claw", ReachFeet: 5, Kind: "melee"}},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
 	s.Require().NoError(err)
 
-	view := driver.calls[0]
-	_, ok := view.PathTo(spatial.Position{X: 999, Y: 999})
-	s.False(ok)
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	s.Require().Len(driver.calls, 1)
+	aliceSeen := s.seenFor(driver.calls[0], alice)
+	s.Empty(aliceSeen.Path, "seen across the gap, but nothing walkable reaches her")
 }

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -542,3 +542,79 @@ func (s *MonsterTurnTestSuite) TestJoinRejectsANegativeMemberFactBeforeMutating(
 		s.NotEqual(core.EntityID("wolf"), m.ID, "the rejected join left no half-placed entity behind")
 	}
 }
+
+// TestPathToWalksAroundAWall pins the new [MonsterView.PathTo] capability
+// (rpg-project#254 follow-up to #1187): behavior.Basic needs "one step along
+// the shortest path toward the target" without computing hex math itself or
+// touching the live *Encounter (the anti-wall-hack contract C2 already
+// enforces for a driver) — so the composition hands it a narrow, view-scoped
+// closure instead. This fixture places a wall between the monster and its
+// target so a straight-line step would fail, and asserts the returned path
+// actually goes AROUND it.
+func (s *MonsterTurnTestSuite) TestPathToWalksAroundAWall() {
+	// A 5x3 room. A wall spans the room's middle column (x=2) except at
+	// y=0, leaving exactly one gap to route through.
+	//
+	//   x: 0 1 2 3 4
+	// y=0: .  .  .  .  .   <- gap
+	// y=1: .  .  #  .  .
+	// y=2: .  .  #  .  .
+	wall := []spatial.Boundary{
+		{From: spatial.Position{X: 2, Y: 1}, To: spatial.Position{X: 3, Y: 1}, BlocksMovement: true},
+		{From: spatial.Position{X: 2, Y: 2}, To: spatial.Position{X: 3, Y: 2}, BlocksMovement: true},
+	}
+	driver := &scriptedDriver{}
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: room1, Width: 5, Height: 3, Boundaries: wall}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 4, Y: 2}},
+			{
+				ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 0, Y: 2},
+				SpeedFeet: 30, Targeting: "closest",
+				Actions: []encounter.ActionView{{Ref: testMeleeAction, Name: "Claw", ReachFeet: 5, Kind: "melee"}},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	s.Require().Len(driver.calls, 1)
+	view := driver.calls[0]
+	s.Require().NotNil(view.PathTo, "a driver gets a path helper, not raw hex math to do itself")
+
+	path, ok := view.PathTo(spatial.Position{X: 4, Y: 2})
+	s.Require().True(ok)
+	s.Require().NotEmpty(path)
+	s.Equal(spatial.Position{X: 4, Y: 2}, path[len(path)-1], "the path ends at the requested cell")
+
+	// The path must route through the one gap at y=0 — asserting it never
+	// crosses x=2 at y=1 or y=2 is the same as asserting it went around,
+	// not through, the wall.
+	for _, p := range path {
+		if p.X == 2 {
+			s.Equal(0.0, p.Y, "the only legal crossing of the wall column is the gap at y=0: %+v", path)
+		}
+	}
+}
+
+// TestPathToReportsNoPathWhenTheTargetIsUnreachable pins the ok=false case:
+// a target cell no authored floor holds.
+func (s *MonsterTurnTestSuite) TestPathToReportsNoPathWhenTheTargetIsUnreachable() {
+	driver := &scriptedDriver{}
+	enc := s.adjacentSkeletonEncounter(driver, &scriptedStriker{kind: encounter.OutcomeMissed})
+
+	_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	view := driver.calls[0]
+	_, ok := view.PathTo(spatial.Position{X: 999, Y: 999})
+	s.False(ok)
+}

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -595,14 +595,21 @@ func (s *MonsterTurnTestSuite) TestPathToWalksAroundAWall() {
 	s.Require().NotEmpty(path)
 	s.Equal(spatial.Position{X: 4, Y: 2}, path[len(path)-1], "the path ends at the requested cell")
 
-	// The path must route through the one gap at y=0 — asserting it never
-	// crosses x=2 at y=1 or y=2 is the same as asserting it went around,
-	// not through, the wall.
+	// The path must cross the wall column through its one gap (Copilot, PR
+	// #1189 review: a cell with X==2 is not itself illegal to visit — (2,1)
+	// and (2,2) sit on the near side of the wall and are legal to stand on,
+	// just not to cross FROM at that row — so asserting every X==2 cell has
+	// Y==0 is stricter than the actual rule and would fail a valid shortest
+	// path that happens to touch the near side). What the wall's existence
+	// actually requires is that SOME step in the path uses the gap itself;
+	// assert that positively instead.
+	usedTheGap := false
 	for _, p := range path {
-		if p.X == 2 {
-			s.Equal(0.0, p.Y, "the only legal crossing of the wall column is the gap at y=0: %+v", path)
+		if p == (spatial.Position{X: 2, Y: 0}) || p == (spatial.Position{X: 3, Y: 0}) {
+			usedTheGap = true
 		}
 	}
+	s.True(usedTheGap, "the path must cross the wall column through its one gap at y=0: %+v", path)
 }
 
 // TestPathToReportsNoPathWhenTheTargetIsUnreachable pins the ok=false case:

--- a/rulebooks/dnd5e/encounter/turndriver.go
+++ b/rulebooks/dnd5e/encounter/turndriver.go
@@ -110,6 +110,13 @@ type MonsterView struct {
 	// the first step to take, last element the requested cell itself. ok is
 	// false when no path exists (an unreachable target, an unowned cell).
 	//
+	// ok TRUE WITH AN EMPTY path IS A LEGAL ANSWER (Copilot, PR #1189
+	// review): requesting a path to the cell this member is already
+	// standing on has nothing to walk, so path is nil rather than
+	// containing that one cell redundantly. A caller must check len(path)
+	// before indexing it, not rely on ok alone — [behavior.Basic]'s own
+	// call does exactly this ("ok && len(path) > 0").
+	//
 	// A CLOSURE, NOT A LIVE *Encounter (rpg-project#254) — the same
 	// anti-wall-hack reason [Decider]'s own Snapshot carries no live
 	// reference either: a driver may ask this one narrow question ("how do

--- a/rulebooks/dnd5e/encounter/turndriver.go
+++ b/rulebooks/dnd5e/encounter/turndriver.go
@@ -103,35 +103,6 @@ type MonsterView struct {
 	// the sighting lapses.
 	Seen []SeenMember
 
-	// PathTo is one step "toward there" made whole: the complete shortest
-	// path from this member's own Position to the requested cell, computed
-	// against this composition's own walls, doors and floor — the same
-	// geometry [Encounter.Step] enforces — DUNGEON-ABSOLUTE, first element
-	// the first step to take, last element the requested cell itself. ok is
-	// false when no path exists (an unreachable target, an unowned cell).
-	//
-	// ok TRUE WITH AN EMPTY path IS A LEGAL ANSWER (Copilot, PR #1189
-	// review): requesting a path to the cell this member is already
-	// standing on has nothing to walk, so path is nil rather than
-	// containing that one cell redundantly. A caller must check len(path)
-	// before indexing it, not rely on ok alone — [behavior.Basic]'s own
-	// call does exactly this ("ok && len(path) > 0").
-	//
-	// A CLOSURE, NOT A LIVE *Encounter (rpg-project#254) — the same
-	// anti-wall-hack reason [Decider]'s own Snapshot carries no live
-	// reference either: a driver may ask this one narrow question ("how do
-	// I get from here to there") and nothing else, never touch the map or
-	// another member's raw state directly. Bound once, at this view's own
-	// build time, to this member's own Position — a driver wanting an
-	// updated path after moving gets one the same way it gets an updated
-	// Position: by being asked again next Act call.
-	//
-	// "expose a path helper from encounter, don't compute hex math in
-	// behavior" (the brief) is what this exists to satisfy: rulebooks/dnd5e/
-	// behavior's Basic driver calls this rather than reimplementing grid
-	// traversal.
-	PathTo func(to spatial.Position) (path []spatial.Position, ok bool)
-
 	// Budget is what remains of this member's turn.
 	Budget TurnBudget
 
@@ -160,11 +131,11 @@ type SeenMember struct {
 	// Position is where they were last actively sighted, DUNGEON-ABSOLUTE.
 	Position spatial.Position
 
-	// Distance is the grid distance from this monster's OWN position to
-	// this sighting, in CELLS — the same unit [Encounter.Distance] answers
-	// in, computed once so a driver never needs to ask the encounter for it
-	// directly.
-	Distance float64
+	// DistanceCells is the grid distance from this monster's OWN position
+	// to this sighting, in CELLS — the same unit [Encounter.Distance]
+	// answers in, computed once so a driver never needs to ask the
+	// encounter for it directly.
+	DistanceCells float64
 
 	// InReach maps each of THIS MONSTER'S OWN action refs (see
 	// [MonsterView.Actions]) to whether this sighting is within that
@@ -172,6 +143,29 @@ type SeenMember struct {
 	// feet to cells itself (see [ActionView.ReachFeet]'s doc for why that
 	// conversion belongs here, once, rather than on every driver).
 	InReach map[core.Ref]bool
+
+	// Path is the shortest route from this monster's OWN position toward
+	// this sighting, computed against this composition's own walls, doors
+	// and floor — the same geometry [Encounter.Step] enforces —
+	// DUNGEON-ABSOLUTE, first element the first step to take. STOPS
+	// ADJACENT rather than walking onto the sighting's own occupied cell:
+	// the last element is the nearest cell the shortest route reaches this
+	// sighting from, one cell short of Position itself. Empty when this
+	// sighting is unreachable OR already adjacent — a driver checking
+	// InReach before consulting Path (as [behavior.Basic] does) never
+	// needs to tell the two apart, since "already adjacent" already means
+	// "in reach" for any action with at least a 5-foot (one-cell) reach.
+	//
+	// DATA, NOT A LIVE CAPABILITY (Kirk, rpg-project#254 review — supersedes
+	// an earlier closure-based design this PR shipped and walked back):
+	// MonsterView must stay loggable, replayable and fixture-buildable
+	// (rpg-project#235's Debug Feed journey; the monster-ai brainstorm's
+	// "perception is data, the decision layer never reaches live state") —
+	// a func field breaks all three. Computed once per Seen member, per
+	// Act call — ONE BFS PER SIGHTING, not one for the chosen target alone;
+	// noted here as the acknowledged cost of keeping this a plain value
+	// rather than a lazy callback.
+	Path []spatial.Position
 }
 
 // TurnBudget is what remains of a member's turn.

--- a/rulebooks/dnd5e/encounter/turndriver.go
+++ b/rulebooks/dnd5e/encounter/turndriver.go
@@ -103,6 +103,28 @@ type MonsterView struct {
 	// the sighting lapses.
 	Seen []SeenMember
 
+	// PathTo is one step "toward there" made whole: the complete shortest
+	// path from this member's own Position to the requested cell, computed
+	// against this composition's own walls, doors and floor — the same
+	// geometry [Encounter.Step] enforces — DUNGEON-ABSOLUTE, first element
+	// the first step to take, last element the requested cell itself. ok is
+	// false when no path exists (an unreachable target, an unowned cell).
+	//
+	// A CLOSURE, NOT A LIVE *Encounter (rpg-project#254) — the same
+	// anti-wall-hack reason [Decider]'s own Snapshot carries no live
+	// reference either: a driver may ask this one narrow question ("how do
+	// I get from here to there") and nothing else, never touch the map or
+	// another member's raw state directly. Bound once, at this view's own
+	// build time, to this member's own Position — a driver wanting an
+	// updated path after moving gets one the same way it gets an updated
+	// Position: by being asked again next Act call.
+	//
+	// "expose a path helper from encounter, don't compute hex math in
+	// behavior" (the brief) is what this exists to satisfy: rulebooks/dnd5e/
+	// behavior's Basic driver calls this rather than reimplementing grid
+	// traversal.
+	PathTo func(to spatial.Position) (path []spatial.Position, ok bool)
+
 	// Budget is what remains of this member's turn.
 	Budget TurnBudget
 


### PR DESCRIPTION
## Summary

Closes #1188 — small follow-up to #1187 (rpg-project#254), discovered while starting `rulebooks/dnd5e/behavior`'s `Basic` driver.

The brief's exact words: "else movement left → Move one step along the composition's shortest path toward the target (expose a path helper from encounter, don't compute hex math in behavior)." `MonsterView` shipped in #1187 without one, and a `TurnDriver` has no live `*Encounter` to compute a path against — the same anti-wall-hack contract (C2) that already keeps `Decider`'s own `Snapshot` data-only, extended to this new question.

## Revised shape (Kirk's review, superseding this PR's first commits)

The first version of this PR exposed `MonsterView.PathTo func(to spatial.Position) ([]spatial.Position, bool)` — a closure. Kirk's review: **MonsterView must stay DATA** — loggable, replayable, fixture-buildable (rpg-project#235's Debug Feed journey; the monster-ai brainstorm's own "perception is data, the decision layer never reaches live state") — and a func field breaks all three. Replaced with precomputed data on each `SeenMember`:

- `SeenMember.Path []spatial.Position` — the shortest route from this monster's own position toward that sighting, computed at view-build time against this composition's own walls, doors and floor. **Stops ADJACENT** rather than walking onto the sighting's own occupied cell (drops the underlying BFS's final "onto them" hop) — empty when unreachable OR already adjacent. `behavior.Basic` never has to tell the two apart, because it only consults `Path` after already confirming the target is NOT in reach (if it were adjacent, `InReach` would already be true for any 5-foot-or-better action).
- `SeenMember.Distance` renamed `SeenMember.DistanceCells`, matching this session's own established unit-suffix convention (`SpeedFeet`, `SightFeet`, `ReachFeet`) rather than leaving the one field without one.

**Cost, noted explicitly per Kirk's ask**: one BFS per Seen member per `Act` call now, not one per driver-initiated question. Fine at this scale (a handful of sightings, once per unplayed member's turn) — called out in the field's own doc comment so it's a documented tradeoff, not a silent one.

## The shape underneath (unchanged from the first version)

Backed by a private `Encounter.pathTo`, reached via `canvasRoom`'s embedding of `*spatial.BasicRoom`:

- Floor: `RegionAt` (same check `Step` and `stepMember` already use)
- Walls/doors: `BasicRoom.IsBoundaryMovementBlocked(from, to)` — already exported by spatial, just never reached from this module before
- A plain BFS over `Grid.GetNeighbors`, neighbours visited in a fixed sort order (C8 determinism). BFS is exact here, not a heuristic substitute for A*: every edge this module's grids offer costs exactly one cell (Chebyshev on square, cube distance on hex).
- Deliberately ignores occupancy for the underlying route computation: this answers "how would the geometry let me get there." A transient occupant still refuses at actual step time, and `driveMonsterTurns` already treats a mid-move refusal as "stop the walk, keep the turn running."

## Test

`TestSeenMemberPathWalksAroundAWall` — an authored wall with one gap; asserts the path routes through the gap AND stops adjacent to the target rather than on her own cell. `TestSeenMemberPathIsEmptyWhenSightedButUnreachable` — two floor regions separated by a void gap wide enough that nothing walkable bridges them, with the void transparent to sight (`VoidIsTransparent`): the sighting is real (appears in `Seen`) but `Path` is empty, proving the design's accepted ambiguity is actually reachable and behaves as documented.

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race -count=1 ./...` — all green
- `golangci-lint run ./...` — 0 issues
- `gorelease` — `SeenMember.Distance: removed` (the rename; incompatible, expected — no backcompat baggage during active pre-1.0 development, and nothing outside this same initiative consumes it yet), `SeenMember.DistanceCells`/`SeenMember.Path`: added. Suggests `v0.31.0`.
- `./scripts/check-decisions.sh` — all 45 ADRs summarised

## For rpg-api / behavior

`behavior.Basic` (already built and locally tested against this branch) reads `Seen[i].Path` directly and takes its first element for a one-cell `Move` intent — no hex math in `behavior`, no live `*Encounter` reference, no closures. Will update this PR body's own "for rpg-api" note is unnecessary since behavior isn't yet a public consumer — this is the last shape change before that PR opens.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu