### PR TITLE
feat(session): atlas projection carries prop facing and offset (rpg-project#261)

### DIFF
--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -81,6 +81,8 @@ func projectAtlas(in encounter.Atlas) Atlas {
 			At:                prop.At,
 			BlocksMovement:    prop.BlocksMovement,
 			BlocksLineOfSight: prop.BlocksLineOfSight,
+			Facing:            prop.Facing,
+			Offset:            prop.Offset,
 		})
 	}
 

--- a/rulebooks/dnd5e/session/convert_internal_test.go
+++ b/rulebooks/dnd5e/session/convert_internal_test.go
@@ -1,0 +1,51 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// convert_internal_test.go tests projectAtlas directly, white-box, because it
+// is unexported and convert_test.go's external-package audit is deliberately
+// structural (field NAMES match, by reflection) rather than a value check —
+// it would pass even if a field were added to both types' definitions and
+// never actually wired into the copy loop below. This file is the value half:
+// proof that the bytes projectAtlas returns are the bytes it was handed, not
+// just that the outer type has somewhere to put them.
+//
+// TestPropFacingAndOffsetCrossTheSeam pins rpg-project#261's projection: a
+// straight copy, by design, of the two additive presentational fields —
+// carried exactly as the composition reports them, including the "said
+// nothing" zero values on a prop that authored neither.
+func TestPropFacingAndOffsetCrossTheSeam(t *testing.T) {
+	in := encounter.Atlas{
+		Orientation: encounter.HexesArePointyTop(),
+		Props: []encounter.AtlasProp{
+			{
+				Ref: "dnd5e:props:statue-reaper", At: spatial.Position{X: 3, Y: 4},
+				BlocksMovement: true, BlocksLineOfSight: true,
+				Facing: "se", Offset: [2]float64{0.2, -0.1},
+			},
+			{
+				Ref: "dnd5e:props:candles", At: spatial.Position{X: 5, Y: 6},
+				BlocksMovement: false, BlocksLineOfSight: false,
+			},
+		},
+	}
+
+	out := projectAtlas(in)
+
+	require.Len(t, out.Props, 2)
+	require.Equal(t, "se", out.Props[0].Facing, "the exact authored word, uninterpreted")
+	require.Equal(t, [2]float64{0.2, -0.1}, out.Props[0].Offset, "the exact authored numbers")
+
+	require.Equal(t, "", out.Props[1].Facing, "said nothing")
+	require.Equal(t, [2]float64{0, 0}, out.Props[1].Offset, "and said zero/center: the same fact by design")
+}

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.31.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.31.2-0.20260824023227-cae9319880a8
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.8
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.2 h1:2waZXnic6MNnJVi+C5
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.2/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0 h1:LxEJMtm4M3PMDnpRC61ooGvWKS/eRZImu/GTeTDCYuM=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0/go.mod h1:Y5eXfAAyQ0N4Sp07T5C7MxD2CwAwdAUi2zo5SyN60Ds=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.31.0 h1:kCj25/eN74ZmHNW2O9wjT+b5GVet9RSe+kXW2hhRKxA=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.31.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.31.2-0.20260824023227-cae9319880a8 h1:WxK57ByJtM/zFLhuGmCfpZ1UsFnUhnTh1ActL+H0qvA=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.31.2-0.20260824023227-cae9319880a8/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.8 h1:Um4R9m9U56MezAOJYOGT/lR/5lKtDOA7733Tm/pb+Ck=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.8/go.mod h1:MwJQ7ICnFlBBzYJrgPfv8coScPaz4gYYw9JtsGRUIMc=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -197,9 +197,17 @@ type AtlasProp struct {
 
 	// Offset is a within-cell VISUAL nudge, [x,y] fractions of the cell
 	// size, carried verbatim from [encounter.AtlasProp.Offset]. {0,0} means
-	// centered, which omitting the field also means. VISUAL ONLY — a prop
-	// still occupies its whole cell for movement and line of sight; this
-	// never reaches a rule.
+	// centered — the SAME fact a prop that authored no offset carries, by
+	// design (rpg-project#261).
+	//
+	// No omitempty: Go's encoding/json cannot omit a fixed-size array
+	// regardless of the tag (verified — the key is always written), so a
+	// reading client checks the VALUE for {0,0} rather than the key for
+	// absence, the same way [Lighting.Intensity]'s own zero is an answer
+	// rather than a gap.
+	//
+	// VISUAL ONLY — a prop still occupies its whole cell for movement and
+	// line of sight; this never reaches a rule.
 	Offset [2]float64 `json:"offset"`
 }
 

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -186,6 +186,21 @@ type AtlasProp struct {
 
 	// BlocksLineOfSight reports whether sight passes through its cell.
 	BlocksLineOfSight bool `json:"blocks_line_of_sight"`
+
+	// Facing is the authored direction this prop faces, in the field's own
+	// orientation vocabulary — carried verbatim from
+	// [encounter.AtlasProp.Facing] and never interpreted here (rpg-project
+	// #261). Optional: "" means the asset's own default facing. Angle math
+	// is a render concern, not this seam's — the wire names the fact, the
+	// client derives pixels.
+	Facing string `json:"facing,omitempty"`
+
+	// Offset is a within-cell VISUAL nudge, [x,y] fractions of the cell
+	// size, carried verbatim from [encounter.AtlasProp.Offset]. {0,0} means
+	// centered, which omitting the field also means. VISUAL ONLY — a prop
+	// still occupies its whole cell for movement and line of sight; this
+	// never reaches a rule.
+	Offset [2]float64 `json:"offset"`
 }
 
 // AtlasBoundary is one wall or barrier crossing between adjacent cells.


### PR DESCRIPTION
## Summary

- `session.AtlasProp` gains `Facing string` and `Offset [2]float64`, mirroring `encounter.AtlasProp` (rpg-toolkit#1227) field for field.
- `projectAtlas` (`convert.go`) copies both straight across — this seam owns no rules (session/CLAUDE.md), and neither field is one: no interpretation, no angle math, no bounds re-check (dungeonspec already validated those at authoring time).
- **Persistence note**: `encounter.EncounterData` — the exact type `EncounterRepository` round-trips (S3's deliberate boundary exception, `repositories.go`) — already persists `Facing`/`Offset` as of #1227's `PropData` extension. No session-local persistence type needed changing; this PR is the live-read projection only.

## Module pin

Pins `rulebooks/dnd5e/encounter` at rpg-toolkit#1227's **final** head via pseudo-version: `v0.31.2-0.20260824023227-cae9319880a8` (commit `cae9319`, post-Copilot-review). This is a committable, CI-buildable pseudo-version — not a local `replace`. **At merge time this needs re-pinning to the real published tag** once #1227 lands and tags, per the squash-merge lesson in rpg-project#253's log (committing the graph honest — what CI builds is what a consumer gets).

## Test plan

- [x] `convert_test.go`'s existing structural completeness check (`TestEveryInnerFieldIsCarriedOrJustified/AtlasProp`) passes automatically — the two new fields exist under the same name on both `encounter.AtlasProp` and `session.AtlasProp`, so the field-name audit finds nothing to justify.
- [x] New `convert_internal_test.go` (white-box, `package session`): a genuine **value**-level test of `projectAtlas` directly — the structural check above only proves the outer type HAS the field, not that the hand-written copy loop actually assigns it. Constructs an `encounter.Atlas` with one prop authoring both fields and one authoring neither, asserts the projected `session.AtlasProp` carries the exact word/numbers on the first and the zero value ("said nothing") on the second.
- [x] `go build ./... && go vet ./... && go test ./...` run module-whole from `rulebooks/dnd5e/session`: all green. `go mod tidy` clean, `gofmt -l` clean.

— world-builder lane, on behalf of KirkDiggler