### PR TITLE
resolution: re-pin encounter to v0.30.6, supply the now-required Striker

### DIFF
--- a/rulebooks/dnd5e/resolution/character_attack_test.go
+++ b/rulebooks/dnd5e/resolution/character_attack_test.go
@@ -122,7 +122,7 @@ func (s *CharacterAttackTestSuite) mainHand() *CharacterAttackInput {
 // world puts the hero next to the wolf. Adjacency matters only to prone's
 // range predicate, which nobody here triggers.
 func (s *CharacterAttackTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},

--- a/rulebooks/dnd5e/resolution/contest_test.go
+++ b/rulebooks/dnd5e/resolution/contest_test.go
@@ -67,7 +67,7 @@ func (s *ContestTestSuite) wolfsKnockdown() *saves.SaveGate {
 }
 
 func (s *ContestTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},

--- a/rulebooks/dnd5e/resolution/cost_test.go
+++ b/rulebooks/dnd5e/resolution/cost_test.go
@@ -134,7 +134,7 @@ func (s *CostTestSuite) strikeCost(data *character.Data) *combat.SpendProfile {
 }
 
 func (s *CostTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},

--- a/rulebooks/dnd5e/resolution/damage_custody_test.go
+++ b/rulebooks/dnd5e/resolution/damage_custody_test.go
@@ -194,7 +194,7 @@ func (s *DamageCustodyTestSuite) TestTypedOutcomePreservesMixedVulnerabilityAndI
 // Real content, and the case a synthetic subscriber cannot pin: a raging
 // barbarian takes half from the wolf's piercing bite.
 func (s *DamageCustodyTestSuite) TestARagingTargetsResistanceReadsTheEventsDamageType() {
-	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
@@ -326,7 +326,7 @@ func (s *DamageCustodyTestSuite) addFlatOnBus(bus events.EventBus, amount int, t
 // it keeps a character's AC chain out of the arithmetic under test, and the
 // damage fold is the same fold whoever is swinging.
 func (s *DamageCustodyTestSuite) roomWith(attacker, target encounter.MemberID) encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},

--- a/rulebooks/dnd5e/resolution/declared_consequence_test.go
+++ b/rulebooks/dnd5e/resolution/declared_consequence_test.go
@@ -63,7 +63,7 @@ func (s *DeclaredConsequenceTestSuite) biteProfile() AttackProfile {
 // world places the hero and the wolf three cells apart — far enough that
 // prone's range predicate stays out of these cases.
 func (s *DeclaredConsequenceTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},

--- a/rulebooks/dnd5e/resolution/effective_ac_test.go
+++ b/rulebooks/dnd5e/resolution/effective_ac_test.go
@@ -98,7 +98,7 @@ func (s *EffectiveACTestSuite) defenseStyle() json.RawMessage {
 }
 
 func (s *EffectiveACTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
@@ -189,7 +189,7 @@ func (s *EffectiveACTestSuite) TestAMonsterTargetStillReportsItsStatBlockAC() {
 	attack, err := AttackFromMonsterAction(data.Actions[0])
 	s.Require().NoError(err)
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.6
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -18,8 +18,8 @@ github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZ
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1 h1:8KqSUfctVMx0+h0bO71fx/IH/7i9kjtAv6cqa7ZV8wY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0 h1:BnDZ//xyK/vcFmhUyDV8mRd4KSnj6Ofrz5Kpxy0GH1o=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.6 h1:O4YgK5tjVmeAY2L+Oj9IIuRh3SCFFRvODemW42u5Zyw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.6/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -293,6 +293,15 @@ func resolveOn(ctx context.Context, in *Input, surf *surface) (*Output, error) {
 		Standing:   in.Standing,
 		Sight:      in.Sight,
 		TurnDriver: in.TurnDriver,
+		// A construction-only Striker (rpg-project#254): this package runs
+		// ONE interaction machine against a loaded snapshot and returns — it
+		// never drives a monster's whole turn (that is driveMonsterTurns'
+		// own job, reached through EndTurn/form, neither of which this
+		// package's Resolve calls). A driven turn reaching this Striker
+		// would mean this reconstruction is being asked to do something it
+		// was never built for; RefusingStriker names that loudly rather
+		// than fabricating a hit.
+		Striker: encounter.RefusingStriker{},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("resolution: load world: %w", err)

--- a/rulebooks/dnd5e/resolution/resolve_test.go
+++ b/rulebooks/dnd5e/resolution/resolve_test.go
@@ -69,7 +69,7 @@ func (s *ResolveTestSuite) SetupTest() {
 // world is a two-member encounter, already normalised by a load/save cycle so
 // that "unchanged" can be asserted literally.
 func (s *ResolveTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
@@ -643,7 +643,7 @@ func (c *countingStanding) Standing(_ []encounter.MemberID) ([]encounter.MemberI
 // zero is how that stays a decision rather than a coincidence.
 func TestTheStandingCapabilityIsCarriedAndNeverAsked(t *testing.T) {
 	world, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
@@ -709,7 +709,7 @@ func (c *countingSight) Sight(members []encounter.MemberID) (map[encounter.Membe
 // darkvision it holds nothing of.
 func TestTheSightCapabilityIsCarriedAndNeverAsked(t *testing.T) {
 	world, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},

--- a/rulebooks/dnd5e/resolution/strictness_test.go
+++ b/rulebooks/dnd5e/resolution/strictness_test.go
@@ -65,7 +65,7 @@ func (s *StrictnessTestSuite) SetupTest() {
 // world is a two-member encounter: the hero, and a second character whose sheet
 // is the corrupt one.
 func (s *StrictnessTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
@@ -208,7 +208,7 @@ func (s *StrictnessTestSuite) TestAnUnroutableMonsterTraitFailsTheResolution() {
 		},
 	}
 
-	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},

--- a/rulebooks/dnd5e/resolution/strike_test.go
+++ b/rulebooks/dnd5e/resolution/strike_test.go
@@ -105,7 +105,7 @@ func (s *StrikeTestSuite) wolfBite() monster.ActionData {
 // hero; otherwise it stands three cells away — the two sides of prone's range
 // split.
 func (s *StrikeTestSuite) world(secondWolfAt spatial.Position) encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
@@ -367,7 +367,7 @@ func (s *StrikeTestSuite) TestTheStrikeRunsInPieces() {
 	surf := newSurface(events.NewEventBus())
 
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Data: world, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
+		Data: world, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{},
 		Sight: everyoneSeesTheWholeMap{},
 	})
 	s.Require().NoError(err)
@@ -945,7 +945,7 @@ func (s *StrikeTestSuite) TestASkeletonSwingsItsShortsword() {
 	s.Require().NoError(err)
 	s.Require().Nil(attack.Gate, "a plain weapon declares no rider")
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
 			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
@@ -1000,7 +1000,7 @@ const scoutID = "scout-1"
 // deciding a rule" (ADR-0038).
 func (s *StrikeTestSuite) spreadWorld(secondWolfRoom string, secondWolfAt spatial.Position) encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{},
 		Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
@@ -1163,7 +1163,7 @@ func (s *StrikeTestSuite) TestAWolfInTheNextChamberIsSixtyFeetAwayNotOneCell() {
 // after this test predated it — see localIsInRoom's own doc.)
 func (s *StrikeTestSuite) hexWorld() encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{},
 		Sight: everyoneSeesTheWholeMap{},
 		// Orientation is required for a hex field but arbitrary here: axial
 		// distance (what this test measures) is the same six neighbours either

--- a/rulebooks/dnd5e/resolution/testrollers_test.go
+++ b/rulebooks/dnd5e/resolution/testrollers_test.go
@@ -2,8 +2,10 @@ package resolution
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 )
 
@@ -76,8 +78,21 @@ func (everyoneStanding) Standing(_ []encounter.MemberID) ([]encounter.MemberID, 
 // fixtures hand over the one answer that changes nothing.
 type passDriver struct{}
 
-func (passDriver) Act(encounter.MemberID) (encounter.TurnOutcome, error) {
+func (passDriver) Act(encounter.MonsterView) (encounter.TurnIntent, error) {
 	return encounter.Pass{}, nil
+}
+
+// noAttacksExpected is the deterministic Striker every fixture wires. This
+// package's own fixtures never drive a monster's turn through the
+// composition (passDriver never returns anything but Pass), so this is
+// never actually called — required at construction regardless
+// (rpg-project#254), and it says so honestly rather than fabricating a hit.
+type noAttacksExpected struct{}
+
+func (noAttacksExpected) Strike(
+	context.Context, *encounter.Encounter, encounter.MemberID, encounter.MemberID, core.Ref,
+) error {
+	return errors.New("resolution fixtures: no scene here ever attacks")
 }
 
 // unlimitedSight is the range these fixtures hand out. Further than the longest

--- a/rulebooks/dnd5e/resolution/world_test.go
+++ b/rulebooks/dnd5e/resolution/world_test.go
@@ -77,7 +77,7 @@ func walledWorld(t *testing.T) encounter.EncounterData {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{},
 		Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},


### PR DESCRIPTION
## Summary

Closes #1194 — urgent companion fix discovered while wiring `rulebooks/dnd5e/session`'s own `Striker` implementation (rpg-project#254), which calls `resolution.Resolve` internally.

encounter v0.30.4+ made `Striker` a required capability at construction (`ErrNoStriker` if absent, the same "capabilities supplied, never defaulted" law `TurnDriver`/`Standing`/`Sight` already follow). `resolution.Resolve`'s own internal `encounter.LoadEncounter` call never supplied one — resolution was still pinned to encounter v0.30.0 in its own go.mod, so its own test suite never exercised the break. Re-pinning resolution to any tag past v0.30.3 (as session's own re-pin now needs) **compiles fine and fails every single `resolution.Resolve` call at runtime** with "Striker is required" — meaning session's already-shipped `Attack` verb would have broken silently the moment its own re-pin landed.

Verified the failure mode directly before fixing it: an isolated reproduction pinning encounter v0.30.6 + resolution v0.11.6 and calling `resolution.Resolve` with a fully-supplied `Input` reproduces exactly `resolution: load world: load encounter: Striker is required: encounter: no striker capability`.

## The fix

`encounter.RefusingStriker{}`, not a real `Striker` — this package runs ONE interaction machine against a loaded snapshot and returns; it never drives a monster's whole turn (that's `driveMonsterTurns`' own job, reached through `EndTurn`/`form`, neither of which `Resolve` calls). A driven turn reaching this `Striker` would mean this reconstruction is being asked to do something it was never built for, and `RefusingStriker` says so loudly rather than fabricating a hit.

Also re-pins `resolution`'s own `encounter` dependency from v0.30.0 to v0.30.6 (picking up `MonsterView`/`TurnIntent`/`Striker`/`SeenMember.Path` — none of which this package's own vocabulary uses directly, but the pin needed to move regardless).

## Test fixtures

Mechanical updates across all 10 test files: `passDriver`'s `Act` signature (`encounter.TurnOutcome` → `encounter.TurnIntent`, matching encounter's own vocabulary rewrite), a new `noAttacksExpected` Striker fixture wired onto every `encounter.SetupInput`/`LoadEncounterInput` construction (79 call sites). **Careful NOT to add it to `resolution.Input` literals** — that type has no `Striker` field at all; the capability is `resolution`'s own internal concern, never something a caller of `Resolve` configures. (First pass of the mechanical replace did add it to ~60 `resolution.Input` literals by mistake; caught by `go vet` immediately, fixed with a context-aware second pass distinguishing which struct type each match belonged to.)

## Verification

- `go build ./...`, `go vet ./...` — clean
- `go test -race -count=1 ./...` — all green (the existing ~79-call-site test suite through `resolve_test.go` and friends now exercises the fixed path directly and thoroughly — no separate regression test needed beyond what already covers `Resolve`)
- `golangci-lint run ./...` — 0 issues
- `gorelease` — fully compatible (no exported API surface change), suggests `v0.11.7`
- `./scripts/check-decisions.sh` — all 45 ADRs summarised

## For rpg-api / session

No shape change for callers of `resolution.Resolve` — `Input` is unchanged. Just a dependency re-pin that needed a real fix underneath it, which this PR is. `session`'s own re-pin (in flight) will pin this tag once it lands.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu