### PR TITLE
feat(session): Sighting carries Kind — viewers can tell a player from a monster

### DIFF
--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -137,7 +137,9 @@ func projectStatus(in *encounter.Status) *Status {
 	return out
 }
 
-func projectSightings(in []intel.Holding, names map[string]string, down map[string]bool) []Sighting {
+func projectSightings(
+	in []intel.Holding, names map[string]string, kinds map[string]MemberKind, down map[string]bool,
+) []Sighting {
 	out := make([]Sighting, 0, len(in))
 	for _, h := range in {
 		via := make([]string, 0, len(h.CurrentVia))
@@ -147,6 +149,7 @@ func projectSightings(in []intel.Holding, names map[string]string, down map[stri
 		out = append(out, Sighting{
 			Subject:    string(h.Subject),
 			Name:       names[string(h.Subject)],
+			Kind:       kinds[string(h.Subject)],
 			Seen:       projectSeen(h.Channel, h.Payload, down[string(h.Subject)]),
 			Payload:    append([]byte(nil), h.Payload...),
 			Channel:    string(h.Channel),

--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -142,15 +142,16 @@ func projectSightings(
 ) []Sighting {
 	out := make([]Sighting, 0, len(in))
 	for _, h := range in {
+		subject := string(h.Subject)
 		via := make([]string, 0, len(h.CurrentVia))
 		for _, c := range h.CurrentVia {
 			via = append(via, string(c))
 		}
 		out = append(out, Sighting{
-			Subject:    string(h.Subject),
-			Name:       names[string(h.Subject)],
-			Kind:       kinds[string(h.Subject)],
-			Seen:       projectSeen(h.Channel, h.Payload, down[string(h.Subject)]),
+			Subject:    subject,
+			Name:       names[subject],
+			Kind:       kinds[subject],
+			Seen:       projectSeen(h.Channel, h.Payload, down[subject]),
 			Payload:    append([]byte(nil), h.Payload...),
 			Channel:    string(h.Channel),
 			At:         h.At,

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -238,7 +238,7 @@ func (m *Manager) View(ctx context.Context, in *ViewInput) ([]Sighting, error) {
 		return nil, fmt.Errorf("view: %w", err)
 	}
 
-	return projectSightings(holdings, rosterNames(roster), down), nil
+	return projectSightings(holdings, rosterNames(roster), rosterKinds(roster), down), nil
 }
 
 // Story returns the beats a member has witnessed, from FromSeq onward

--- a/rulebooks/dnd5e/session/read_test.go
+++ b/rulebooks/dnd5e/session/read_test.go
@@ -356,3 +356,55 @@ func (s *ReadTestSuite) TestViewCarriesNameAndStanding() {
 	s.Require().NotNil(skeleton.Seen, "a live sight-channel sighting carries Seen")
 	s.Equal(session.StandingUp, skeleton.Seen.Standing, "nothing has touched it yet")
 }
+
+// twoObservedWorld is one open 6x6 hall with no occluders and unbounded
+// sight: "scout" watches "ally" (a fellow player) and "goblin" (a monster),
+// both mutually visible from the moment the session starts — no walk needed
+// to open sight, unlike seen_test.go's doorway scenes, because this is about
+// what Kind reports once a sighting exists, not about how one opens.
+func twoObservedWorld(t fataler) *encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Striker: encounter.RefusingStriker{}, Sight: encEveryoneSees{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{}, Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: pointyCanvas(), Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 6, 6)}},
+		Members: []encounter.MemberInput{
+			{ID: "scout", Kind: encounter.KindPlayer, Position: spatial.Position{X: 0, Y: 0}},
+			{ID: "ally", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 0}},
+			{ID: "goblin", Kind: encounter.KindMonster, Position: spatial.Position{X: 2, Y: 0}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "out", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	if err != nil {
+		t.Fatalf("building twoObservedWorld: %v", err)
+	}
+	data := enc.ToData()
+	return &data
+}
+
+// TestViewCarriesKind pins rpg-toolkit#1230: a Sighting reports what kind of
+// member the subject is, looked up from the roster the same way Name already
+// is, so a client can tell a player from a monster without guessing (the
+// diagnosis behind rpg-dnd5e-web#792). One session, one player and one
+// monster besides the observer, one View call — both kinds must come back
+// right, not just whichever one a hard-coded default would fake.
+func (s *ReadTestSuite) TestViewCarriesKind() {
+	s.startWith(twoObservedWorld(s.T()))
+
+	sightings, err := s.mgr.View(context.Background(),
+		&session.ViewInput{Session: "sess", Member: "scout"})
+	s.Require().NoError(err)
+
+	var ally, goblin *session.Sighting
+	for i := range sightings {
+		switch sightings[i].Subject {
+		case "ally":
+			ally = &sightings[i]
+		case "goblin":
+			goblin = &sightings[i]
+		}
+	}
+	s.Require().NotNil(ally, "scout must see ally in the open hall")
+	s.Require().NotNil(goblin, "scout must see goblin in the open hall")
+	s.Equal(session.KindPlayer, ally.Kind, "a fellow player's Sighting must report Kind player")
+	s.Equal(session.KindMonster, goblin.Kind, "a monster's Sighting must report Kind monster")
+}

--- a/rulebooks/dnd5e/session/rosterlookup.go
+++ b/rulebooks/dnd5e/session/rosterlookup.go
@@ -17,6 +17,18 @@ func rosterNames(roster []encounter.Member) map[string]string {
 	return out
 }
 
+// rosterKinds indexes a roster read by member id — the same batching
+// rosterNames does, for Sighting.Kind (rpg-toolkit#1230). The roster is the
+// one place a member's kind lives; this is the only lookup, reused wherever
+// a Sighting is projected rather than invented a second time.
+func rosterKinds(roster []encounter.Member) map[string]MemberKind {
+	out := make(map[string]MemberKind, len(roster))
+	for _, m := range roster {
+		out[string(m.ID)] = MemberKind(m.Kind)
+	}
+	return out
+}
+
 // standingSet batches a down-check over a set of member ids into a lookup —
 // one Standing() call per verb rather than one per sighted subject or
 // participant, and the same batching turn.go's own participantsFor uses.

--- a/rulebooks/dnd5e/session/seen_internal_test.go
+++ b/rulebooks/dnd5e/session/seen_internal_test.go
@@ -37,7 +37,7 @@ func TestProjectSightingsSightChannelGetsASeen(t *testing.T) {
 		Status:     intel.Current,
 	}}
 
-	out := projectSightings(holdings, nil, map[string]bool{"skeleton-1": true})
+	out := projectSightings(holdings, nil, nil, map[string]bool{"skeleton-1": true})
 	require.Len(t, out, 1)
 	require.NotNil(t, out[0].Seen, "a sight-channel holding must carry Seen")
 	require.Equal(t, spatial.Position{X: 10, Y: 3}, out[0].Seen.Position)
@@ -60,7 +60,7 @@ func TestProjectSightingsNonSightChannelGetsNoSeen(t *testing.T) {
 		Status:     intel.Current,
 	}}
 
-	out := projectSightings(holdings, nil, nil)
+	out := projectSightings(holdings, nil, nil, nil)
 	require.Len(t, out, 1)
 	require.Nil(t, out[0].Seen, "a non-sight channel must not carry Seen, however the payload happens to decode")
 }
@@ -79,11 +79,70 @@ func TestProjectSightingsHeldMemoryKeepsItsLastSeen(t *testing.T) {
 		Status:     intel.Held,
 	}}
 
-	out := projectSightings(holdings, nil, nil)
+	out := projectSightings(holdings, nil, nil, nil)
 	require.Len(t, out, 1)
 	require.NotNil(t, out[0].Seen, "a held memory must keep its last Seen")
 	require.Equal(t, spatial.Position{X: 6, Y: 10}, out[0].Seen.Position)
 	require.Equal(t, StandingUp, out[0].Seen.Standing, "not in the down set: reports up")
+}
+
+// TestProjectSightingsCarriesKindFromTheRoster pins rpg-toolkit#1230: kind is
+// a roster fact looked up the same way Name is, not a second perception
+// question. Two holdings, two kinds, so a projection that swapped the map
+// lookup for a constant would still fail.
+func TestProjectSightingsCarriesKindFromTheRoster(t *testing.T) {
+	holdings := []intel.Holding{
+		{
+			Subject:    intel.Subject("fighter"),
+			Payload:    sightPayloadBytes(t, 1, 1),
+			Channel:    intel.Sight,
+			At:         1,
+			CurrentVia: []intel.Channel{intel.Sight},
+			Status:     intel.Current,
+		},
+		{
+			Subject:    intel.Subject("skeleton-1"),
+			Payload:    sightPayloadBytes(t, 2, 2),
+			Channel:    intel.Sight,
+			At:         1,
+			CurrentVia: []intel.Channel{intel.Sight},
+			Status:     intel.Current,
+		},
+	}
+	kinds := map[string]MemberKind{"fighter": KindPlayer, "skeleton-1": KindMonster}
+
+	out := projectSightings(holdings, nil, kinds, nil)
+	require.Len(t, out, 2)
+	for _, s := range out {
+		switch s.Subject {
+		case "fighter":
+			require.Equal(t, KindPlayer, s.Kind)
+		case "skeleton-1":
+			require.Equal(t, KindMonster, s.Kind)
+		default:
+			t.Fatalf("unexpected subject %q", s.Subject)
+		}
+	}
+}
+
+// TestProjectSightingsHeldMemoryKeepsItsKind is TestProjectSightingsHeldMemoryKeepsItsLastSeen's
+// twin for Kind: a subject whose CurrentVia has gone empty (Status == Held, a
+// ghost) still carries the kind the roster reports for it, same as it keeps
+// its name — a memory does not forget what it once classified at a glance.
+func TestProjectSightingsHeldMemoryKeepsItsKind(t *testing.T) {
+	holdings := []intel.Holding{{
+		Subject:    intel.Subject("goblin-1"),
+		Payload:    sightPayloadBytes(t, 6, 10),
+		Channel:    intel.Sight,
+		At:         3,
+		CurrentVia: nil, // faded: no channel currently sustains it
+		Status:     intel.Held,
+	}}
+	kinds := map[string]MemberKind{"goblin-1": KindMonster}
+
+	out := projectSightings(holdings, nil, kinds, nil)
+	require.Len(t, out, 1)
+	require.Equal(t, KindMonster, out[0].Kind, "a held memory must keep its kind")
 }
 
 // TestProjectSeenIsNilWhenASightPayloadFailsToDecode is the defensive arm: an

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -396,6 +396,13 @@ type Sighting struct {
 	// Lands with rpg-toolkit#1137.
 	Name string `json:"name,omitempty"`
 
+	// Kind is the sighted subject's member kind — player or monster. Beside
+	// Name for the same reason: kind is not a perception question either,
+	// anything an observer can sight, they can classify at a glance. A
+	// memory (CurrentVia empty) keeps its kind exactly as it keeps its
+	// name. Lands with rpg-toolkit#1230.
+	Kind MemberKind `json:"kind,omitempty"`
+
 	// Seen is the sight channel's own typed knowledge; see [Seen]. Decoded by
 	// the composition, not by this package — session never unmarshals
 	// Payload itself.

--- a/rulebooks/dnd5e/session/write.go
+++ b/rulebooks/dnd5e/session/write.go
@@ -534,7 +534,7 @@ func (m *Manager) Exit(ctx context.Context, in *ExitInput) (*ExitOutput, error) 
 
 	return &ExitOutput{
 		Outcome:  projectMemberOutcome(left.Outcome),
-		Carry:    projectSightings(left.Carry, rosterNames(roster), down),
+		Carry:    projectSightings(left.Carry, rosterNames(roster), rosterKinds(roster), down),
 		Seq:      left.Seq,
 		Closed:   projectOutcome(left.Closed),
 		Saved:    report,


### PR DESCRIPTION
## Summary

`session.Sighting` carried `Subject`, `Name`, and typed `Seen` — but not what KIND of member the subject is, even though the roster already knows (`MemberKind`, already exposed on the turn-driver seam's `SeenMember.Kind`). A client could label and place a sighted member but had to guess whether to draw a player or a monster.

Adds `Kind MemberKind` to `session.Sighting`, beside `Name`, populated at view projection from the roster — the same lookup pattern `Name` already uses (a new `rosterKinds` helper beside `rosterNames`, fed into `projectSightings`). A memory (`CurrentVia` empty) keeps its kind exactly as it keeps its name.

Additive to the session module; no encounter module change was needed — `encounter.Member.Kind` was already reachable from every call site that builds Sightings (`read.go`'s `View`, `write.go`'s `Exit`), both of which already read the roster for `rosterNames`.

Closes #1230. Toolkit leg of rpg-dnd5e-web#792, journey rpg-project#253, alongside rpg-api-protos#244.

## Test plan

- [x] `TestProjectSightingsCarriesKindFromTheRoster` (unit): two holdings, two kinds — the map lookup, not a constant, must decide.
- [x] `TestProjectSightingsHeldMemoryKeepsItsKind` (unit): a held/faded holding still reports its kind.
- [x] `TestViewCarriesKind` (end-to-end, real SDK verbs): a session with one observer, one fellow player, and one monster, all mutually visible — `View` returns the player's Sighting with `Kind player` and the monster's with `Kind monster`.
- [x] `go test ./...` green in `rulebooks/dnd5e/session`.
- [x] `gofmt -l` clean, `go vet ./...` clean.

— asset-pipeline agent, on behalf of KirkDiggler