### PR TITLE
encounter: a driven member's own killing blow must not abort EndTurn

### DIFF
--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -242,6 +242,25 @@ func (e *Encounter) appendClockBeat(payload map[string]interface{}) (uint64, err
 	return out.Seq, nil
 }
 
+// lastRecordedSeq returns the sequence of the most recently appended story
+// entry, or 0 if nothing has ever been appended (unreachable in practice —
+// Setup's own scene-opened beat is always first).
+//
+// Its one caller is driveOneMonsterTurn's own bubble-already-dissolved case:
+// a driven member whose killing blow just ended the fight has no
+// "turn-ended" beat of its own left to append (there is no bubble left to
+// end a turn IN), but the caller still needs an honest answer to "how far
+// did the story move," and the dissolution's own beat — already appended,
+// several calls down, inside the Record that noticed the kill — is the
+// truthful one.
+func (e *Encounter) lastRecordedSeq() uint64 {
+	next, err := e.story.NextSeq()
+	if err != nil || next == 0 {
+		return 0
+	}
+	return next - 1
+}
+
 // driveMonsterTurns advances bubble past every consecutive member with no
 // player, starting from its current Active member, stopping at the first
 // KindPlayer member.
@@ -291,6 +310,22 @@ func (e *Encounter) driveMonsterTurns(bubble *clock.Turn) (wrapped bool, lastSeq
 	// the most this loop could ever legitimately need, and hasPlayer above
 	// already guarantees it terminates well before then.
 	for i := 0; i < len(order); i++ {
+		// A member driven earlier in THIS SAME loop can have ended the fight
+		// with its own killing blow — see driveOneMonsterTurn's own doc.
+		// bubble is then idle, and idle is a state bubble.Active() refuses
+		// with ErrIdle. Order() never does (an idle clock answers with an
+		// empty slice, by its own contract), so it is the check that lets
+		// this loop notice "nothing is left to drive" and stop cleanly,
+		// rather than asking a dissolved clock whose turn it still thinks it
+		// is.
+		remaining, oerr := bubble.Order()
+		if oerr != nil {
+			return wrapped, lastSeq, fmt.Errorf("drive monster turns: %w", oerr)
+		}
+		if len(remaining) == 0 {
+			break
+		}
+
 		active, aerr := bubble.Active()
 		if aerr != nil {
 			return wrapped, lastSeq, fmt.Errorf("drive monster turns: %w", aerr)
@@ -366,6 +401,27 @@ func (e *Encounter) driveOneMonsterTurn(
 		if done {
 			break
 		}
+	}
+
+	// A step just executed (almost always a Strike) can have ended the fight
+	// out from under this very turn: [Encounter.noticeDown], reached through
+	// Record, dissolves a bubble that has run out of a side the instant it
+	// notices (rpg-toolkit#1078, ByDefeat) — and a driven member's own
+	// killing blow notices EXACTLY that. When it does, bubble is the same
+	// *clock.Turn this call has held throughout, now idle: there is nothing
+	// left to end, and nothing wrong — the "bubble-dissolved" beat that
+	// noticing already appended tells the whole story of why this member's
+	// own turn never explicitly closed. Calling bubble.End regardless would
+	// ask an idle clock to end a turn it no longer has, and play/clock
+	// refuses that with ErrIdle exactly as it should — which is what turned
+	// a driven monster's own killing blow into an error on the CALLER's
+	// verb (rpg-project#254's live walk, round 4) until this check existed.
+	stillRunning, cerr := bubble.Contains(&clock.ContainsInput{ID: active})
+	if cerr != nil {
+		return 0, false, fmt.Errorf("contains: %w", cerr)
+	}
+	if !stillRunning {
+		return e.lastRecordedSeq(), false, nil
 	}
 
 	out, eerr := bubble.End(&clock.EndInput{Actor: active})
@@ -1008,6 +1064,14 @@ type EndTurnOutput struct {
 	// unplayed members, this call already drove them forward via TurnDriver
 	// before returning (rpg-toolkit#1162): the caller never receives a Next
 	// nobody can act for.
+	//
+	// EXCEPT when a driven member's own turn ends the fight (its killing
+	// blow — rpg-toolkit#1078, ByDefeat — noticed while THIS call was still
+	// driving it forward): there is then no bubble left to name a Next
+	// turn IN, and Next reports Member instead — the caller who ended their
+	// own turn, now free again. A caller learns the fight actually ended,
+	// as it always has, from the "bubble-dissolved" beat this same call's
+	// own fan-out carries, not from a distinguishable value here.
 	Next MemberID
 
 	// RoundWrapped is true when this end, OR any unplayed member's pass this
@@ -1100,11 +1164,34 @@ func (e *Encounter) EndTurn(in *EndTurnInput) (*EndTurnOutput, error) {
 		if moreSeq != 0 {
 			lastSeq = moreSeq
 		}
-		active, aerr := bubble.Active()
-		if aerr != nil {
-			return nil, fmt.Errorf("end turn %q: %w", in.Member, aerr)
+
+		// The drive just run can have ended the fight this bubble was
+		// holding — a driven member's own killing blow, exactly as
+		// driveOneMonsterTurn's own doc describes. bubble.Active() refuses
+		// an idle clock with ErrIdle, so Order() is asked first: it never
+		// does (an idle clock's Order is an empty slice, not an error), and
+		// an empty one means there is no bubble left to ask whose turn it
+		// is.
+		remaining, oerr := bubble.Order()
+		if oerr != nil {
+			return nil, fmt.Errorf("end turn %q: %w", in.Member, oerr)
 		}
-		next = MemberID(active)
+		if len(remaining) == 0 {
+			// There is no "next" turn in a bubble that no longer exists.
+			// in.Member — who called this verb — is the honest answer: they
+			// are the one free again, exactly as a non-driven defeat already
+			// leaves the survivor (rpg-toolkit#1078). A caller learns the
+			// fight actually ended the way it always has: the
+			// "bubble-dissolved" beat this same call's own fan-out already
+			// carries, not a new field on this output.
+			next = in.Member
+		} else {
+			active, aerr := bubble.Active()
+			if aerr != nil {
+				return nil, fmt.Errorf("end turn %q: %w", in.Member, aerr)
+			}
+			next = MemberID(active)
+		}
 	}
 
 	return &EndTurnOutput{

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -778,20 +778,26 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathFindsTheNearestInRangeCellNotJu
 }
 
 // killerStriker wraps scriptedStriker's own outcome-recording, additionally
-// marking target down in standing BEFORE recording — the same order the real
-// session seam keeps (rpg-toolkit#1083: a swing's sheet is written before its
-// outcome is recorded), so the standing consult inside THIS SAME Record call
-// already sees the killing blow.
+// marking the STRUCK CALL'S OWN target down in standing BEFORE recording —
+// the same order the real session seam keeps (rpg-toolkit#1083: a swing's
+// sheet is written before its outcome is recorded), so the standing consult
+// inside THIS SAME Record call already sees the killing blow.
+//
+// Reads target from Strike's own argument rather than a field configured at
+// construction (Copilot, PR #1202 review): a fixed field the caller sets up
+// front is a value that can drift from what a future scene's driver actually
+// declares, silently marking the wrong member down. There is only ever one
+// honest answer to "who did this strike hit" — the one Strike itself was
+// called with.
 type killerStriker struct {
 	*scriptedStriker
 	standing *downList
-	target   encounter.MemberID
 }
 
 func (k *killerStriker) Strike(
 	ctx context.Context, enc *encounter.Encounter, attacker, target encounter.MemberID, action core.Ref,
 ) error {
-	k.standing.down = append(k.standing.down, k.target)
+	k.standing.down = append(k.standing.down, target)
 	return k.scriptedStriker.Strike(ctx, enc, attacker, target, action)
 }
 
@@ -819,7 +825,7 @@ func (s *MonsterTurnTestSuite) TestDrivenKillingBlowEndsTheDriveCleanly() {
 	}}
 	striker := &killerStriker{
 		scriptedStriker: &scriptedStriker{kind: encounter.OutcomeStruck},
-		standing:        standing, target: alice,
+		standing:        standing,
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -776,3 +776,93 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathFindsTheNearestInRangeCellNotJu
 	s.Equal([]spatial.Position{{X: 1, Y: 0}}, aliceSeen.Path,
 		"the nearest WALKABLE in-range cell is one step away, not several steps around the wall")
 }
+
+// killerStriker wraps scriptedStriker's own outcome-recording, additionally
+// marking target down in standing BEFORE recording — the same order the real
+// session seam keeps (rpg-toolkit#1083: a swing's sheet is written before its
+// outcome is recorded), so the standing consult inside THIS SAME Record call
+// already sees the killing blow.
+type killerStriker struct {
+	*scriptedStriker
+	standing *downList
+	target   encounter.MemberID
+}
+
+func (k *killerStriker) Strike(
+	ctx context.Context, enc *encounter.Encounter, attacker, target encounter.MemberID, action core.Ref,
+) error {
+	k.standing.down = append(k.standing.down, k.target)
+	return k.scriptedStriker.Strike(ctx, enc, attacker, target, action)
+}
+
+// TestDrivenKillingBlowEndsTheDriveCleanly reproduces rpg-project#254's live
+// walk anomaly #2 (the tomb evidence, round 4:
+// "drive monster turns \"skeleton-1\": end: end turn: clock is idle").
+//
+// A driven member's own strike can be the fight's own killing blow —
+// [Encounter.noticeDown], reached through Record (which Strike calls before
+// returning), dissolves the SAME bubble driveMonsterTurns is still mid-loop
+// over the instant it notices (rpg-toolkit#1078, ByDefeat) — before the loop
+// gets back around to closing THIS member's own turn out of it. bubble.End
+// then asked an idle clock to end a turn it no longer had, and play/clock's
+// own ErrIdle turned an entirely ordinary outcome — a monster winning the
+// fight it was in — into an error on the CALLER's own EndTurn. That is
+// exactly the asymmetry this file's own doc draws for a driver malfunction
+// (TestADriverMalfunctionAbortsTheWholeCall) versus everything else
+// (TestAttackOnOutOfReachTargetEndsTheTurnWithoutAborting and friends): only
+// a malfunction earns aborting the caller's verb, and the fight ending is
+// not one.
+func (s *MonsterTurnTestSuite) TestDrivenKillingBlowEndsTheDriveCleanly() {
+	standing := &downList{}
+	driver := &scriptedDriver{intents: []encounter.TurnIntent{
+		encounter.Attack{Target: alice, Action: testMeleeAction},
+	}}
+	striker := &killerStriker{
+		scriptedStriker: &scriptedStriker{kind: encounter.OutcomeStruck},
+		standing:        standing, target: alice,
+	}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: standing, Initiative: orderAsGiven{},
+		TurnDriver: driver, Striker: striker,
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 2}},
+			{
+				ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 3, Y: 2},
+				SpeedFeet: 30, Targeting: "closest",
+				Actions: []encounter.ActionView{
+					{Ref: testMeleeAction, Name: "Shortsword", ReachFeet: 5, Kind: "melee"},
+				},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	et, err := enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err, "a driven turn that wins the fight must not abort the caller's own EndTurn")
+	s.Equal(alice, et.Next,
+		"there is no bubble left to name a turn IN; EndTurnOutput.Next reports the caller instead")
+
+	clockOf, err := enc.ClockOf(&encounter.ClockOfInput{Member: alice})
+	s.Require().NoError(err)
+	s.Equal(encounter.ClockWorld, clockOf.Kind, "the bubble the killing blow ended left nobody still in it")
+
+	beats := s.clockBeats(enc, alice)
+	var sawStruck, sawDissolved bool
+	for _, b := range beats {
+		switch b["beat"] {
+		case "struck":
+			sawStruck = true
+		case "bubble-dissolved":
+			sawDissolved = true
+			s.Equal("defeat", b["cause"])
+		}
+	}
+	s.True(sawStruck, "the killing blow itself is on the record: %+v", beats)
+	s.True(sawDissolved, "and so is the fight it ended: %+v", beats)
+}


### PR DESCRIPTION
## Summary

- Fixes rpg-toolkit#1201 (sub-issue of rpg-project#254): a driven monster's
  own strike that ends the fight it was in (the last player going down,
  `noticeDown` -> `ByDefeat`) dissolves the bubble `driveMonsterTurns` is
  still mid-loop over, and the loop's own unconditional `bubble.End`/
  `bubble.Active()` calls afterward asked an idle clock for a turn it no
  longer had — surfacing `play/clock`'s `ErrIdle` as an error on the
  CALLER's own `EndTurn`, reproduced live in rpg-project#254's round-4 walk.
- Three call sites (`driveOneMonsterTurn`, `driveMonsterTurns`'s own loop,
  `EndTurn` itself) now check whether the bubble still holds an order
  before touching a verb that errors on idle, and treat "my own bubble
  is already gone" as the same graceful stop this loop already gives
  `Pass` and `ErrBadIntent` — not a driver malfunction.
- `EndTurnOutput.Next` gains one documented case: when the drive ends the
  fight it was running, `Next` reports the calling member (there is no
  bubble left to name a turn IN) instead of erroring.

## Test plan

- [x] `TestDrivenKillingBlowEndsTheDriveCleanly` added RED (first commit),
      reproduces the exact production error
      (`drive monster turns "goblin": end: end turn: clock is idle`)
- [x] Fix applied (second commit); full `rulebooks/dnd5e/encounter` suite
      green under `-race`
- [x] `gofmt`, `go vet`, `go mod tidy`, `golangci-lint run` clean
- [x] `gorelease` clean (suggests `v0.30.7`, no breaking changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu