### PR TITLE
feat(session): Joined/Exited events carry their member

### DIFF
--- a/rulebooks/dnd5e/session/events.go
+++ b/rulebooks/dnd5e/session/events.go
@@ -275,6 +275,22 @@ func bodyFor(kind EventKind, payload []byte) EventBody {
 			return nil
 		}
 		return MovedBody{Member: p.Member, To: p.Position}
+	case EventJoined:
+		var p struct {
+			Member string `json:"member"`
+		}
+		if json.Unmarshal(payload, &p) != nil || p.Member == "" {
+			return nil
+		}
+		return JoinedBody{Member: p.Member}
+	case EventExited:
+		var p struct {
+			Member string `json:"member"`
+		}
+		if json.Unmarshal(payload, &p) != nil || p.Member == "" {
+			return nil
+		}
+		return ExitedBody{Member: p.Member}
 	case EventTurnEnded:
 		var p struct {
 			Member string `json:"member"`
@@ -313,8 +329,8 @@ func bodyFor(kind EventKind, payload []byte) EventBody {
 		}
 		return DownedBody{Member: p.Member}
 	default:
-		// EventJoined, EventExited, EventEnded, EventSceneOpened, EventTick:
-		// no body member exists for these — see EventBody's own doc.
+		// EventEnded, EventSceneOpened, EventTick: no body member exists for
+		// these — see EventBody's own doc.
 		return nil
 	}
 }

--- a/rulebooks/dnd5e/session/events_internal_test.go
+++ b/rulebooks/dnd5e/session/events_internal_test.go
@@ -127,6 +127,8 @@ func TestBodyForRefusesAMissingRequiredField(t *testing.T) {
 		{"bubble-formed with an empty order", EventFightStarted, `{"beat":"bubble-formed","order":[]}`},
 		{"bubble-dissolved with no cause", EventFightEnded, `{"beat":"bubble-dissolved"}`},
 		{"down with no member", EventDowned, `{"beat":"down"}`},
+		{"joined with no member", EventJoined, `{"beat":"joined"}`},
+		{"exited with no member", EventExited, `{"beat":"exited"}`},
 		{"struck with no actor", EventStruck, `{"beat":"struck","targets":["bob"],"attack":{"ref":"longsword"}}`},
 		{"struck with no targets", EventStruck, `{"beat":"struck","actor":"alice","attack":{"ref":"longsword"}}`},
 		{"struck with two targets", EventStruck, `{"beat":"struck","actor":"alice","targets":["bob","carol"],"attack":{"ref":"longsword"}}`},
@@ -155,4 +157,28 @@ func TestBodyForAcceptsACompleteBeat(t *testing.T) {
 		Attacker: "alice", Target: "bob", Roll: 15, Total: 20, Against: 12, Damage: 8,
 		Attack: AttackRef{Ref: "longsword", Name: "Longsword", DamageType: DamageSlashing},
 	}, body)
+}
+
+// TestJoinedAndExitedBodiesCarryTheMember pins bodyFor's newest arms
+// (rpg-project#260 slice 4, item 2): the encounter composition's join/exit
+// beats already carry "member" (encounter.go's Join and Exit), so this is
+// the same decode-from-payload shape every other typed body uses — no new
+// field on the wire, only a typed name for what was already there.
+func TestJoinedAndExitedBodiesCarryTheMember(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		kind EventKind
+		want EventBody
+	}{
+		{"joined", `{"beat":"joined","member":"erin"}`, EventJoined, JoinedBody{Member: "erin"}},
+		{"exited", `{"beat":"exited","member":"erin"}`, EventExited, ExitedBody{Member: "erin"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			kind, body := decodeBeat([]byte(tc.json))
+			require.Equal(t, tc.kind, kind)
+			require.Equal(t, tc.want, body)
+		})
+	}
 }

--- a/rulebooks/dnd5e/session/events_test.go
+++ b/rulebooks/dnd5e/session/events_test.go
@@ -257,6 +257,12 @@ func (s *EventsTestSuite) TestDepartingMemberHearsTheirOwnExit() {
 // joining and leaving, and "movement" covers both a step and a doorway
 // crossing. Switching on the tag would collapse pairs of opposite events into
 // one kind, and a client cannot narrate an arrival and a departure the same way.
+//
+// It also pins JoinedBody/ExitedBody (rpg-project#260 slice 4): every
+// recipient's Join event carries JoinedBody.Member == the joiner, and every
+// recipient's Exit event carries ExitedBody.Member == the leaver — not just
+// the actor's own copy, since the beat is fanned out to the whole audience by
+// one producer (projectEntry) and live/catch-up must agree.
 func (s *EventsTestSuite) TestKindsComeFromTheBeatNotTheTag() {
 	s.start()
 	ctx := context.Background()
@@ -278,12 +284,32 @@ func (s *EventsTestSuite) TestKindsComeFromTheBeatNotTheTag() {
 	s.NotContains(joined, session.EventExited,
 		"joining and leaving share a tag and must not share a kind")
 
+	s.Require().NotEmpty(s.stream.published, "the join beat must have fanned out to someone")
+	for _, e := range s.stream.published {
+		if e.Kind != session.EventJoined {
+			continue
+		}
+		body, ok := e.Body.(session.JoinedBody)
+		s.Require().True(ok, "recipient %s: EventJoined must carry JoinedBody", e.Recipient)
+		s.Equal("erin", body.Member, "recipient %s: JoinedBody names the joiner", e.Recipient)
+	}
+
 	s.stream.published = nil
 	_, err = s.mgr.Exit(ctx, &session.ExitInput{Session: "sess", Member: "erin"})
 	s.Require().NoError(err)
 	exited := s.kinds()
 	s.Contains(exited, session.EventExited)
 	s.NotContains(exited, session.EventJoined)
+
+	s.Require().NotEmpty(s.stream.published, "the exit beat must have fanned out to someone")
+	for _, e := range s.stream.published {
+		if e.Kind != session.EventExited {
+			continue
+		}
+		body, ok := e.Body.(session.ExitedBody)
+		s.Require().True(ok, "recipient %s: EventExited must carry ExitedBody", e.Recipient)
+		s.Equal("erin", body.Member, "recipient %s: ExitedBody names the leaver", e.Recipient)
+	}
 }
 
 func (s *EventsTestSuite) kinds() []session.EventKind {

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -586,10 +586,12 @@ type Event struct {
 
 	// Body is the beat, typed: a sealed interface with one struct per kind
 	// that has one, decoded from the SAME payload this package already
-	// wrote rather than a second encoding of it (rpg-toolkit#941). Nil for
-	// a kind with no typed body member (ENDED, SCENE_OPENED, TICK, UNKNOWN)
-	// and for a beat this build's decoder does not recognise — see
-	// decodeBeat.
+	// wrote rather than a second encoding of it (rpg-toolkit#941). Nil in
+	// three cases: a kind with no typed body member (ENDED, SCENE_OPENED,
+	// TICK, UNKNOWN); a beat this build's decoder does not recognise; and a
+	// beat whose declared kind IS recognised but whose payload does not
+	// match that kind's required shape — bodyFor's own refusal rather than
+	// a zero-valued body (see TestBodyForRefusesAMissingRequiredField).
 	Body EventBody `json:"-"`
 }
 

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -587,15 +587,16 @@ type Event struct {
 	// Body is the beat, typed: a sealed interface with one struct per kind
 	// that has one, decoded from the SAME payload this package already
 	// wrote rather than a second encoding of it (rpg-toolkit#941). Nil for
-	// a kind with no typed body member (JOINED, EXITED, ENDED,
-	// SCENE_OPENED, TICK, UNKNOWN) and for a beat this build's decoder does
-	// not recognise — see decodeBeat.
+	// a kind with no typed body member (ENDED, SCENE_OPENED, TICK, UNKNOWN)
+	// and for a beat this build's decoder does not recognise — see
+	// decodeBeat.
 	Body EventBody `json:"-"`
 }
 
 // EventBody is the beat, typed — a sealed interface with one struct per
 // kind Event.Body carries: TurnEndedBody, DownedBody, StruckBody,
-// MissedBody, FightStartedBody, FightEndedBody, MovedBody. Sealed the way
+// MissedBody, FightStartedBody, FightEndedBody, MovedBody, JoinedBody,
+// ExitedBody. Sealed the way
 // DissolveCause is (dissolve.go) and for the same reason: a caller matches
 // on it with a type switch, and a second implementation declared outside
 // this package would be indistinguishable from these to anyone reading the
@@ -696,6 +697,24 @@ type MovedBody struct {
 }
 
 func (MovedBody) isEventBody() {}
+
+// JoinedBody is EventJoined's typed body: who entered the encounter. The
+// same member the beat's audience already includes (Join's own memberIDs),
+// carried here so a client rendering the beat does not have to cross-reference
+// Event.Recipient to learn who arrived.
+type JoinedBody struct {
+	Member string `json:"member"`
+}
+
+func (JoinedBody) isEventBody() {}
+
+// ExitedBody is EventExited's typed body: who left the encounter. See
+// JoinedBody's own doc — the same reasoning, the opposite beat.
+type ExitedBody struct {
+	Member string `json:"member"`
+}
+
+func (ExitedBody) isEventBody() {}
 
 // SaveReport names which aggregates were persisted by a verb and which were
 // not.


### PR DESCRIPTION
## Summary

- Adds `JoinedBody{Member string}` and `ExitedBody{Member string}`, the typed `Event.Body` payloads for `EventJoined`/`EventExited`, matching the existing per-kind body pattern (`TurnEndedBody`, `DownedBody`, `StruckBody`, `MissedBody`, `FightStartedBody`, `FightEndedBody`, `MovedBody`).
- `bodyFor` now decodes them from the beat's existing `"member"` field — the encounter composition's join/exit beats already carry it (`encounter.go`'s `Join`/`Exit`), so this is purely a typed name for data already on the payload. No wire/proto change on this side (rpg-api-protos#242 already added `Joined{member}`/`Exited{member}` to the Event oneof).
- Since `projectEntry` is the one function both live delivery and Story catch-up go through (#1213), both paths get the typed body identically, by construction — no separate wiring needed.

## Test plan
- [x] New: `TestJoinedAndExitedBodiesCarryTheMember` (events_internal_test.go) pins `decodeBeat` on complete joined/exited beats.
- [x] Extended: `TestBodyForRefusesAMissingRequiredField` gains joined/exited-with-no-member cases (nil body, not a zero-valued one).
- [x] Extended: `TestKindsComeFromTheBeatNotTheTag` (events_test.go) now asserts every recipient's `EventJoined`/`EventExited` carries `JoinedBody`/`ExitedBody` naming the joiner/leaver.
- [x] Regression: `TestLiveDeliveryAndStoryCatchUpAreByteEqual` and the `TestTwoPlayersSuite` walk (which both Join real players in setup) keep passing unmodified — confirming live/catch-up parity holds for the new body too.
- [x] `go test ./...` and `go test -race ./...` green in `rulebooks/dnd5e/session`.
- [x] `golangci-lint run ./...` clean.
- [x] `gorelease`: additive/compatible (`ExitedBody: added`, `JoinedBody: added`), suggested `v0.24.0`.
- [x] `./scripts/check-decisions.sh` passes (unaffected — no ADR here).
- [x] Sanity mutation: temporarily removed the new `bodyFor` cases and confirmed the new/extended tests fail red, then restored to green.

Closes rpg-toolkit#1216 (sub-issue of rpg-project#260 slice 4, item 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu