### PR TITLE
encounter: SeenMember.Path — reach-aware stop, and a same-day bug fix

### DIFF
--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -561,37 +561,31 @@ func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round i
 			inReach[a.Ref] = dist <= float64(CellsFromFeet(a.ReachFeet))
 		}
 
-		// Path ends on the NEAREST cell (to this member's own position)
-		// from which the sighting is within bestReachCells — the full
-		// route pathTo computes walks all the way onto pos itself, and
-		// every cell along a shortest route gets monotonically closer, so
-		// the first cell (from the start) satisfying the reach test is
-		// exactly the stopping point a driver wants: not one step farther
-		// than necessary, and never onto the sighting's own occupied cell
-		// (Kirk, rpg-project#254 review — this also removes the "already
-		// in reach, don't bother moving" workaround behavior.Basic carried
-		// before this truncation existed). One BFS per sighting, every Act
-		// call — see the field's own doc for why that cost is accepted
-		// rather than deferred behind a lazy capability.
+		// Path ends on the NEAREST WALKABLE cell (to this member's own
+		// position — the shortest route BY STEPS, not "however far along
+		// the route to pos happens to land") from which the sighting is
+		// within bestReachCells (Kirk, rpg-project#254 review — this also
+		// removes the "already in reach, don't bother moving" workaround
+		// behavior.Basic carried before this truncation existed).
 		//
-		// ALREADY WITHIN REACH IS CHECKED FIRST, SEPARATELY, rather than
-		// folded into the scan below: when dist already satisfies
-		// bestReachCells, the "first in-reach cell" the naive scan would
-		// find is pathTo's own final element — the sighting's own occupied
-		// cell — since a member exactly bestReachCells away has no
-		// intermediate cell between itself and the target to stop at
-		// instead. That is precisely the cell this field must never name.
-		var path []spatial.Position
-		if dist > float64(bestReachCells) {
-			if full, ok := e.pathTo(ownCell, pos); ok {
-				for i, cell := range full {
-					if e.Distance(cell, pos) <= float64(bestReachCells) {
-						path = full[:i+1]
-						break
-					}
-				}
-			}
-		}
+		// SEARCHED AS ITS OWN GOAL, NOT TRUNCATED FROM A ROUTE TO pos
+		// (Copilot, PR #1191 review): a route to pos and a route to "any
+		// cell within reach of pos" are different questions the moment a
+		// movement-blocking boundary makes them different — a
+		// geometrically closer in-range cell can be a walkable dead end
+		// relative to the far side of a wall, reachable in fewer steps
+		// than continuing on toward pos itself, and InReach never checked
+		// walkability to begin with (it is distance-only, matching 5e's
+		// own reach rule). bfsShortestPath's goal predicate stops the
+		// search the moment ANY cell — including this member's own
+		// starting position, handling "already in reach" for free — is
+		// within bestReachCells of pos, which is the actual nearest
+		// walkable answer rather than a proxy for it. One BFS per
+		// sighting, every Act call — see the field's own doc for why that
+		// cost is accepted rather than deferred behind a lazy capability.
+		path, _ := e.bfsShortestPath(ownCell, func(cell spatial.Position) bool {
+			return e.Distance(cell, pos) <= float64(bestReachCells)
+		})
 
 		seen = append(seen, SeenMember{
 			ID:            subjectID,
@@ -638,11 +632,27 @@ func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round i
 // NEIGHBOURS ARE VISITED IN A FIXED ORDER (C8): map iteration has none, and
 // a driver asked twice against unchanged geometry must get the same answer
 // both times, not merely an equally-short one.
-func (e *Encounter) pathTo(from, to spatial.Position) ([]spatial.Position, bool) {
-	if _, owned := e.RegionAt(to); !owned {
-		return nil, false
-	}
-	if from == to {
+// bfsShortestPath is the search engine [Encounter.buildMonsterView]'s
+// reach-aware Path runs on: a breadth-first search from `from` over this
+// composition's own floor and
+// walls, stopping at the first cell — in BFS DISCOVERY order, which is
+// shortest-distance-from-`from` order — satisfying `goal`. goal(from)
+// itself is checked first: a caller whose own starting cell already
+// satisfies the goal gets an EMPTY path with ok=true, not a one-element
+// path naming its own position.
+//
+// Exact (not a heuristic): every edge this module's grids offer costs
+// exactly one cell (Chebyshev on a square grid, cube distance on a hex
+// one), so BFS IS shortest-path here — there is no weighted-edge case for
+// A* to earn its keep over. Returns the path EXCLUDING `from` and
+// INCLUDING the first cell satisfying goal, or ok=false when no reachable
+// cell ever does.
+//
+// NEIGHBOURS ARE VISITED IN A FIXED ORDER (C8): map iteration has none,
+// and a driver asked twice against unchanged geometry must get the same
+// answer both times, not merely an equally-short one.
+func (e *Encounter) bfsShortestPath(from spatial.Position, goal func(spatial.Position) bool) ([]spatial.Position, bool) {
+	if goal(from) {
 		return nil, true
 	}
 
@@ -651,7 +661,10 @@ func (e *Encounter) pathTo(from, to spatial.Position) ([]spatial.Position, bool)
 	prev := make(map[spatial.Position]spatial.Position)
 	queue := []spatial.Position{from}
 
-	for len(queue) > 0 {
+	var found spatial.Position
+	ok := false
+
+	for len(queue) > 0 && !ok {
 		cur := queue[0]
 		queue = queue[1:]
 
@@ -675,20 +688,21 @@ func (e *Encounter) pathTo(from, to spatial.Position) ([]spatial.Position, bool)
 			}
 			visited[n] = true
 			prev[n] = cur
-			if n == to {
-				queue = nil
+			if goal(n) {
+				found = n
+				ok = true
 				break
 			}
 			queue = append(queue, n)
 		}
 	}
 
-	if !visited[to] {
+	if !ok {
 		return nil, false
 	}
 
 	var path []spatial.Position
-	for at := to; at != from; at = prev[at] {
+	for at := found; at != from; at = prev[at] {
 		path = append(path, at)
 	}
 	for i, j := 0, len(path)-1; i < j; i, j = i+1, j-1 {

--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -520,6 +520,22 @@ func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round i
 		return MonsterView{}, fmt.Errorf("held by: %w", err)
 	}
 
+	// bestReachCells is the farthest this member's own actions can reach,
+	// in cells — the arithmetic max of authored ReachFeet values, not a
+	// rules opinion about which action is "best" in play (this module
+	// still cannot import the rulebook, C1: it takes the number, not the
+	// meaning). Floored at 1 (5 feet, a bare cell) even for a member with
+	// no actions at all: the floor is a SPATIAL fact independent of combat
+	// capability — nobody's own Path should ever walk onto another
+	// member's occupied cell, whether or not this member has anything to
+	// do once it arrives.
+	bestReachCells := 1
+	for _, a := range m.Actions {
+		if c := CellsFromFeet(a.ReachFeet); c > bestReachCells {
+			bestReachCells = c
+		}
+	}
+
 	var seen []SeenMember
 	for _, h := range holdings {
 		// Sight channel, ACTIVELY sustained only (intel.Current) — a stale
@@ -545,15 +561,36 @@ func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round i
 			inReach[a.Ref] = dist <= float64(CellsFromFeet(a.ReachFeet))
 		}
 
-		// Path stops ADJACENT rather than walking onto the sighting's own
-		// occupied cell (Kirk, rpg-project#254 review) — the full route
-		// pathTo computes ends AT pos, so dropping its last element is the
-		// nearest cell that route reaches this sighting from. One BFS per
-		// sighting, every Act call — see the field's own doc for why that
-		// cost is accepted rather than deferred behind a lazy capability.
+		// Path ends on the NEAREST cell (to this member's own position)
+		// from which the sighting is within bestReachCells — the full
+		// route pathTo computes walks all the way onto pos itself, and
+		// every cell along a shortest route gets monotonically closer, so
+		// the first cell (from the start) satisfying the reach test is
+		// exactly the stopping point a driver wants: not one step farther
+		// than necessary, and never onto the sighting's own occupied cell
+		// (Kirk, rpg-project#254 review — this also removes the "already
+		// in reach, don't bother moving" workaround behavior.Basic carried
+		// before this truncation existed). One BFS per sighting, every Act
+		// call — see the field's own doc for why that cost is accepted
+		// rather than deferred behind a lazy capability.
+		//
+		// ALREADY WITHIN REACH IS CHECKED FIRST, SEPARATELY, rather than
+		// folded into the scan below: when dist already satisfies
+		// bestReachCells, the "first in-reach cell" the naive scan would
+		// find is pathTo's own final element — the sighting's own occupied
+		// cell — since a member exactly bestReachCells away has no
+		// intermediate cell between itself and the target to stop at
+		// instead. That is precisely the cell this field must never name.
 		var path []spatial.Position
-		if full, ok := e.pathTo(ownCell, pos); ok && len(full) > 0 {
-			path = full[:len(full)-1]
+		if dist > float64(bestReachCells) {
+			if full, ok := e.pathTo(ownCell, pos); ok {
+				for i, cell := range full {
+					if e.Distance(cell, pos) <= float64(bestReachCells) {
+						path = full[:i+1]
+						break
+					}
+				}
+			}
 		}
 
 		seen = append(seen, SeenMember{

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -719,3 +719,60 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathIsEmptyWhenAlreadyWithinReach()
 	s.True(aliceSeen.InReach[testMeleeAction], "control: alice really is in reach at the start")
 	s.Empty(aliceSeen.Path, "already in reach — nothing to walk onto her cell for")
 }
+
+// TestSeenMemberPathFindsTheNearestInRangeCellNotJustTheRouteToTarget pins
+// Copilot's PR #1191 review: a route to the target's own cell and a route
+// to "any cell within reach of the target" are different questions the
+// moment a wall makes them different. This fixture puts a cell right next
+// to the monster's own starting position that is GEOMETRICALLY within a
+// generous reach (InReach is distance-only, matching 5e's own reach rule —
+// walls do not extend it) but is nowhere near the walking route the wall
+// forces toward the target's own cell. The nearest WALKABLE in-range cell
+// is one step away; the naive "truncate the route to the target" approach
+// would instead walk most of the way around the wall before ever
+// mentioning it.
+func (s *MonsterTurnTestSuite) TestSeenMemberPathFindsTheNearestInRangeCellNotJustTheRouteToTarget() {
+	longReach := core.Ref{Module: "dnd5e", Type: "monster_actions", ID: "long-reach"}
+	// A 5x3 room. A wall spans the column between x=1 and x=2 at y=0 and
+	// y=1, leaving the bottom row (y=2) as the only gap.
+	//
+	//   x: 0 1 | 2 3 4
+	// y=0: .  . | .  .  .
+	// y=1: .  . | .  .  .
+	// y=2: .  .   .  .  .   <- gap
+	wall := []spatial.Boundary{
+		{From: spatial.Position{X: 1, Y: 0}, To: spatial.Position{X: 2, Y: 0}, BlocksMovement: true},
+		{From: spatial.Position{X: 1, Y: 1}, To: spatial.Position{X: 2, Y: 1}, BlocksMovement: true},
+	}
+	driver := &scriptedDriver{}
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: room1, Width: 5, Height: 3, Boundaries: wall}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 4, Y: 0}},
+			{
+				ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 0, Y: 0},
+				SpeedFeet: 60, Targeting: "closest",
+				// 15 feet (3 cells) — deliberately generous so the cell
+				// right beside the monster's own start (1 step away,
+				// Chebyshev distance 3 from alice) is already in range,
+				// making the detour-vs-shortcut distinction unambiguous.
+				Actions: []encounter.ActionView{{Ref: longReach, Name: "Whip", ReachFeet: 15, Kind: "melee"}},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	s.Require().Len(driver.calls, 1, "the first Act call already finds a target in range, one step away")
+	aliceSeen := s.seenFor(driver.calls[0], alice)
+	s.Equal([]spatial.Position{{X: 1, Y: 0}}, aliceSeen.Path,
+		"the nearest WALKABLE in-range cell is one step away, not several steps around the wall")
+}

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -661,3 +661,61 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathIsEmptyWhenSightedButUnreachabl
 	aliceSeen := s.seenFor(driver.calls[0], alice)
 	s.Empty(aliceSeen.Path, "seen across the gap, but nothing walkable reaches her")
 }
+
+// TestSeenMemberPathStopsAtTheMemberOwnLongestReachNotJustAdjacent pins the
+// reach-aware stopping distance (Kirk, rpg-project#254 review): a monster
+// with a 10-foot reach weapon (2 cells) should stop TWO cells from its
+// target, not walk needlessly to melee-adjacent — Path already ends
+// wherever InReach would turn true, so a driver never has to check InReach
+// before consulting Path.
+func (s *MonsterTurnTestSuite) TestSeenMemberPathStopsAtTheMemberOwnLongestReachNotJustAdjacent() {
+	reachWeapon := core.Ref{Module: "dnd5e", Type: "monster_actions", ID: "reach"}
+	driver := &scriptedDriver{}
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: room1, Width: 10, Height: 3}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 0, Y: 0}},
+			{
+				ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 6, Y: 0},
+				SpeedFeet: 30, Targeting: "closest",
+				Actions: []encounter.ActionView{{Ref: reachWeapon, Name: "Glaive", ReachFeet: 10, Kind: "melee"}},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	s.Require().Len(driver.calls, 1)
+	aliceSeen := s.seenFor(driver.calls[0], alice)
+	s.Require().NotEmpty(aliceSeen.Path)
+	last := aliceSeen.Path[len(aliceSeen.Path)-1]
+	s.InDelta(2.0, enc.Distance(last, spatial.Position{X: 0, Y: 0}), 0.001,
+		"a 10-foot (2-cell) reach stops 2 cells out, not adjacent: %+v", aliceSeen.Path)
+}
+
+// TestSeenMemberPathIsEmptyWhenAlreadyWithinReach is the bug the
+// end-to-end behavior.Basic test found: a member already at exactly
+// bestReachCells' distance (no earlier cell to stop at before the
+// target's own) must not return a one-element Path onto the target's own
+// cell — Path must be empty, matching its own documented contract ("empty
+// ... or this member is already within reach without moving at all").
+func (s *MonsterTurnTestSuite) TestSeenMemberPathIsEmptyWhenAlreadyWithinReach() {
+	driver := &scriptedDriver{}
+	enc := s.adjacentSkeletonEncounter(driver, &scriptedStriker{kind: encounter.OutcomeMissed})
+
+	_, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	s.Require().Len(driver.calls, 1, "an in-reach attack ends the goblin's turn in one Act call")
+	aliceSeen := s.seenFor(driver.calls[0], alice)
+	s.True(aliceSeen.InReach[testMeleeAction], "control: alice really is in reach at the start")
+	s.Empty(aliceSeen.Path, "already in reach — nothing to walk onto her cell for")
+}

--- a/rulebooks/dnd5e/encounter/turndriver.go
+++ b/rulebooks/dnd5e/encounter/turndriver.go
@@ -147,24 +147,28 @@ type SeenMember struct {
 	// Path is the shortest route from this monster's OWN position toward
 	// this sighting, computed against this composition's own walls, doors
 	// and floor — the same geometry [Encounter.Step] enforces —
-	// DUNGEON-ABSOLUTE, first element the first step to take. STOPS
-	// ADJACENT rather than walking onto the sighting's own occupied cell:
-	// the last element is the nearest cell the shortest route reaches this
-	// sighting from, one cell short of Position itself. Empty when this
-	// sighting is unreachable OR already adjacent — a driver checking
-	// InReach before consulting Path (as [behavior.Basic] does) never
-	// needs to tell the two apart, since "already adjacent" already means
-	// "in reach" for any action with at least a 5-foot (one-cell) reach.
+	// DUNGEON-ABSOLUTE, first element the first step to take.
 	//
-	// DATA, NOT A LIVE CAPABILITY (Kirk, rpg-project#254 review — supersedes
-	// an earlier closure-based design this PR shipped and walked back):
-	// MonsterView must stay loggable, replayable and fixture-buildable
-	// (rpg-project#235's Debug Feed journey; the monster-ai brainstorm's
-	// "perception is data, the decision layer never reaches live state") —
-	// a func field breaks all three. Computed once per Seen member, per
-	// Act call — ONE BFS PER SIGHTING, not one for the chosen target alone;
-	// noted here as the acknowledged cost of keeping this a plain value
-	// rather than a lazy callback.
+	// ENDS ON THE NEAREST CELL (to this member's own position — the fewest
+	// steps, never one more than necessary) FROM WHICH THIS SIGHTING IS
+	// WITHIN REACH of this member's own longest-reaching action (Kirk,
+	// rpg-project#254 review): NEVER the sighting's own occupied cell, and
+	// never farther than the shortest route needs. A driver moving along
+	// Path therefore never has to separately check InReach before issuing
+	// a Move — Path itself already stops exactly where InReach would turn
+	// true. Empty in two cases a caller does not need to tell apart: no
+	// walkable route exists, or this member is already within reach
+	// without moving at all (Distance already <= its own best reach).
+	//
+	// DATA, NOT A LIVE CAPABILITY (supersedes an earlier closure-based
+	// design this PR shipped and walked back): MonsterView must stay
+	// loggable, replayable and fixture-buildable (rpg-project#235's Debug
+	// Feed journey; the monster-ai brainstorm's "perception is data, the
+	// decision layer never reaches live state") — a func field breaks all
+	// three. Computed once per Seen member, per Act call — ONE BFS PER
+	// SIGHTING, not one for the chosen target alone; noted here as the
+	// acknowledged cost of keeping this a plain value rather than a lazy
+	// callback.
 	Path []spatial.Position
 }
 


### PR DESCRIPTION
## Summary

Closes #1190 — follow-up to #1189 (rpg-project#254), merged today at `db5aa53`/`559635d` (tag v0.30.5). This PR was actually finished BEFORE the merge landed but pushed to the wrong branch state — see the timeline note below; the content is unchanged from what was reported ready, plus a real bug this PR's own end-to-end wiring test found immediately after.

## Two changes, same commit

**1. Reach-aware stopping distance (Kirk's review on #1189, already reported and merged with the intent, not the full fix — see timeline below):** `SeenMember.Path` now ends on the nearest cell from which the sighting is within reach of this member's OWN longest-reaching action — the arithmetic max of `ReachFeet` across `Actions`, converted to cells, floored at 1 (5 feet — the physical "don't stand where someone else is standing" minimum even for a member with no actions at all). A monster with a 10-foot reach weapon now stops 2 cells out, not 1. This also let `behavior.Basic` drop its own "already in reach, don't bother moving" workaround entirely — Path itself now ends exactly where `InReach` would turn true.

**2. Bug fix — Path walking onto the target's own cell when already in reach:** the truncation scans the full BFS path for the first cell within `bestReachCells`. When the member is ALREADY within reach at the START (no intervening cell before the target), that scan's first candidate is unavoidably the target's OWN final cell — a member exactly at reach distance has a one-element full path (the target's cell alone) — so the naive scan returned a one-element `Path` onto the target's own occupied cell instead of empty. Fixed by checking the starting distance against `bestReachCells` BEFORE scanning at all.

**How the bug was found:** `behavior.Basic`'s end-to-end test (against a real `encounter.NewEncounter`/`EndTurn`, not just unit-tested decision logic) failed immediately after the workaround was removed — the goblin closed to melee, attacked, and then walked the rest of the way onto alice's own cell on its next `Act` call. A dedicated encounter-level regression test (`TestSeenMemberPathIsEmptyWhenAlreadyWithinReach`) now pins this directly, independent of `behavior`.

## Timeline note

This PR's content was fully built, tested, and reported as ready against PR #1189's branch (commit `db5aa53`) before Kirk's merge of #1189 landed at that same commit — the bug-fix commit (`ca12dd4` on the original branch) was pushed moments after the merge, too late to land in #1189 itself. Rebuilt cleanly here as a fresh PR against post-merge `main` (a clean `git cherry-pick`, no conflicts).

## Test

`TestSeenMemberPathStopsAtTheMemberOwnLongestReachNotJustAdjacent` — a 10-foot reach weapon stops 2 cells out. `TestSeenMemberPathIsEmptyWhenAlreadyWithinReach` — the bug fix itself, pinned directly (asserts `InReach` is true and `Path` is empty for a member already adjacent with a 5-foot reach action).

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race -count=1 ./...` — all green
- `golangci-lint run ./...` — 0 issues
- `gorelease` — compatible additions on top of #1189's own already-merged shape (its base-detection reports against v0.30.4 rather than v0.30.5 for reasons unrelated to this diff's own correctness; the actual delta here is purely additive test coverage plus the truncation-loop fix, no new exported surface)
- `./scripts/check-decisions.sh` — all 45 ADRs summarised

## For rpg-api / behavior

No further shape changes: `SeenMember.Path`'s contract is now exactly as documented in #1189 — this PR makes the implementation match that contract in the one case it didn't. `rulebooks/dnd5e/behavior`'s `Basic` (about to open its own PR) pins this tag.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu