### PR TITLE
resolution: carry a monster action's authored Name onto its AttackProfile

### DIFF
--- a/rulebooks/dnd5e/resolution/monster_attack_test.go
+++ b/rulebooks/dnd5e/resolution/monster_attack_test.go
@@ -109,7 +109,7 @@ func (s *MonsterAttackTestSuite) TestBiteNameIsNotEmpty() {
 
 	profile, err := AttackFromMonsterAction(action)
 	s.Require().NoError(err)
-	s.NotEmpty(profile.Name)
+	s.Equal("Bite", profile.Name)
 }
 
 // TestMeleeReachCarriesTheAuthoredValue pins the fix: a generic melee

--- a/rulebooks/dnd5e/resolution/monster_attack_test.go
+++ b/rulebooks/dnd5e/resolution/monster_attack_test.go
@@ -75,6 +75,43 @@ func (s *MonsterAttackTestSuite) TestMeleePreservesCanonicalPoolsAndIntrinsicBon
 	}
 }
 
+// TestMeleeNameCarriesTheAuthoredValue pins a sibling gap to the Reach one
+// below: AttackProfile.Name stayed empty for every monster melee action
+// regardless of what the stat block authored (MeleeConfig.Name — "shortsword",
+// "scimitar"), even though the field exists on the profile precisely so a
+// caller reporting what was swung never has to look the ref back up in a
+// catalog (rpg-toolkit#866, AttackProfile.Name's own doc). A monster
+// attacker reaching a recording caller — session's Striker, driving a
+// monster's own turn (rpg-project#254) — needs this to say more than "" in
+// a struck/missed beat's AttackIdentity.Name.
+func (s *MonsterAttackTestSuite) TestMeleeNameCarriesTheAuthoredValue() {
+	action := s.action(refs.MonsterActions.Melee(), monsterActions.MeleeConfig{
+		Name:        "scimitar",
+		AttackBonus: 4,
+		Damage:      []damage.Damage{{Dice: "1d6", Type: damage.Slashing}},
+		Reach:       5,
+	})
+
+	profile, err := AttackFromMonsterAction(action)
+	s.Require().NoError(err)
+	s.Equal("scimitar", profile.Name)
+}
+
+// TestBiteNameIsNotEmpty pins that a bite — which has no configurable Name
+// field at all (BiteConfig carries none; every bite is just "the bite") —
+// compiles to a non-empty display name rather than "", for the same reason
+// TestMeleeNameCarriesTheAuthoredValue does.
+func (s *MonsterAttackTestSuite) TestBiteNameIsNotEmpty() {
+	action := s.action(refs.MonsterActions.Bite(), monsterActions.BiteConfig{
+		AttackBonus: 4,
+		Damage:      []damage.Damage{{Dice: "2d4", Type: damage.Piercing}},
+	})
+
+	profile, err := AttackFromMonsterAction(action)
+	s.Require().NoError(err)
+	s.NotEmpty(profile.Name)
+}
+
 // TestMeleeReachCarriesTheAuthoredValue pins the fix: a generic melee
 // action's Reach was silently dropped — AttackProfile.Reach stayed zero
 // regardless of what the stat block authored, meaning nothing gated a

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -745,7 +745,15 @@ func attackFromMelee(action monster.ActionData) (AttackProfile, error) {
 
 	ref := action.Ref
 	profile := AttackProfile{
-		Ref:         &ref,
+		Ref: &ref,
+		// The stat block's own authored display name — "shortsword",
+		// "scimitar" — carried through exactly as AttackFromCharacter
+		// already carries a weapon's (rpg-toolkit#866). Previously dropped
+		// (AttackProfile.Name stayed "" for every monster melee action),
+		// harmless only while nothing that compiled a monster's attack
+		// ever reported it to a caller — session's Striker now does
+		// (rpg-project#254).
+		Name:        config.Name,
 		AttackBonus: config.AttackBonus,
 		Damage:      copyDamagePools(config.Damage),
 		// The stat block's own authored reach, in cells — carried through
@@ -775,7 +783,14 @@ func attackFromBite(action monster.ActionData) (AttackProfile, error) {
 
 	ref := action.Ref
 	profile := AttackProfile{
-		Ref:         &ref,
+		Ref: &ref,
+		// BiteConfig carries no authored display name — every bite is just
+		// "the bite" — so this is a fixed label rather than read off
+		// content, the same way Reach below is a fixed value rather than a
+		// configured one. Kept non-empty for the same reason melee's Name
+		// is carried at all: a caller reporting what was swung (a beat
+		// line, a struck/missed event) reads this rather than a catalog.
+		Name:        "Bite",
 		AttackBonus: config.AttackBonus,
 		Damage:      copyDamagePools(config.Damage),
 		Gate:        config.SaveGate,

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -63,10 +63,11 @@ type AttackProfile struct {
 	// Name is the catalog's display name for Ref — "Longsword", "Unarmed
 	// Strike" — carried alongside it so a caller reporting what was swung
 	// (a beat line, a struck/missed event) never has to look the ref back
-	// up in a catalog of its own (rpg-toolkit#866). Populated by
-	// [AttackFromCharacter]; empty from [AttackFromMonsterAction] today —
-	// monster attackers do not yet reach a caller that reports this
-	// (v1 compiles CHARACTER attackers only, session.Attack's own doc).
+	// up in a catalog of its own (rpg-toolkit#866). Populated by both
+	// compilers: [AttackFromCharacter] reads it off the equipped weapon,
+	// and [AttackFromMonsterAction] carries the stat block's own authored
+	// name through for a melee action ("shortsword", "scimitar") or
+	// reports the fixed label "Bite" for a bite, which authors none.
 	Name string
 
 	// AttackBonus is added to the d20.


### PR DESCRIPTION
## Summary

`AttackFromMonsterAction` compiled both monster attack shapes (melee, bite) with `AttackProfile.Name` left `""`, even though `MeleeConfig.Name` ("shortsword", "scimitar", ...) is already authored and persisted. Harmless while nothing that compiled a monster's attack ever reported the name to a caller — but that stops being true with session's Striker (rpg-project#254), which records a monster's struck/missed beat with `encounter.AttackIdentity{Ref, Name, DamageType}` the same way a character's own swing already does. An empty Name there would read as a bug in the beat, not as the profile having genuinely none to give.

- `attackFromMelee` now carries `config.Name` onto the profile
- `attackFromBite` sets the fixed `"Bite"` label — the same treatment Reach already gets for a bite, since `BiteConfig` authors no name at all

## Test plan

- [x] TDD: added `TestMeleeNameCarriesTheAuthoredValue` and `TestBiteNameIsNotEmpty`, watched both fail RED against the unfixed compiler, watched them pass GREEN after the fix
- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./...` — full resolution suite green
- [x] `golangci-lint run ./...` — 0 issues
- [x] `gofmt -l .` — clean
- [x] `go mod tidy` — no diff
- [x] `./scripts/check-decisions.sh` — 45/45 ADRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu