### PR TITLE
feat(session)!: Story returns the same typed Events the stream publishes

### DIFF
--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -5,7 +5,6 @@ package session
 
 import (
 	"github.com/KirkDiggler/rpg-toolkit/play/intel"
-	"github.com/KirkDiggler/rpg-toolkit/play/record"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -186,35 +185,6 @@ func projectSeen(channel intel.Channel, payload []byte, downed bool) *Seen {
 		standing = StandingDowned
 	}
 	return &Seen{Position: pos, Standing: standing}
-}
-
-// projectStory drops each entry's audience roster deliberately.
-//
-// A story is queried by one viewer, and the roster names every OTHER viewer a
-// beat was addressed to. Handing that back would tell Alice which members
-// exist and were present for something — including members she has never
-// perceived, and members in rooms she has never entered. The audience is a
-// delivery rule, not story content, and it is the composition's business
-// rather than the host's.
-func projectStory(in []record.Entry) []StoryEntry {
-	out := make([]StoryEntry, 0, len(in))
-	for _, e := range in {
-		var tags map[string]string
-		if len(e.Tags) > 0 {
-			tags = make(map[string]string, len(e.Tags))
-			for k, v := range e.Tags {
-				tags[k] = v
-			}
-		}
-		out = append(out, StoryEntry{
-			Seq:         e.Seq,
-			At:          e.At,
-			Correlation: e.Correlation,
-			Tags:        tags,
-			Payload:     append([]byte(nil), e.Payload...),
-		})
-	}
-	return out
 }
 
 func projectMember(in encounter.Member) Member {

--- a/rulebooks/dnd5e/session/convert_test.go
+++ b/rulebooks/dnd5e/session/convert_test.go
@@ -58,7 +58,10 @@ var projectedPairs = []struct {
 	{"Member", encounter.Member{}, session.Member{}},
 	{"MemberOutcome", encounter.MemberOutcome{}, session.MemberOutcome{}},
 	{"Sighting", intel.Holding{}, session.Sighting{}},
-	{"StoryEntry", record.Entry{}, session.StoryEntry{}},
+	// An Event, not a StoryEntry: rpg-api-protos#239 deleted StoryEntry, and
+	// Manager.Story now returns the SAME Event projectEvents builds for the
+	// live stream (projectEntry, events.go) — one projection, audited once.
+	{"Event", record.Entry{}, session.Event{}},
 }
 
 // renamed lists inner fields carried across under a DIFFERENT name, each with

--- a/rulebooks/dnd5e/session/economy_test.go
+++ b/rulebooks/dnd5e/session/economy_test.go
@@ -192,7 +192,7 @@ func (s *EconomySuite) storedEconomy() *character.ActionEconomyData {
 	return stored.ActionEconomy
 }
 
-func (s *EconomySuite) story() []session.StoryEntry {
+func (s *EconomySuite) story() []session.Event {
 	s.T().Helper()
 	out, err := s.mgr.Story(context.Background(), &session.StoryInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/events.go
+++ b/rulebooks/dnd5e/session/events.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/KirkDiggler/rpg-toolkit/play/record"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
@@ -124,21 +125,47 @@ func (m *Manager) projectEvents(
 		}
 
 		for _, entry := range entries {
-			kind, body := decodeBeat(entry.Payload)
-			events = append(events, Event{
-				Session:     scope.session,
-				Seq:         entry.Seq,
-				At:          entry.At,
-				Correlation: entry.Correlation,
-				Recipient:   string(member),
-				Kind:        kind,
-				Payload:     append([]byte(nil), entry.Payload...),
-				Body:        body,
-			})
+			events = append(events, projectEntry(scope.session, string(member), entry))
 		}
 	}
 
 	return events
+}
+
+// projectEntry turns one story-log entry into the Event it becomes for one
+// recipient — the SAME projection whether the entry reaches a client live
+// (projectEvents, moments after Record) or later, on catch-up ([Manager.Story]).
+//
+// One function, two call sites, is the whole mechanism behind rpg-api-protos
+// #239's ruling: live delivery and a Story catch-up are byte-equal for the
+// same seq because nothing else in this package is allowed to build an Event
+// any other way. Before this, Story returned a thinner StoryEntry with the
+// raw payload and no typed Kind or Body, so a client that noticed a gap and
+// re-queried Story got a shape it had to decode a second, different way —
+// exactly the drift #239 found live in the debug feed (kind=UNKNOWN
+// body=null on every caught-up entry).
+func projectEntry(session, recipient string, e record.Entry) Event {
+	kind, body := decodeBeat(e.Payload)
+
+	var tags map[string]string
+	if len(e.Tags) > 0 {
+		tags = make(map[string]string, len(e.Tags))
+		for k, v := range e.Tags {
+			tags[k] = v
+		}
+	}
+
+	return Event{
+		Session:     session,
+		Seq:         e.Seq,
+		At:          e.At,
+		Correlation: e.Correlation,
+		Tags:        tags,
+		Recipient:   recipient,
+		Kind:        kind,
+		Payload:     append([]byte(nil), e.Payload...),
+		Body:        body,
+	}
 }
 
 // decodeBeat determines a beat's wire EventKind and, for the kinds this

--- a/rulebooks/dnd5e/session/events.go
+++ b/rulebooks/dnd5e/session/events.go
@@ -177,22 +177,6 @@ func projectEntry(session, recipient string, e record.Entry) Event {
 // LoadJSON's own routing already uses for conditions and features elsewhere
 // in this codebase.
 //
-// An unrecognised beat, or one whose declared kind decodes to a shape this
-// build's struct does not match, becomes (EventUnknown, nil) rather than
-// being dropped. A client that receives something it cannot interpret still
-// learns its sequence advanced, which keeps gap-detection working; dropping
-// it would manufacture a hole and send every client into a resync it did
-// not need. It also means a newer composition can add beats without older
-// clients losing their place.
-// decodeBeat determines a beat's wire EventKind and, for the kinds this
-// version types, its typed EventBody — DELETING kindOf's own JSON sniffing
-// (rpg-toolkit#941). It is still the one place this package interprets a
-// payload rather than passing it through: the composition's own "beat" key
-// is a DECLARED kind (every append site in encounter names it explicitly),
-// not content this function guesses at, the same peek-then-dispatch pattern
-// LoadJSON's own routing already uses for conditions and features elsewhere
-// in this codebase.
-//
 // KIND AND BODY ARE TWO SEPARATE QUESTIONS, on purpose. kindFor answers the
 // first from "beat" alone and is total over every string the composition
 // can write there; bodyFor attempts the second, and a payload whose other

--- a/rulebooks/dnd5e/session/monster_turn_test.go
+++ b/rulebooks/dnd5e/session/monster_turn_test.go
@@ -477,6 +477,72 @@ func (s *MonsterTurnTestSuite) TestRoundTwoStruckReachesTheLiveSubscriber() {
 		"the struck event's Recipient must be exactly the string Join was called with")
 }
 
+// (g) Live delivery and a Story catch-up are the SAME projection of the
+// same story-log entries, entry by entry, for a driven monster turn —
+// rpg-api-protos#239's ruling (rpg-project#257 slice 3), and the reason
+// [projectEntry] exists: one producer, not two mappings that happen to
+// agree today. The debug feed found this broken as kind=UNKNOWN body=null
+// on every caught-up entry while the same beats arrived live typed
+// correctly (moved, missed, ...); a client that notices a gap and
+// re-queries Story from FromSeq:1 must see exactly what a live subscriber
+// already received.
+//
+// A driven monster turn is the fixture rather than a single Move, because
+// it is the shape #239 was found broken under, and because it exercises
+// several kinds at once (joined, bubble-formed, moved, struck-or-missed,
+// turn-ended) rather than one kind that might happen to survive both paths
+// by accident.
+func (s *MonsterTurnTestSuite) TestLiveDeliveryAndStoryCatchUpAreByteEqual() {
+	ctx := context.Background()
+	stream := &fakeStream{}
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, TurnDriver: session.Behavior(),
+		Sessions: s.sessions, Encounters: s.encounters,
+		Characters: newFakeCharacters(armedFighter("fighter")),
+		Events:     stream,
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.StartSession(ctx, &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: tombRoom(12, 6),
+	})
+	s.Require().NoError(err)
+
+	_, err = mgr.Join(ctx, &session.JoinInput{
+		Session: "sess", Member: "fighter", Position: spatial.Position{X: 0, Y: 0},
+	})
+	s.Require().NoError(err)
+
+	spawned, err := mgr.Spawn(ctx, &session.SpawnInput{
+		Session: "sess", ID: "skel-1", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 4, Y: 0}, // four cells off: closes, then swings (TestSkeletonClosesAndAttacks)
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(spawned.Formed, "the skeleton's driven turn is this test's whole point")
+
+	_, err = mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter"})
+	s.Require().NoError(err, "the skeleton's whole turn — move, strike, end — drives inside this one call")
+
+	// live is everything the fake stream delivered to fighter across the
+	// WHOLE scene, join through the driven turn — never reset — so it lines
+	// up against Story{FromSeq:1}, which answers from the very first entry
+	// fighter's own audience appears in.
+	var live []session.Event
+	for _, e := range stream.published {
+		if e.Recipient == "fighter" {
+			live = append(live, e)
+		}
+	}
+	s.Require().NotEmpty(live, "join, spawn and the driven turn must all have addressed fighter")
+
+	caughtUp, err := mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "fighter", FromSeq: 1})
+	s.Require().NoError(err)
+
+	s.Equal(live, caughtUp,
+		"live delivery and Story{FromSeq:1} catch-up must be the SAME projection, entry by "+
+			"entry — kind, typed Body and Tags included — not two mappings that merely agree today")
+}
+
 // reachlessAttacker always declares an attack against the fighter using the
 // first action it is told about, regardless of whether it is anywhere near
 // reach — (c)'s bad intent, by construction rather than by accident.

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -242,14 +242,18 @@ func (m *Manager) View(ctx context.Context, in *ViewInput) ([]Sighting, error) {
 }
 
 // Story returns the beats a member has witnessed, from FromSeq onward
-// inclusive.
+// inclusive, projected exactly as a live [EventStream] subscriber would have
+// received them: same Kind, same typed Body, same Tags — one projection
+// ([projectEntry]) for both paths, so a client that notices a gap and
+// re-queries Story sees byte-equal entries for the same seq rather than a
+// second, thinner shape it must decode differently (rpg-api-protos#239).
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
 // ErrNoEncounter, ErrNoMember, or ErrStoryTrimmed when the requested resume
 // point has aged out of the retention window — in which case the caller must
 // resync from zero rather than resume, since a short answer would be
 // indistinguishable from a complete one.
-func (m *Manager) Story(ctx context.Context, in *StoryInput) ([]StoryEntry, error) {
+func (m *Manager) Story(ctx context.Context, in *StoryInput) ([]Event, error) {
 	if in == nil {
 		return nil, fmt.Errorf("story: %w", ErrNilInput)
 	}
@@ -271,7 +275,15 @@ func (m *Manager) Story(ctx context.Context, in *StoryInput) ([]StoryEntry, erro
 		return nil, fmt.Errorf("story: %w", translate(err))
 	}
 
-	return projectStory(entries), nil
+	// projectEntry, not a second mapping: catch-up must be byte-equal to
+	// what a live subscriber received for the same seq (rpg-api-protos#239).
+	// The requesting member IS the recipient — Story asks after one's own
+	// story, there is no other audience to address it to.
+	events := make([]Event, 0, len(entries))
+	for _, e := range entries {
+		events = append(events, projectEntry(in.Session, in.Member, e))
+	}
+	return events, nil
 }
 
 // open loads a session and reconstitutes the encounter it points at.

--- a/rulebooks/dnd5e/session/read_test.go
+++ b/rulebooks/dnd5e/session/read_test.go
@@ -214,7 +214,7 @@ func (s *ReadTestSuite) TestStoryOmitsTheAudienceRoster() {
 	s.Require().NoError(err)
 	s.Require().NotEmpty(entries, "setup records a scene-opened beat")
 
-	// If StoryEntry ever grows an Audience field, this assertion's premise is
+	// If Event ever grows an Audience field, this assertion's premise is
 	// gone and the reflection below reports it.
 	for _, field := range structFields(entries[0]) {
 		s.NotEqual("Audience", field,

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -566,10 +566,11 @@ type Event struct {
 	Correlation string `json:"correlation,omitempty"`
 
 	// Tags is queryable metadata describing the beat, carried unchanged from
-	// the story-log entry this event was projected from — the same map
-	// StoryEntry alone used to carry before rpg-api-protos#239: a client
-	// resolving a gap by re-querying Story now gets the identical Tags a
-	// live subscriber already had, rather than a second, thinner shape.
+	// the story-log entry this event was projected from. Before
+	// rpg-api-protos#239 only a Story catch-up carried this field; a live
+	// subscriber now gets the identical Tags too, so a client resolving a
+	// gap by re-querying Story is never handed a thinner answer than what
+	// arrived live.
 	Tags map[string]string `json:"tags,omitempty"`
 
 	// Recipient is the member this projection is addressed to.

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -397,25 +397,6 @@ type Sighting struct {
 	Status string `json:"status,omitempty"`
 }
 
-// StoryEntry is one beat of what an observer has witnessed.
-type StoryEntry struct {
-	// Seq is the beat's sequence: monotonic, gapless, never renumbered. A
-	// client that notices a gap has missed a beat and should re-query.
-	Seq uint64 `json:"seq"`
-
-	// At is the clock reading when the beat was recorded.
-	At uint64 `json:"at,omitempty"`
-
-	// Correlation groups cause and effect across beats. Empty is legal.
-	Correlation string `json:"correlation,omitempty"`
-
-	// Tags is queryable metadata describing the beat.
-	Tags map[string]string `json:"tags,omitempty"`
-
-	// Payload is the beat itself, encoded by the composition.
-	Payload []byte `json:"payload,omitempty"`
-}
-
 // EventKind names what an event reports.
 //
 // A string enum rather than free-form prose, because this is the field clients
@@ -583,6 +564,13 @@ type Event struct {
 
 	// Correlation groups cause and effect across events. Empty is legal.
 	Correlation string `json:"correlation,omitempty"`
+
+	// Tags is queryable metadata describing the beat, carried unchanged from
+	// the story-log entry this event was projected from — the same map
+	// StoryEntry alone used to carry before rpg-api-protos#239: a client
+	// resolving a gap by re-querying Story now gets the identical Tags a
+	// live subscriber already had, rather than a second, thinner shape.
+	Tags map[string]string `json:"tags,omitempty"`
 
 	// Recipient is the member this projection is addressed to.
 	Recipient string `json:"recipient"`


### PR DESCRIPTION
## Summary

Closes #1212. rpg-project#257 slice 3; correction of rpg-api-protos#239.

`Manager.Story` returned a thinner `StoryEntry{Seq, At, Correlation, Tags, Payload}` while the live `EventStream` carried typed `Event{Kind, Body, ...}` through decoding (`decodeBeat`/`kindFor`/`bodyFor`) that was unexported and reachable only from a write scope's `projectEvents`. A client that missed a live beat and caught up via `Story` saw `kind=UNKNOWN body=null` — the exact drift the debug feed caught live (rpg-dnd5e-web#784, `740-03-skeleton-turn-in-log.png`).

**Ruling (Kirk/team-lead):** live and catch-up must be byte-equal for the same seq, enforced by ONE producer.

## The change

- Extracted the per-entry projection out of `projectEvents` into `projectEntry(session, recipient string, e record.Entry) Event` (events.go) — the SAME function both the live stream and `Story` now call. No behaviour change for the stream: every existing event test is untouched, unmoved.
- `Manager.Story(ctx, *StoryInput) ([]Event, error)` — each entry projected exactly as `projectEntry` projects it: Session, Recipient (the requesting member), Seq, At, Correlation, Kind, Payload, Body. `FromSeq` semantics and the aged-out `ErrStoryTrimmed` sentinel are unchanged.
- `StoryEntry` deleted (no backcompat baggage — rpg-api pins its own version).
- **Tags carries across, not dropped**: `attack_test.go`'s `TestASwingLandsAndTheStoryRecordsIt` and `turn_test.go`'s `TestEndingATurnHandsItOn` both read `.Tags["tag"]` off a `Story` result — checked, and it wasn't dead. `Event` gained a `Tags map[string]string` field, populated by `projectEntry` on **both** paths, so it is now available live too, not only on catch-up.

## Tests

- **New**: `TestLiveDeliveryAndStoryCatchUpAreByteEqual` (monster_turn_test.go) — for a driven monster turn (Join, Spawn, EndTurn under `session.Behavior()`), the events a capturing `EventStream` received for one member equal `Story{FromSeq:1}` for that same member, entry by entry.
- `TestStoryFromSeqIsInclusive`, `TestTrimmedStoryUsesOurSentinelNotTheirs` (read_test.go) — FromSeq resume and the aged-out sentinel, unchanged behaviour, now against `[]Event`.
- Full `rulebooks/dnd5e/session` + `session-workbench` suites green, including the existing round-2 live-delivery negative control (`TestRoundTwoStruckReachesTheLiveSubscriber`).

## Version

`gorelease` (from `rulebooks/dnd5e/session/`): incompatible change `StoryEntry: removed`. Inferred base `v0.22.0`. **Suggested version: `v0.23.0`** (tag `rulebooks/dnd5e/session/v0.23.0`).

The squash-merge title should keep this commit's own `feat(session)!:` prefix (matching precedent — `2e00a9b feat(encounter)!: regions replace rooms...`) so the auto-tag workflow's `!:` breaking-change detection fires and bumps minor per this repo's v0.x convention.

## Test plan

- [x] `go build ./...`, `go vet ./...` clean
- [x] `go test ./... -race` clean (session + session-workbench)
- [x] `gofmt -l` / `goimports -l` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `./scripts/check-decisions.sh` clean (46/46 ADRs, unaffected)
- [x] `gorelease` — breaking, see Version above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu
