### PR TITLE
fix(session): pin encounter at its real tag v0.32.0

### DIFF
--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.2
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.31.2-0.20260824023227-cae9319880a8
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.32.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.8
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.2 h1:2waZXnic6MNnJVi+C5
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.97.2/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0 h1:LxEJMtm4M3PMDnpRC61ooGvWKS/eRZImu/GTeTDCYuM=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0/go.mod h1:Y5eXfAAyQ0N4Sp07T5C7MxD2CwAwdAUi2zo5SyN60Ds=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.31.2-0.20260824023227-cae9319880a8 h1:WxK57ByJtM/zFLhuGmCfpZ1UsFnUhnTh1ActL+H0qvA=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.31.2-0.20260824023227-cae9319880a8/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.32.0 h1:mCZLo4QDLlZ/iBlHS25oMJ6Ejs7t6dHq3fPEBdIql3I=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.32.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.8 h1:Um4R9m9U56MezAOJYOGT/lR/5lKtDOA7733Tm/pb+Ck=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.11.8/go.mod h1:MwJQ7ICnFlBBzYJrgPfv8coScPaz4gYYw9JtsGRUIMc=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=


### PR DESCRIPTION
## Summary

rpg-toolkit#1228 merged with `encounter` pinned to a pseudo-version (`v0.31.2-0.20260824023227-cae9319880a8`) — that pseudo-version is now baked into the published `session v0.25.0` tag. The commit it points at, `cae9319` (rpg-toolkit#1227's final head, after the Copilot-review fix), was **squash-orphaned** when #1227 merged and is not reachable from `main` — verified via `git merge-base --is-ancestor cae9319... origin/main` (fails). This is the exact slice-1 squash-orphan situation recorded in rpg-project#253's learning log: a pseudo-version pin only survives as long as GitHub happens to keep the orphaned commit fetchable, which is not a guarantee.

This PR re-pins `rulebooks/dnd5e/session`'s `go.mod` to the real published tag, `encounter v0.32.0` (which supersedes the pseudo-version and is reachable from `main` — also verified). Merging this auto-tags a corrected `session` release that consumers (rpg-api) can pin cleanly.

## Test plan

- [x] `go.mod`/`go.sum` diff is minimal: only the one dependency bump, `go mod tidy` produced no other changes.
- [x] `go build ./... && go vet ./... && go test ./...` run module-whole from `rulebooks/dnd5e/session`: all green.
- [x] `gofmt -l` clean.

— world-builder lane, on behalf of KirkDiggler