### PR TITLE
encounter: a driven turn runs to completion under one budget (rpg-project#257)

### DIFF
--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -297,7 +297,7 @@ func (e *Encounter) bubbleHasPlayer(order []core.EntityID) bool {
 }
 
 func (e *Encounter) driveMonsterTurns(bubble *clock.Turn) (wrapped bool, lastSeq uint64, err error) {
-	// RE-ENTRANCY GUARD (rpg-toolkit#1206). driveMonsterTurns is the single
+	// RE-ENTRANCY GUARD (rpg-toolkit#1207). driveMonsterTurns is the single
 	// owner of driving a bubble forward, and this call may already be
 	// running deeper on THIS SAME Go call stack: a driven member's own
 	// Strike can down a teammate without deciding the fight, whose
@@ -1037,7 +1037,7 @@ func (e *Encounter) Transfer(in *TransferInput) (*TransferOutput, error) {
 		}
 		// Read BEFORE the clock-level move: whether the departing member
 		// was the one whose slot is about to need rescuing is a fact about
-		// the bubble as it stood a moment ago, not after (rpg-toolkit#1206).
+		// the bubble as it stood a moment ago, not after (rpg-toolkit#1207).
 		wasActive, aerr := bubble.Active()
 		if aerr != nil {
 			return nil, fmt.Errorf("transfer %q: %w", in.Member, aerr)
@@ -1060,15 +1060,18 @@ func (e *Encounter) Transfer(in *TransferInput) (*TransferOutput, error) {
 		// it reaches this same branch through Transfer.
 		//
 		// ONLY WHEN THE DEPARTING MEMBER GENUINELY WAS ACTIVE, though
-		// (rpg-toolkit#1206). A member spliced out of a bubble whose active
+		// (rpg-toolkit#1207). A member spliced out of a bubble whose active
 		// slot belongs to somebody else — most commonly a driven monster
 		// still mid-turn, reached here through its own Strike's noticeDown
 		// — leaves nothing stalled to rescue: the active member's own turn
 		// is already running and will end itself in the ordinary way.
 		// Driving again here would hand that still-running turn a second,
 		// undocumented one under a second, fresh budget — the exact defect
-		// TestADownedTeammateDoesNotHandTheDrivenMonsterASecondTurn (session
-		// package, rpg-toolkit#1205) found. driveMonsterTurns' own
+		// TestADownedTeammateDoesNotHandTheDrivenMonsterASecondTurn found,
+		// reproduced directly against the composition in
+		// rulebooks/dnd5e/encounter/monsterturn_test.go (encounter_test
+		// package) after first surfacing while writing the session
+		// package's own rpg-toolkit#1205. driveMonsterTurns' own
 		// re-entrancy guard (its doc) makes the same mistake impossible a
 		// second, structural way; this is the semantic one — the call
 		// this branch would otherwise be making is simply the wrong one to

--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -297,6 +297,24 @@ func (e *Encounter) bubbleHasPlayer(order []core.EntityID) bool {
 }
 
 func (e *Encounter) driveMonsterTurns(bubble *clock.Turn) (wrapped bool, lastSeq uint64, err error) {
+	// RE-ENTRANCY GUARD (rpg-toolkit#1206). driveMonsterTurns is the single
+	// owner of driving a bubble forward, and this call may already be
+	// running deeper on THIS SAME Go call stack: a driven member's own
+	// Strike can down a teammate without deciding the fight, whose
+	// noticeDown -> Transfer(id, ClockWorld) -> driveIfStillRunning reaches
+	// back here while the OUTER driveOneMonsterTurn call is still mid-turn,
+	// budget not yet spent. Without this check that reentry would hand the
+	// SAME still-acting monster a second, undocumented turn under a fresh
+	// budget — exactly the defect this guard exists to make impossible
+	// rather than merely unlikely. A nested call is a no-op the caller
+	// ignores: the outer call already owns driving this bubble and will
+	// finish it once its own Strike call returns.
+	if e.driving {
+		return false, 0, nil
+	}
+	e.driving = true
+	defer func() { e.driving = false }()
+
 	order, err := bubble.Order()
 	if err != nil {
 		return false, 0, fmt.Errorf("drive monster turns: %w", err)
@@ -1017,6 +1035,15 @@ func (e *Encounter) Transfer(in *TransferInput) (*TransferOutput, error) {
 		if bubble == nil {
 			return nil, fmt.Errorf("transfer %q: %w", in.Member, ErrNoBubble)
 		}
+		// Read BEFORE the clock-level move: whether the departing member
+		// was the one whose slot is about to need rescuing is a fact about
+		// the bubble as it stood a moment ago, not after (rpg-toolkit#1206).
+		wasActive, aerr := bubble.Active()
+		if aerr != nil {
+			return nil, fmt.Errorf("transfer %q: %w", in.Member, aerr)
+		}
+		departedWasActive := wasActive == core.EntityID(in.Member)
+
 		if _, terr := clock.Transfer(&clock.TransferInput{
 			From: bubble,
 			To:   e.clock,
@@ -1031,8 +1058,25 @@ func (e *Encounter) Transfer(in *TransferInput) (*TransferOutput, error) {
 		// slot is driven forward if they have no player (rpg-toolkit#1162) —
 		// this is how noticeDown's splice of a fallen body stays safe, since
 		// it reaches this same branch through Transfer.
-		if derr := e.driveIfStillRunning(bubble); derr != nil {
-			return nil, fmt.Errorf("transfer %q: %w", in.Member, derr)
+		//
+		// ONLY WHEN THE DEPARTING MEMBER GENUINELY WAS ACTIVE, though
+		// (rpg-toolkit#1206). A member spliced out of a bubble whose active
+		// slot belongs to somebody else — most commonly a driven monster
+		// still mid-turn, reached here through its own Strike's noticeDown
+		// — leaves nothing stalled to rescue: the active member's own turn
+		// is already running and will end itself in the ordinary way.
+		// Driving again here would hand that still-running turn a second,
+		// undocumented one under a second, fresh budget — the exact defect
+		// TestADownedTeammateDoesNotHandTheDrivenMonsterASecondTurn (session
+		// package, rpg-toolkit#1205) found. driveMonsterTurns' own
+		// re-entrancy guard (its doc) makes the same mistake impossible a
+		// second, structural way; this is the semantic one — the call
+		// this branch would otherwise be making is simply the wrong one to
+		// make at all when nothing is actually stalled.
+		if departedWasActive {
+			if derr := e.driveIfStillRunning(bubble); derr != nil {
+				return nil, fmt.Errorf("transfer %q: %w", in.Member, derr)
+			}
 		}
 	default:
 		return nil, fmt.Errorf("transfer %q to %q: %w", in.Member, in.To, ErrBadClock)

--- a/rulebooks/dnd5e/encounter/drivereentrancy_internal_test.go
+++ b/rulebooks/dnd5e/encounter/drivereentrancy_internal_test.go
@@ -38,7 +38,7 @@ func threePlayerMonsterBubble(t *testing.T) *Encounter {
 }
 
 // TestNestedDriveMonsterTurnsWhileOneIsRunningIsANoOp pins guard 2 of
-// rpg-toolkit#1206's fix directly against driveMonsterTurns, independent of
+// rpg-toolkit#1207's fix directly against driveMonsterTurns, independent of
 // how a caller might reach a nested call in practice (Transfer's own
 // path is guard 1's — pinned separately below).
 //
@@ -78,7 +78,7 @@ func TestNestedDriveMonsterTurnsWhileOneIsRunningIsANoOp(t *testing.T) {
 }
 
 // TestTransferOfANonActiveMemberNeverDrives pins guard 1 of
-// rpg-toolkit#1206's fix: Transfer's ClockWorld case must not call
+// rpg-toolkit#1207's fix: Transfer's ClockWorld case must not call
 // driveIfStillRunning for a departing member who was never the bubble's
 // own active one — there is nothing stalled to rescue.
 //

--- a/rulebooks/dnd5e/encounter/drivereentrancy_internal_test.go
+++ b/rulebooks/dnd5e/encounter/drivereentrancy_internal_test.go
@@ -1,0 +1,140 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/clock"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// threePlayerMonsterBubble is alice, bob and goblin, in that initiative
+// order (orderAsGiven preserves Members' own literal order), sharing one
+// room so first light forms the bubble immediately.
+func threePlayerMonsterBubble(t *testing.T) *Encounter {
+	t.Helper()
+	enc, err := NewEncounter(&SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: passDriver{}, Striker: passStriker{},
+		Field: FieldInput{
+			Canvas: CanvasInput{Void: VoidIsOpaque()},
+			Rooms:  []RoomInput{{ID: "room-1", Width: 8, Height: 8}},
+		},
+		Members: []MemberInput{
+			{ID: "alice", Kind: KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: KindPlayer, Room: "room-1", Position: spatial.Position{X: 2, Y: 1}},
+			{ID: "goblin", Kind: KindMonster, Room: "room-1", Position: spatial.Position{X: 3, Y: 1}},
+		},
+		Endings: []EndingInput{{Key: "called", Trigger: TriggerExternal{}}},
+	})
+	require.NoError(t, err)
+	require.Len(t, enc.bubbles, 1, "first light forms the bubble")
+	return enc
+}
+
+// TestNestedDriveMonsterTurnsWhileOneIsRunningIsANoOp pins guard 2 of
+// rpg-toolkit#1206's fix directly against driveMonsterTurns, independent of
+// how a caller might reach a nested call in practice (Transfer's own
+// path is guard 1's — pinned separately below).
+//
+// goblin is put into "active, and genuinely UNDRIVEN" by ending bob's own
+// turn through play/clock's OWN End primitive rather than
+// [Encounter.EndTurn] — the only way to reach that state at all, since
+// every public path (EndTurn, form, Transfer) drives an unplayed leading
+// member to completion before returning; there is no caller-observable
+// moment where an unplayed member is active and waiting.
+func TestNestedDriveMonsterTurnsWhileOneIsRunningIsANoOp(t *testing.T) {
+	enc := threePlayerMonsterBubble(t)
+	bubble := enc.bubbles[0]
+
+	_, err := enc.EndTurn(&EndTurnInput{Member: "alice"})
+	require.NoError(t, err)
+
+	_, err = bubble.End(&clock.EndInput{Actor: "bob"})
+	require.NoError(t, err)
+
+	active, err := bubble.Active()
+	require.NoError(t, err)
+	require.Equal(t, core.EntityID("goblin"), active, "goblin is active and undriven — the state this guard is about")
+
+	// Simulate an outer driveMonsterTurns call already owning this
+	// encounter's own drive — exactly the state Strike -> Record ->
+	// noticeDown -> Transfer -> driveIfStillRunning reaches mid-Strike.
+	enc.driving = true
+	wrapped, seq, err := enc.driveMonsterTurns(bubble)
+	require.NoError(t, err)
+	require.False(t, wrapped)
+	require.Zero(t, seq, "a re-entrant call must not touch the story at all")
+
+	stillActive, err := bubble.Active()
+	require.NoError(t, err)
+	require.Equal(t, core.EntityID("goblin"), stillActive,
+		"goblin's own turn is untouched — the nested call was a no-op, not a second drive")
+}
+
+// TestTransferOfANonActiveMemberNeverDrives pins guard 1 of
+// rpg-toolkit#1206's fix: Transfer's ClockWorld case must not call
+// driveIfStillRunning for a departing member who was never the bubble's
+// own active one — there is nothing stalled to rescue.
+//
+// goblin is put into "active, undriven" the same way the sibling test
+// does. alice — NOT active, still sitting in the order — is then
+// transferred out. Without this guard, the old unconditional call would
+// still fire and drive goblin's own turn to completion (passDriver ->
+// Pass), which is exactly the observable difference this test checks for.
+func TestTransferOfANonActiveMemberNeverDrives(t *testing.T) {
+	enc := threePlayerMonsterBubble(t)
+	bubble := enc.bubbles[0]
+
+	_, err := enc.EndTurn(&EndTurnInput{Member: "alice"})
+	require.NoError(t, err)
+
+	_, err = bubble.End(&clock.EndInput{Actor: "bob"})
+	require.NoError(t, err)
+
+	active, err := bubble.Active()
+	require.NoError(t, err)
+	require.Equal(t, core.EntityID("goblin"), active, "goblin is active and undriven — the state this guard is about")
+
+	_, err = enc.Transfer(&TransferInput{Member: "alice", To: ClockWorld})
+	require.NoError(t, err)
+
+	stillActive, err := bubble.Active()
+	require.NoError(t, err)
+	require.Equal(t, core.EntityID("goblin"), stillActive,
+		"transferring a non-active member must never drive — goblin's own turn is still exactly where it was")
+}
+
+// TestTransferOfTheActiveMemberStillRescuesAnUnplayedSuccessor pins that
+// guard 1 does not OVER-restrict: rpg-toolkit#1162's own rescue — the
+// departing member genuinely WAS active, and whoever inherits the slot has
+// no player — must still fire.
+func TestTransferOfTheActiveMemberStillRescuesAnUnplayedSuccessor(t *testing.T) {
+	enc := threePlayerMonsterBubble(t)
+	bubble := enc.bubbles[0]
+
+	_, err := enc.EndTurn(&EndTurnInput{Member: "alice"})
+	require.NoError(t, err)
+
+	active, err := bubble.Active()
+	require.NoError(t, err)
+	require.Equal(t, core.EntityID("bob"), active)
+
+	// bob himself is the active member. Transferring him out hands the
+	// active slot to goblin, who has no player — exactly rpg-toolkit#1162's
+	// own stalled-slot case.
+	_, err = enc.Transfer(&TransferInput{Member: "bob", To: ClockWorld})
+	require.NoError(t, err)
+
+	// goblin's own turn (passDriver -> Pass) already resolved and handed
+	// back to alice — the only player left in the now two-member order.
+	stillActive, err := bubble.Active()
+	require.NoError(t, err)
+	require.Equal(t, core.EntityID("alice"), stillActive,
+		"the rescue must still fire when the departing member genuinely was active")
+}

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -204,6 +204,29 @@ type Encounter struct {
 	// Required at both constructors for the same reason turnDriver is; see
 	// [Striker].
 	striker Striker
+
+	// driving is true for the duration of ONE driveMonsterTurns call, at
+	// any depth of Go call stack — runtime state, never persisted (there is
+	// no stack mid-verb for ToData to capture, and none is needed: a fresh
+	// load always starts false).
+	//
+	// The load-bearing half of rpg-toolkit#1206's fix, alongside Transfer's
+	// own active-member guard (see its own doc). A driven turn's own Strike
+	// can splice a downed teammate out through Transfer, whose "the
+	// departing member may have been active" rescue (rpg-toolkit#1162) is a
+	// real need for a genuinely stalled slot — but nothing before this flag
+	// stopped that rescue firing AGAIN for the SAME still-mid-turn monster
+	// its own Strike call is nested inside, handing it a second,
+	// undocumented turn under a second, fresh budget.
+	//
+	// driveMonsterTurns is the single owner of driving a bubble forward: a
+	// driven turn runs to completion under one budget, and nothing that
+	// happens inside it starts another. A nested call reaching it while one
+	// is already running on this *Encounter is therefore a no-op — the
+	// outer call already owns it and will finish it; see
+	// driveMonsterTurns's own doc for the check itself.
+	driving bool
+
 	// endings holds declared endings in Setup order. Evaluation is
 	// deterministic (law C8), but NOT globally "first-declared-wins":
 	// for a single action (Step, Join) declaration order is

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -210,7 +210,7 @@ type Encounter struct {
 	// no stack mid-verb for ToData to capture, and none is needed: a fresh
 	// load always starts false).
 	//
-	// The load-bearing half of rpg-toolkit#1206's fix, alongside Transfer's
+	// The load-bearing half of rpg-toolkit#1207's fix, alongside Transfer's
 	// own active-member guard (see its own doc). A driven turn's own Strike
 	// can splice a downed teammate out through Transfer, whose "the
 	// departing member may have been active" rescue (rpg-toolkit#1162) is a

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -872,3 +872,130 @@ func (s *MonsterTurnTestSuite) TestDrivenKillingBlowEndsTheDriveCleanly() {
 	s.True(sawStruck, "the killing blow itself is on the record: %+v", beats)
 	s.True(sawDissolved, "and so is the fight it ended: %+v", beats)
 }
+
+// killEveryoneStandingDriver attacks the first standing, in-reach seen
+// member (Seen is sorted by ID — C8 — so this is deterministic), or closes
+// on the nearest standing seen member's own precomputed Path when none is
+// yet in reach, or passes when nobody standing remains. The shape a hostile
+// monster's own AI takes when a fresh target comes into reach mid-turn — no
+// caller-declared script, so the ONLY thing standing between "one attack"
+// and "attack everyone available" is this composition's own budget.
+type killEveryoneStandingDriver struct {
+	action core.Ref
+}
+
+func (d killEveryoneStandingDriver) Act(view encounter.MonsterView) (encounter.TurnIntent, error) {
+	for _, sm := range view.Seen {
+		if sm.Standing && sm.InReach[d.action] {
+			return encounter.Attack{Target: sm.ID, Action: d.action}, nil
+		}
+	}
+	for _, sm := range view.Seen {
+		if sm.Standing && len(sm.Path) > 0 {
+			return encounter.Move{Path: sm.Path}, nil
+		}
+	}
+	return encounter.Pass{}, nil
+}
+
+// TestADownedTeammateDoesNotHandTheDrivenMonsterASecondTurn is the RED
+// repro for the defect found writing rpg-project#257's two-player proof
+// (rpg-toolkit#1205): a driven monster that downs ONE of two players
+// WITHOUT deciding the fight (the other still stands) must still get
+// exactly the one attack plus speed its own turn is budgeted — never a
+// second, undocumented turn.
+//
+// alice stands adjacent to goblin (in reach at rest); bob stands two cells
+// off (one move short of reach). killEveryoneStandingDriver, given the
+// chance, attacks whoever it can reach — alice first (Seen's own ID sort),
+// then would close on and strike bob too if driveOneMonsterTurn's budget
+// ever restarted mid-turn.
+//
+// Root cause (traced, not guessed): [Encounter.noticeDown], on downing
+// alice — the fight not yet decided, bob still standing — calls
+// [Encounter.Transfer](alice, ClockWorld) to splice her out. Transfer's
+// ClockWorld case unconditionally calls driveIfStillRunning(bubble), whose
+// own doc names its actual job: "the departing member may have been
+// active; whoever inherited the slot is driven forward if they have no
+// player" (rpg-toolkit#1162). alice is NOT the active member here — goblin
+// is, mid-Strike, mid-driveOneMonsterTurn, budget not yet spent —
+// driveIfStillRunning does not check that, asks bubble.Active(), finds
+// goblin (nothing has ended ITS turn), and re-enters driveMonsterTurns: a
+// brand-new driveOneMonsterTurn(goblin) call, nested inside the still-
+// running outer one, with a completely fresh TurnBudget{AttacksLeft:1,
+// MovementFeet:speed}.
+//
+// killerStriker marks EVERY struck target down unconditionally (its own
+// doc), so bob's own strike — if the bug lets it happen — also decides the
+// fight and dissolves the bubble; asserted against directly rather than
+// inferred, so this test is unambiguous about what "the bug" produced.
+func (s *MonsterTurnTestSuite) TestADownedTeammateDoesNotHandTheDrivenMonsterASecondTurn() {
+	standing := &downList{}
+	driver := killEveryoneStandingDriver{action: testMeleeAction}
+	inner := &scriptedStriker{kind: encounter.OutcomeStruck}
+	striker := &killerStriker{scriptedStriker: inner, standing: standing}
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: standing, Initiative: orderAsGiven{},
+		TurnDriver: driver, Striker: striker,
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: room1, Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 5, Y: 5}},
+			{ID: bob, Kind: encounter.KindPlayer, Room: room1, Position: spatial.Position{X: 2, Y: 5}},
+			{
+				ID: goblin, Kind: encounter.KindMonster, Room: room1, Position: spatial.Position{X: 4, Y: 5},
+				SpeedFeet: 30, Targeting: "closest",
+				Actions: []encounter.ActionView{
+					{Ref: testMeleeAction, Name: "Shortsword", ReachFeet: 5, Kind: "melee"},
+				},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	// alice's own turn, first in the order (orderAsGiven preserves Members'
+	// literal order): nothing to drive, both other members are a player and
+	// a not-yet-active monster.
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	// bob's own turn ends and hands to goblin — driven, entirely inside
+	// this one call.
+	et, err := enc.EndTurn(&encounter.EndTurnInput{Member: bob})
+	s.Require().NoError(err, "a driven turn that downs a teammate without deciding the fight must not abort the caller's own EndTurn")
+
+	// The core claim: exactly one attack. Two IS the bug this test pins RED
+	// against.
+	s.Require().Len(inner.calls, 1,
+		"goblin's own turn is budgeted for exactly one attack — a second Strike call means a second, undocumented turn happened")
+	s.Equal(alice, inner.calls[0].Target, "the one attack goblin gets lands on alice — Seen's own ID sort puts her first")
+
+	// bob was never touched: not attacked, not marked down.
+	s.NotContains(standing.down, bob, "bob must never be struck by a turn budgeted for one attack against someone already in reach")
+
+	// Movement spent across the WHOLE driven-turn call — including any
+	// nested re-entry — must never exceed what ONE turn's own speed
+	// affords. A single well-behaved move (one cell, closing on alice's own
+	// adjacency needs none) costs at most 5 of goblin's 30 feet here; the
+	// bug's own nested budget would spend MORE by restarting movement
+	// alongside a second attack it should never have been offered.
+	var movedCells int
+	for _, b := range s.clockBeats(enc, alice) {
+		if b["beat"] == "moved" && b["member"] == string(goblin) {
+			movedCells++
+		}
+	}
+	s.LessOrEqual(movedCells*5, 30, "goblin's own turn must not spend more feet than its own 30-foot speed affords")
+
+	// The fight is still running, with bob still in it: alice's down did
+	// not decide it, and goblin's own turn — however many attacks it
+	// should have gotten — ends normally and hands back to whoever is next.
+	clockOf, err := enc.ClockOf(&encounter.ClockOfInput{Member: bob})
+	s.Require().NoError(err)
+	s.Equal(encounter.ClockTurn, clockOf.Kind, "bob is untouched and the fight he is in must still be running")
+	s.Equal(bob, et.Next, "goblin's own turn-ended wraps the two-member order (alice spliced) straight back to bob")
+}


### PR DESCRIPTION
## Summary

Closes #1207 (sub-issue of rpg-project#257). Found writing rpg-project#257 slice 3's two-player proof (rpg-toolkit#1205): a driven monster's own strike downing ONE of two players — the fight not decided, the other still standing — hands that same monster a full, undocumented SECOND turn. Unreachable with one player.

Root cause: `noticeDown`'s `Transfer(id, ClockWorld)` (standing.go) unconditionally invokes `driveIfStillRunning` (clocks.go) even when the departing member was NOT the bubble's own active one — its rescue (rpg-toolkit#1162) does not apply, but nothing checked that before re-entering `driveMonsterTurns` for the SAME still-mid-turn monster its own Strike call is nested inside.

Two independent guards, both individually tested and verified to actually discriminate (each disabled in turn against its own dedicated test, confirmed failing, restored):

1. `Transfer`'s `ClockWorld` case only calls `driveIfStillRunning` when the departing member genuinely WAS the bubble's active member before the transfer.
2. `driveMonsterTurns` gained a re-entrancy guard (`Encounter.driving`) — a nested invocation while one is already running is a no-op the caller ignores.

Documented together as the contract: "a driven turn runs to completion under one budget, and nothing that happens inside it starts another."

## Test plan

- [x] `TestADownedTeammateDoesNotHandTheDrivenMonsterASecondTurn` — RED (previous commit) then GREEN
- [x] `TestTransferOfANonActiveMemberNeverDrives`, `TestNestedDriveMonsterTurnsWhileOneIsRunningIsANoOp` — each guard's own test, each verified to fail when its own guard is disabled
- [x] `TestTransferOfTheActiveMemberStillRescuesAnUnplayedSuccessor` — guard 1 does not over-restrict rpg-toolkit#1162's own rescue
- [x] Full `rulebooks/dnd5e/encounter` suite green under `-race`, including #1202's `TestDrivenKillingBlowEndsTheDriveCleanly` and every #1162 Exit-based test — unaffected
- [x] `gofmt`, `goimports`, `go vet`, `go mod tidy`, `golangci-lint run` clean
- [x] `./scripts/check-decisions.sh` clean (45/45 ADRs, unaffected)
- [x] `gorelease` clean — suggests `rulebooks/dnd5e/encounter/v0.30.8` (patch, no API changes)

## Next

rpg-project#257's session-level two-player proof (rpg-toolkit#1205, PR #1206) pins this tag next and writes the killing-blow case (e) against it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu
