### PR TITLE
feat(dnd5e): launch seating restores every character fully, not just the downed

### DIFF
--- a/rulebooks/dnd5e/character/arcade_recovery.go
+++ b/rulebooks/dnd5e/character/arcade_recovery.go
@@ -8,17 +8,20 @@ import (
 )
 
 // RestoreForNewEncounter applies arcade recovery to a character's persisted
-// data before it is seated in a BRAND NEW encounter — an arcade run start,
-// not a real-world rest. Two independent restorations, gated differently:
+// data before it is seated at a game LAUNCH — an arcade run start, not a
+// real-world rest. Two independent restorations, both ungated:
 //
-//  1. HP / death-save / Unconscious (rpg-toolkit#785): death is an
-//     encounter-scoped outcome, not a persistent character state. A
-//     character carrying 0 HP or less from a prior encounter — whether a
-//     confirmed 3-failed-death-save death or an unresolved TPK snapshot —
-//     is restored to full HP with its death-save state cleared and its
-//     Unconscious condition removed, as if walking into a fresh fight
-//     healthy. Gated on HitPoints <= 0: a character already alive is not
-//     touched by this branch (no free heal on every new fight).
+//  1. HP / death-save / Unconscious (rpg-toolkit#785, ungated by #1225):
+//     death and damage are run-scoped outcomes, not persistent character
+//     state. EVERY seated character is restored to full HP with its
+//     death-save state cleared and its Unconscious condition removed —
+//     whether it arrived dead (3 failed death saves or an unresolved TPK
+//     snapshot) or merely wounded from an earlier run. The original
+//     HitPoints <= 0 gate ("no free heal on every new fight") guarded the
+//     OLD stack's per-encounter reseat through encounter.AddPlayer; on the
+//     session stack the only caller is the host's launch path and fights
+//     afterwards form by sighting, so a full heal here is a run start, not
+//     a mid-run freebie (Kirk's ruling, rpg-project#253 walk 2026-08-24).
 //  2. Resource pools (rpg-toolkit#795): every tracked resource in
 //     d.Resources (rage charges, ki, hit dice, and anything else a future
 //     feature keys into that map — see restoreResourcePools) refreshes to
@@ -33,11 +36,13 @@ import (
 //     rpg-toolkit#800 and #799 respectively, both out of this scope).
 //
 // Contract — read before calling this from anywhere new: it fires only at
-// first seating, never on rehydration. Callers own distinguishing the two.
-// encounter.LoadFromData — the per-RPC reload of an EXISTING seat — must
-// NEVER call this; only a new-seat path (encounter.AddPlayer) should.
-// Calling it on an already-restored or already-healthy, already-full-
-// resource character is a harmless no-op.
+// launch seating, never on rehydration. Callers own distinguishing the
+// two. A per-RPC reload of an EXISTING seat must NEVER call this; only the
+// host's launch path (today, rpg-api's StartEncounter before it Joins each
+// member) should — mid-run, the full heal this now performs would be a
+// free heal, which is exactly what launch-only scoping prevents. Calling
+// it on an already-healthy, already-full-resource character is a harmless
+// no-op.
 //
 // Why the Unconscious condition must be stripped, not left to re-hydrate:
 // conditions.UnconsciousCondition does not subscribe to CombatEndTopic, so
@@ -50,22 +55,27 @@ import (
 // shaped differently.
 //
 // Returns true iff it actually restored something — HP/death-save OR at
-// least one resource pool — so a caller (today, encounter.AddPlayer) knows
-// whether to also resync any HP snapshot it keeps alongside d and whether
-// to persist the (possibly resource-only) change. Because resource
-// restoration is now ungated, this returns true for most resource-bearing
-// characters on most new seatings, not only revived ones — see that call
-// site's own doc for why HP/DataJSON must not be allowed to diverge.
+// least one resource pool — so the caller knows whether the record needs
+// persisting before it is seated. A character already at full HP with full
+// pools returns false.
 func RestoreForNewEncounter(d *Data) bool {
 	if d == nil {
 		return false
 	}
 	restored := false
 
-	if d.HitPoints <= 0 {
+	if d.HitPoints < d.MaxHitPoints {
 		d.HitPoints = d.MaxHitPoints
+		restored = true
+	}
+	if d.DeathSaveState != nil {
 		d.DeathSaveState = nil
-		d.Conditions = stripConditionByRef(d.Conditions, refs.Conditions.Unconscious())
+		restored = true
+	}
+	// Stripped unconditionally: an Unconscious blob with HP already at max is
+	// exactly the incoherent state this function exists to remove.
+	if stripped := stripConditionByRef(d.Conditions, refs.Conditions.Unconscious()); len(stripped) != len(d.Conditions) {
+		d.Conditions = stripped
 		restored = true
 	}
 

--- a/rulebooks/dnd5e/character/arcade_recovery.go
+++ b/rulebooks/dnd5e/character/arcade_recovery.go
@@ -7,9 +7,12 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
-// RestoreForNewEncounter applies arcade recovery to a character's persisted
+// RestoreForLaunch applies arcade recovery to a character's persisted
 // data before it is seated at a game LAUNCH — an arcade run start, not a
-// real-world rest. Two independent restorations, both ungated:
+// real-world rest. (Named RestoreForNewEncounter until rpg-toolkit#1225
+// renamed it: "encounter" stopped describing the call site once the only
+// legitimate caller became the host's launch path — the old name invited
+// exactly the mid-run misuse the contract below forbids.) Two independent restorations, both ungated:
 //
 //  1. HP / death-save / Unconscious (rpg-toolkit#785, ungated by #1225):
 //     death and damage are run-scoped outcomes, not persistent character
@@ -58,7 +61,7 @@ import (
 // least one resource pool — so the caller knows whether the record needs
 // persisting before it is seated. A character already at full HP with full
 // pools returns false.
-func RestoreForNewEncounter(d *Data) bool {
+func RestoreForLaunch(d *Data) bool {
 	if d == nil {
 		return false
 	}

--- a/rulebooks/dnd5e/character/arcade_recovery_test.go
+++ b/rulebooks/dnd5e/character/arcade_recovery_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
 )
 
-// ArcadeRecoveryTestSuite exercises RestoreForNewEncounter (rpg-toolkit#785).
+// ArcadeRecoveryTestSuite exercises RestoreForLaunch (rpg-toolkit#785).
 type ArcadeRecoveryTestSuite struct {
 	suite.Suite
 	ctx context.Context
@@ -68,7 +68,7 @@ func conditionRef(t *testing.T, cond interface {
 }
 
 func (s *ArcadeRecoveryTestSuite) TestNilData_NoPanic_ReturnsFalse() {
-	s.False(RestoreForNewEncounter(nil))
+	s.False(RestoreForLaunch(nil))
 }
 
 // TestWounded_RestoredToFull: the #1225 ungate (Kirk's ruling,
@@ -83,12 +83,32 @@ func (s *ArcadeRecoveryTestSuite) TestWounded_RestoredToFull() {
 		Conditions:     []json.RawMessage{unconsciousBlob(s.T(), "char-1", 2, false)},
 	}
 
-	restored := RestoreForNewEncounter(data)
+	restored := RestoreForLaunch(data)
 
 	s.True(restored, "a wounded character is restored at launch since #1225")
 	s.Equal(20, data.HitPoints, "HP must restore to MaxHitPoints, not just for the downed")
 	s.Nil(data.DeathSaveState)
 	s.Empty(data.Conditions, "a lingering Unconscious blob is stripped regardless of HP")
+}
+
+// TestHealthy_LingeringUnconsciousBlob_IsStrippedAndReported: the strip
+// runs unconditionally, so a coherent-looking record (full HP, no
+// death-save state) that still carries an Unconscious blob from a broken
+// earlier state is cleaned AND reported true — the caller must persist
+// the strip, or the next hydration re-Applies the condition onto a
+// healthy character.
+func (s *ArcadeRecoveryTestSuite) TestHealthy_LingeringUnconsciousBlob_IsStrippedAndReported() {
+	data := &Data{
+		HitPoints:    20,
+		MaxHitPoints: 20,
+		Conditions:   []json.RawMessage{unconsciousBlob(s.T(), "char-1", 1, false)},
+	}
+
+	restored := RestoreForLaunch(data)
+
+	s.True(restored, "a stripped blob alone must still tell the caller to persist")
+	s.Equal(20, data.HitPoints)
+	s.Empty(data.Conditions)
 }
 
 // TestFullyHealthy_IsNoOp: what remains of the old above-zero no-op after
@@ -101,7 +121,7 @@ func (s *ArcadeRecoveryTestSuite) TestFullyHealthy_IsNoOp() {
 		MaxHitPoints: 20,
 	}
 
-	restored := RestoreForNewEncounter(data)
+	restored := RestoreForLaunch(data)
 
 	s.False(restored, "nothing to restore, nothing to persist")
 	s.Equal(20, data.HitPoints)
@@ -117,7 +137,7 @@ func (s *ArcadeRecoveryTestSuite) TestZeroHP_TPKDeath_RestoresFullHPAndClearsDea
 		Conditions:     []json.RawMessage{unconsciousBlob(s.T(), "char-1", 3, true)},
 	}
 
-	restored := RestoreForNewEncounter(data)
+	restored := RestoreForLaunch(data)
 
 	s.True(restored)
 	s.Equal(16, data.HitPoints, "HP must restore to MaxHitPoints")
@@ -131,7 +151,7 @@ func (s *ArcadeRecoveryTestSuite) TestNegativeHP_TreatedSameAsZero() {
 	// require exactly 0 to trigger a restore for an equally-broken record.
 	data := &Data{HitPoints: -4, MaxHitPoints: 12}
 
-	restored := RestoreForNewEncounter(data)
+	restored := RestoreForLaunch(data)
 
 	s.True(restored)
 	s.Equal(12, data.HitPoints)
@@ -155,7 +175,7 @@ func (s *ArcadeRecoveryTestSuite) TestPreservesOtherConditions() {
 		},
 	}
 
-	restored := RestoreForNewEncounter(data)
+	restored := RestoreForLaunch(data)
 
 	s.True(restored)
 	s.Require().Len(data.Conditions, 1, "only the Unconscious condition should be stripped")
@@ -171,7 +191,7 @@ func (s *ArcadeRecoveryTestSuite) TestPreservesOtherConditions() {
 // ToData/LoadFromData shape a new encounter's hydration cascade exercises:
 // marshal the restored Data, unmarshal it, LoadFromData it, and confirm the
 // resulting live Character has no Unconscious condition subscribed and full
-// HP -- not just that RestoreForNewEncounter mutated the struct in memory.
+// HP -- not just that RestoreForLaunch mutated the struct in memory.
 func (s *ArcadeRecoveryTestSuite) TestRoundTrip_HydratesCleanly() {
 	data := &Data{
 		ID:               "char-1",
@@ -185,7 +205,7 @@ func (s *ArcadeRecoveryTestSuite) TestRoundTrip_HydratesCleanly() {
 		Conditions:       []json.RawMessage{unconsciousBlob(s.T(), "char-1", 3, true)},
 	}
 
-	s.Require().True(RestoreForNewEncounter(data))
+	s.Require().True(RestoreForLaunch(data))
 
 	raw, err := json.Marshal(data)
 	s.Require().NoError(err)
@@ -235,7 +255,7 @@ func (s *ArcadeRecoveryTestSuite) TestDeadBarbarian_SpentRage_SeatedAlive_FullHP
 		Resources:      spentRageResources(),
 	}
 
-	restored := RestoreForNewEncounter(data)
+	restored := RestoreForLaunch(data)
 
 	s.True(restored)
 	s.Equal(20, data.HitPoints, "HP must restore to MaxHitPoints")
@@ -256,7 +276,7 @@ func (s *ArcadeRecoveryTestSuite) TestAliveBarbarian_SpentRage_SeatedWithFullRag
 		Resources:    spentRageResources(),
 	}
 
-	restored := RestoreForNewEncounter(data)
+	restored := RestoreForLaunch(data)
 
 	s.True(restored)
 	s.Equal(20, data.HitPoints, "since #1225 launch heals the wounded to full, not just the downed")
@@ -280,12 +300,12 @@ func (s *ArcadeRecoveryTestSuite) TestFullRage_AboveZeroHP_IsFullNoOp() {
 	// before is a real, independent snapshot, not a shallow struct copy --
 	// *data alone would leave before.Resources pointing at the SAME map as
 	// data.Resources, making the s.Equal below compare the map to itself
-	// (trivially "equal" no matter what RestoreForNewEncounter does to it,
+	// (trivially "equal" no matter what RestoreForLaunch does to it,
 	// proving nothing about the no-op claim). Copilot catch on PR #801.
 	before := *data
 	before.Resources = maps.Clone(data.Resources)
 
-	restored := RestoreForNewEncounter(data)
+	restored := RestoreForLaunch(data)
 
 	s.False(restored, "a character already whole on both HP and resources must be a full no-op")
 	s.Equal(before.HitPoints, data.HitPoints)
@@ -306,7 +326,7 @@ func (s *ArcadeRecoveryTestSuite) TestMultipleResourcePools_AllRestoreIndependen
 		},
 	}
 
-	restored := RestoreForNewEncounter(data)
+	restored := RestoreForLaunch(data)
 
 	s.True(restored)
 	s.Equal(3, data.Resources[dnd5eResources.RageCharges].Current)

--- a/rulebooks/dnd5e/character/arcade_recovery_test.go
+++ b/rulebooks/dnd5e/character/arcade_recovery_test.go
@@ -71,21 +71,41 @@ func (s *ArcadeRecoveryTestSuite) TestNilData_NoPanic_ReturnsFalse() {
 	s.False(RestoreForNewEncounter(nil))
 }
 
-func (s *ArcadeRecoveryTestSuite) TestAboveZeroHP_IsNoOp() {
+// TestWounded_RestoredToFull: the #1225 ungate (Kirk's ruling,
+// rpg-project#253) -- a character above 0 HP but below max is healed to
+// full at launch, with any lingering death-save state and Unconscious blob
+// removed. Before #1225 this exact input was the documented no-op case.
+func (s *ArcadeRecoveryTestSuite) TestWounded_RestoredToFull() {
 	data := &Data{
 		HitPoints:      5,
 		MaxHitPoints:   20,
 		DeathSaveState: &saves.DeathSaveState{Failures: 2},
 		Conditions:     []json.RawMessage{unconsciousBlob(s.T(), "char-1", 2, false)},
 	}
-	before := *data
 
 	restored := RestoreForNewEncounter(data)
 
-	s.False(restored, "a character above 0 HP must not be touched by arcade recovery")
-	s.Equal(before.HitPoints, data.HitPoints)
-	s.Equal(before.DeathSaveState, data.DeathSaveState)
-	s.Equal(before.Conditions, data.Conditions)
+	s.True(restored, "a wounded character is restored at launch since #1225")
+	s.Equal(20, data.HitPoints, "HP must restore to MaxHitPoints, not just for the downed")
+	s.Nil(data.DeathSaveState)
+	s.Empty(data.Conditions, "a lingering Unconscious blob is stripped regardless of HP")
+}
+
+// TestFullyHealthy_IsNoOp: what remains of the old above-zero no-op after
+// #1225 -- a character already at max HP with no death-save state, no
+// Unconscious blob and full pools reports false, so the caller knows the
+// record does not need persisting.
+func (s *ArcadeRecoveryTestSuite) TestFullyHealthy_IsNoOp() {
+	data := &Data{
+		HitPoints:    20,
+		MaxHitPoints: 20,
+	}
+
+	restored := RestoreForNewEncounter(data)
+
+	s.False(restored, "nothing to restore, nothing to persist")
+	s.Equal(20, data.HitPoints)
+	s.Nil(data.DeathSaveState)
 }
 
 func (s *ArcadeRecoveryTestSuite) TestZeroHP_TPKDeath_RestoresFullHPAndClearsDeathState() {
@@ -225,13 +245,10 @@ func (s *ArcadeRecoveryTestSuite) TestDeadBarbarian_SpentRage_SeatedAlive_FullHP
 		"rage charges must refresh to their maximum alongside HP")
 }
 
-// TestAliveBarbarian_SpentRage_SeatedWithFullRage_HPUntouched: the scope
-// change #795 makes over #785 -- an ALIVE barbarian (above 0 HP) who spent
-// rage earlier in the run must still get rage back at a new seating, even
-// though the HP/death-save branch has nothing to do (HitPoints > 0). Before
-// #795, RestoreForNewEncounter returned false and touched nothing for any
-// character above 0 HP; this is the case that changes.
-func (s *ArcadeRecoveryTestSuite) TestAliveBarbarian_SpentRage_SeatedWithFullRage_HPUntouched() {
+// TestAliveBarbarian_SpentRage_SeatedWithFullRageAndHP: an ALIVE barbarian
+// who spent rage and took some hits earlier in the run gets both back at
+// launch -- rage via #795's ungated pools, HP via #1225's ungated heal.
+func (s *ArcadeRecoveryTestSuite) TestAliveBarbarian_SpentRage_SeatedWithFullRageAndHP() {
 	data := &Data{
 		ID:           "barb-2",
 		HitPoints:    14,
@@ -241,11 +258,11 @@ func (s *ArcadeRecoveryTestSuite) TestAliveBarbarian_SpentRage_SeatedWithFullRag
 
 	restored := RestoreForNewEncounter(data)
 
-	s.True(restored, "resource restoration alone must still report true")
-	s.Equal(14, data.HitPoints, "an alive character's HP must not be touched by this seating")
+	s.True(restored)
+	s.Equal(20, data.HitPoints, "since #1225 launch heals the wounded to full, not just the downed")
 	s.Nil(data.DeathSaveState)
 	s.Equal(3, data.Resources[dnd5eResources.RageCharges].Current,
-		"rage charges must refresh even though the character was never down")
+		"rage charges must refresh alongside the heal")
 }
 
 // TestFullRage_AboveZeroHP_IsFullNoOp: the negative control for the negative


### PR DESCRIPTION
Closes #1225. Kirk's ruling from the 2026-08-24 walk (rpg-project#253): "we will want to set the HP and reset the character fully before launching the game. coming in with 2 HP or spawning in dead makes testing tough."

`RestoreForNewEncounter` lost its only caller with the old encounter module and its HP branch was gated on `HitPoints <= 0` — a wounded-but-alive character was never healed. The gate guarded the old stack's per-encounter reseat; on the session stack the only seating is game launch and fights form by sighting afterwards, so the gate protected nothing and contradicted the ruling.

**Changes**
- HP heal, death-save clear, and Unconscious-blob strip each run and report independently (a cleared death-save state alone still tells the caller to persist).
- Doc rewritten to new-stack reasoning; the contract now names rpg-api's `StartEncounter` as the launch path and states why mid-run calls stay forbidden (the full heal would be a freebie).
- Tests: the two alive-untouched cases now pin the new contract (wounded → full, fully-healthy → no-op false); the barbarian case asserts rage AND HP both refresh.

Host-side call lands in rpg-api#828 (pins the tag this cuts).

— asset-pipeline agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu
