### PR TITLE
refactor(encounter)!: project action range independent of delivery (#1198)

### DIFF
--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -597,8 +597,8 @@ func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round i
 		return MonsterView{}, fmt.Errorf("held by: %w", err)
 	}
 
-	// bestReachCells is the farthest this member's own actions can reach,
-	// in cells — the arithmetic max of authored ReachFeet values, not a
+	// bestRangeCells is the farthest this member's own actions can reach,
+	// in cells — the arithmetic max of authored RangeFeet values, not a
 	// rules opinion about which action is "best" in play (this module
 	// still cannot import the rulebook, C1: it takes the number, not the
 	// meaning). Floored at 1 (5 feet, a bare cell) even for a member with
@@ -606,10 +606,10 @@ func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round i
 	// capability — nobody's own Path should ever walk onto another
 	// member's occupied cell, whether or not this member has anything to
 	// do once it arrives.
-	bestReachCells := 1
+	bestRangeCells := 1
 	for _, a := range m.Actions {
-		if c := CellsFromFeet(a.ReachFeet); c > bestReachCells {
-			bestReachCells = c
+		if c := CellsFromFeet(a.RangeFeet); c > bestRangeCells {
+			bestRangeCells = c
 		}
 	}
 
@@ -635,13 +635,13 @@ func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round i
 		dist := e.Distance(ownCell, pos)
 		inReach := make(map[core.Ref]bool, len(m.Actions))
 		for _, a := range m.Actions {
-			inReach[a.Ref] = dist <= float64(CellsFromFeet(a.ReachFeet))
+			inReach[a.Ref] = dist <= float64(CellsFromFeet(a.RangeFeet))
 		}
 
 		// Path ends on the NEAREST WALKABLE cell (to this member's own
 		// position — the shortest route BY STEPS, not "however far along
 		// the route to pos happens to land") from which the sighting is
-		// within bestReachCells (Kirk, rpg-project#254 review — this also
+		// within bestRangeCells (Kirk, rpg-project#254 review — this also
 		// removes the "already in reach, don't bother moving" workaround
 		// behavior.Basic carried before this truncation existed).
 		//
@@ -656,12 +656,12 @@ func (e *Encounter) buildMonsterView(m *memberRecord, budget TurnBudget, round i
 		// own reach rule). bfsShortestPath's goal predicate stops the
 		// search the moment ANY cell — including this member's own
 		// starting position, handling "already in reach" for free — is
-		// within bestReachCells of pos, which is the actual nearest
+		// within bestRangeCells of pos, which is the actual nearest
 		// walkable answer rather than a proxy for it. One BFS per
 		// sighting, every Act call — see the field's own doc for why that
 		// cost is accepted rather than deferred behind a lazy capability.
 		path, _ := e.bfsShortestPath(ownCell, func(cell spatial.Position) bool {
-			return e.Distance(cell, pos) <= float64(bestReachCells)
+			return e.Distance(cell, pos) <= float64(bestRangeCells)
 		})
 
 		seen = append(seen, SeenMember{

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -353,7 +353,7 @@ type MemberData struct {
 type ActionViewData struct {
 	Ref       core.Ref `json:"ref"`
 	Name      string   `json:"name,omitempty"`
-	ReachFeet int      `json:"reach_feet,omitempty"`
+	RangeFeet int      `json:"range_feet,omitempty"`
 	Kind      string   `json:"kind,omitempty"`
 }
 

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -203,6 +203,16 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 	s.Require().NoError(err)
 }
 
+func (s *DataTestSuite) TestActionViewUsesRangeFeetJSONWithoutLegacyAlias() {
+	raw, err := json.Marshal(encounter.ActionViewData{
+		Ref:       core.Ref{Module: "dnd5e", Type: "monster_actions", ID: "skeleton-shortbow"},
+		RangeFeet: 320,
+	})
+	s.Require().NoError(err)
+	s.JSONEq(`{"ref":{"module":"dnd5e","type":"monster_actions","id":"skeleton-shortbow"},"range_feet":320}`, string(raw))
+	s.NotContains(string(raw), "reach_feet")
+}
+
 func TestDataSuite(t *testing.T) {
 	suite.Run(t, new(DataTestSuite))
 }

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -522,7 +522,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 			return nil, fmt.Errorf("newencounter: player %s cannot carry a decider: %w", m.ID, ErrNoMember)
 		}
 
-		// SpeedFeet, SightFeet and each action's ReachFeet are feet-
+		// SpeedFeet, SightFeet and each action's RangeFeet are feet-
 		// denominated facts CellsFromFeet divides by FeetPerCell — a
 		// negative one is not a shorter distance, it is a caller defect
 		// (Copilot, PR #1187), and would otherwise produce a nonsense

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -318,8 +318,8 @@ type MemberInput struct {
 
 	// Actions are this member's own static facts about what it can do on
 	// its turn: a character's equipped weapon's swing (and the unarmed
-	// strike when no weapon is equipped), or a monster's authored
-	// [monster.ActionData]. Static join-time facts, the same species as
+	// strike when no weapon is equipped), or a monster's authored action
+	// definitions. Static join-time facts, the same species as
 	// Name (rpg-toolkit#1137) — this module cannot import the rulebook
 	// (C1), so every field on [ActionView] is carried and never
 	// interpreted, exactly as [Member.Name] already is.

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -339,12 +339,10 @@ type MemberInput struct {
 // encounter-owned primitive, the same species as [Member.Name] and
 // [AttackIdentity.DamageType]: this composition carries it and never
 // interprets it, per C1 (this module's go.mod cannot import the rulebook,
-// so it cannot know what a Ref like "dnd5e:monster_actions:melee" means, or
+// so it cannot know what a Ref like "dnd5e:monster_actions:skeleton-shortbow" means, or
 // what a Kind string like "melee" means).
 type ActionView struct {
-	// Ref identifies this action's implementation to whoever compiles an
-	// attack from it later — resolution's AttackFromMonsterAction, or a
-	// character's equipped-weapon compiler. Opaque here.
+	// Ref identifies this authored action to its eventual consumer. Opaque here.
 	Ref core.Ref
 
 	// Name is this action's display name — "Shortsword", "Bite" — carried
@@ -352,11 +350,10 @@ type ActionView struct {
 	// is.
 	Name string
 
-	// ReachFeet is how far this action reaches, in FEET (Kirk,
-	// rpg-project#254 review — a cell is 5 feet; see [CellsFromFeet]). The
-	// ONE place that compares this against a grid Distance converts once,
-	// via CellsFromFeet, rather than this record guessing at a conversion.
-	ReachFeet int
+	// RangeFeet is the action delivery's maximum legal distance in FEET:
+	// melee reach or a ranged delivery's long/maximum range. A cell is 5 feet;
+	// the one comparison against grid distance converts once via [CellsFromFeet].
+	RangeFeet int
 
 	// Kind is this action's category, in the rulebook's own words —
 	// "melee", "ranged", "unarmed" — opaque to this composition and never
@@ -366,7 +363,7 @@ type ActionView struct {
 }
 
 // validateMemberFacts rejects a negative SpeedFeet, SightFeet, or any
-// action's ReachFeet — the three feet-denominated member facts
+// action's RangeFeet — the three feet-denominated member facts
 // [CellsFromFeet] divides by [FeetPerCell] (Copilot, PR #1187 review). A
 // negative one is not a shorter distance; it is a caller defect that would
 // otherwise produce a nonsense movement budget or reach the moment a
@@ -381,8 +378,8 @@ func validateMemberFacts(id MemberID, speedFeet, sightFeet int, actions []Action
 		return fmt.Errorf("member %s: sight %d feet is negative: %w", id, sightFeet, ErrNoMember)
 	}
 	for _, a := range actions {
-		if a.ReachFeet < 0 {
-			return fmt.Errorf("member %s: action %q reach %d feet is negative: %w", id, a.Ref, a.ReachFeet, ErrNoMember)
+		if a.RangeFeet < 0 {
+			return fmt.Errorf("member %s: action %q range %d feet is negative: %w", id, a.Ref, a.RangeFeet, ErrNoMember)
 		}
 	}
 	return nil

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -105,7 +105,7 @@ func (s *MonsterTurnTestSuite) adjacentSkeletonEncounter(driver encounter.TurnDr
 				ID: goblin, Kind: encounter.KindMonster, Position: spatial.Position{X: 3, Y: 2},
 				SpeedFeet: 30, Targeting: "closest",
 				Actions: []encounter.ActionView{
-					{Ref: testMeleeAction, Name: "Shortsword", ReachFeet: 5, Kind: "melee"},
+					{Ref: testMeleeAction, Name: "Shortsword", RangeFeet: 5, Kind: "melee"},
 				},
 			},
 		},
@@ -134,7 +134,7 @@ func (s *MonsterTurnTestSuite) farSkeletonEncounter(driver encounter.TurnDriver,
 				ID: goblin, Kind: encounter.KindMonster, Position: spatial.Position{X: 6, Y: 2},
 				SpeedFeet: 30, Targeting: "closest",
 				Actions: []encounter.ActionView{
-					{Ref: testMeleeAction, Name: "Shortsword", ReachFeet: 5, Kind: "melee"},
+					{Ref: testMeleeAction, Name: "Shortsword", RangeFeet: 5, Kind: "melee"},
 				},
 			},
 		},
@@ -183,7 +183,7 @@ func (s *MonsterTurnTestSuite) TestMonsterViewCarriesStaticFactsAndSeen() {
 	s.Equal("closest", view.Targeting)
 	s.Require().Len(view.Actions, 1)
 	s.Equal(testMeleeAction, view.Actions[0].Ref)
-	s.Equal(5, view.Actions[0].ReachFeet)
+	s.Equal(5, view.Actions[0].RangeFeet)
 	s.Equal(1, view.Budget.AttacksLeft)
 	s.Equal(30, view.Budget.MovementFeet)
 
@@ -468,7 +468,7 @@ func (s *MonsterTurnTestSuite) TestMemberFactsRoundTripThroughToDataAndLoadEncou
 		s.Require().Len(m.Actions, 1)
 		s.Equal(testMeleeAction, m.Actions[0].Ref)
 		s.Equal("Shortsword", m.Actions[0].Name)
-		s.Equal(5, m.Actions[0].ReachFeet)
+		s.Equal(5, m.Actions[0].RangeFeet)
 		s.Equal("melee", m.Actions[0].Kind)
 	}
 	s.True(found)
@@ -486,7 +486,7 @@ func (s *MonsterTurnTestSuite) TestRefusingStrikerFailsLoudly() {
 
 // TestSetupRejectsANegativeMemberFact and TestJoinRejectsANegativeMemberFact
 // pin Copilot's PR #1187 review finding: SpeedFeet, SightFeet and an
-// action's ReachFeet are feet CellsFromFeet divides by FeetPerCell, and a
+// action's RangeFeet are feet CellsFromFeet divides by FeetPerCell, and a
 // negative one is a caller defect this composition catches at the door
 // rather than letting it produce a nonsense budget or reach later.
 func (s *MonsterTurnTestSuite) TestSetupRejectsANegativeMemberFact() {
@@ -494,7 +494,7 @@ func (s *MonsterTurnTestSuite) TestSetupRejectsANegativeMemberFact() {
 		mi := encounter.MemberInput{
 			ID: goblin, Kind: encounter.KindMonster, Position: spatial.Position{X: 1, Y: 1},
 			SpeedFeet: 30, SightFeet: 60,
-			Actions: []encounter.ActionView{{Ref: testMeleeAction, Name: "Claw", ReachFeet: 5}},
+			Actions: []encounter.ActionView{{Ref: testMeleeAction, Name: "Claw", RangeFeet: 5}},
 		}
 		mutate(&mi)
 		return &encounter.SetupInput{
@@ -518,7 +518,7 @@ func (s *MonsterTurnTestSuite) TestSetupRejectsANegativeMemberFact() {
 		s.Require().ErrorIs(err, encounter.ErrNoMember)
 	})
 	s.Run("negative action reach", func() {
-		_, err := encounter.NewEncounter(base(func(mi *encounter.MemberInput) { mi.Actions[0].ReachFeet = -5 }))
+		_, err := encounter.NewEncounter(base(func(mi *encounter.MemberInput) { mi.Actions[0].RangeFeet = -5 }))
 		s.Require().ErrorIs(err, encounter.ErrNoMember)
 	})
 }
@@ -592,7 +592,7 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathWalksAroundAWall() {
 			{
 				ID: goblin, Kind: encounter.KindMonster, Position: spatial.Position{X: 0, Y: 2},
 				SpeedFeet: 30, Targeting: "closest",
-				Actions: []encounter.ActionView{{Ref: testMeleeAction, Name: "Claw", ReachFeet: 5, Kind: "melee"}},
+				Actions: []encounter.ActionView{{Ref: testMeleeAction, Name: "Claw", RangeFeet: 5, Kind: "melee"}},
 			},
 		},
 		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
@@ -646,7 +646,7 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathIsEmptyWhenSightedButUnreachabl
 			{
 				ID: goblin, Kind: encounter.KindMonster, Position: spatial.Position{X: 0, Y: 0},
 				SpeedFeet: 30, Targeting: "closest",
-				Actions: []encounter.ActionView{{Ref: testMeleeAction, Name: "Claw", ReachFeet: 5, Kind: "melee"}},
+				Actions: []encounter.ActionView{{Ref: testMeleeAction, Name: "Claw", RangeFeet: 5, Kind: "melee"}},
 			},
 		},
 		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
@@ -682,7 +682,7 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathStopsAtTheMemberOwnLongestReach
 			{
 				ID: goblin, Kind: encounter.KindMonster, Position: spatial.Position{X: 6, Y: 0},
 				SpeedFeet: 30, Targeting: "closest",
-				Actions: []encounter.ActionView{{Ref: reachWeapon, Name: "Glaive", ReachFeet: 10, Kind: "melee"}},
+				Actions: []encounter.ActionView{{Ref: reachWeapon, Name: "Glaive", RangeFeet: 10, Kind: "melee"}},
 			},
 		},
 		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
@@ -762,7 +762,7 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathFindsTheNearestInRangeCellNotJu
 				// right beside the monster's own start (1 step away,
 				// Chebyshev distance 3 from alice) is already in range,
 				// making the detour-vs-shortcut distinction unambiguous.
-				Actions: []encounter.ActionView{{Ref: longReach, Name: "Whip", ReachFeet: 15, Kind: "melee"}},
+				Actions: []encounter.ActionView{{Ref: longReach, Name: "Whip", RangeFeet: 15, Kind: "melee"}},
 			},
 		},
 		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
@@ -842,7 +842,7 @@ func (s *MonsterTurnTestSuite) TestDrivenKillingBlowEndsTheDriveCleanly() {
 				ID: goblin, Kind: encounter.KindMonster, Position: spatial.Position{X: 3, Y: 2},
 				SpeedFeet: 30, Targeting: "closest",
 				Actions: []encounter.ActionView{
-					{Ref: testMeleeAction, Name: "Shortsword", ReachFeet: 5, Kind: "melee"},
+					{Ref: testMeleeAction, Name: "Shortsword", RangeFeet: 5, Kind: "melee"},
 				},
 			},
 		},
@@ -950,7 +950,7 @@ func (s *MonsterTurnTestSuite) TestADownedTeammateDoesNotHandTheDrivenMonsterASe
 				ID: goblin, Kind: encounter.KindMonster, Position: spatial.Position{X: 4, Y: 5},
 				SpeedFeet: 30, Targeting: "closest",
 				Actions: []encounter.ActionView{
-					{Ref: testMeleeAction, Name: "Shortsword", ReachFeet: 5, Kind: "melee"},
+					{Ref: testMeleeAction, Name: "Shortsword", RangeFeet: 5, Kind: "melee"},
 				},
 			},
 		},

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -517,7 +517,7 @@ func (s *MonsterTurnTestSuite) TestSetupRejectsANegativeMemberFact() {
 		_, err := encounter.NewEncounter(base(func(mi *encounter.MemberInput) { mi.SightFeet = -5 }))
 		s.Require().ErrorIs(err, encounter.ErrNoMember)
 	})
-	s.Run("negative action reach", func() {
+	s.Run("negative action range", func() {
 		_, err := encounter.NewEncounter(base(func(mi *encounter.MemberInput) { mi.Actions[0].RangeFeet = -5 }))
 		s.Require().ErrorIs(err, encounter.ErrNoMember)
 	})
@@ -702,7 +702,7 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathStopsAtTheMemberOwnLongestReach
 
 // TestSeenMemberPathIsEmptyWhenAlreadyWithinReach is the bug the
 // end-to-end behavior.Basic test found: a member already at exactly
-// bestReachCells' distance (no earlier cell to stop at before the
+// bestRangeCells' distance (no earlier cell to stop at before the
 // target's own) must not return a one-element Path onto the target's own
 // cell — Path must be empty, matching its own documented contract ("empty
 // ... or this member is already within reach without moving at all").

--- a/rulebooks/dnd5e/encounter/turndriver.go
+++ b/rulebooks/dnd5e/encounter/turndriver.go
@@ -140,7 +140,7 @@ type SeenMember struct {
 	// InReach maps each of THIS MONSTER'S OWN action refs (see
 	// [MonsterView.Actions]) to whether this sighting is within that
 	// action's reach right now — precomputed so a driver never converts
-	// feet to cells itself (see [ActionView.ReachFeet]'s doc for why that
+	// feet to cells itself (see [ActionView.RangeFeet]'s doc for why that
 	// conversion belongs here, once, rather than on every driver).
 	InReach map[core.Ref]bool
 
@@ -180,7 +180,7 @@ type TurnBudget struct {
 	AttacksLeft int
 
 	// MovementFeet is how much further this member may move this turn, in
-	// FEET (Kirk, rpg-project#254 review — see [ActionView.ReachFeet]'s doc
+	// FEET (Kirk, rpg-project#254 review — see [ActionView.RangeFeet]'s doc
 	// for the feet/cells split) — [Member.SpeedFeet] at the start of a
 	// turn, decremented by 5 feet per cell as [Move] intents execute.
 	MovementFeet int


### PR DESCRIPTION
## Summary

Part 3 of the module-isolated ADR-0045 delivery for #1198.

- rename active encounter `ActionView.ReachFeet` to delivery-neutral `RangeFeet`
- persist the same `range_feet` contract in `ActionViewData`
- use maximum action range for in-reach projection and path stopping
- retain action identity/name/kind as opaque composition data
- remove the old field without a compatibility alias or legacy JSON key

This PR changes only the `rulebooks/dnd5e/encounter` Go module. It replaces the encounter portion of quarantined draft #1232 and implements the accepted design on #1214.

## Dependency boundary

Encounter remains rulebook-agnostic and imports no D&D action-definition package. Session will project `AttackDelivery.MaxRangeFeet()` into this opaque contract after this module publishes its tag.

## Verification

- `go test -race ./...` in `rulebooks/dnd5e/encounter`
- `golangci-lint run ./...`
- `go mod tidy`
- `git diff --check`
- JSON regression proving `range_feet` is emitted and `reach_feet` is absent
- module-scope census: encounter files only

## Delivery

Use the repository's normal **squash merge**. After merge, wait for the encounter module tag generated by `Auto Tag Modules (Safe)` before updating session.

Part of #1198. Does not close it.

— asset-pipeline agent, on behalf of KirkDiggler
