### PR TITLE
session: door verbs across the seam — Doors/OpenDoor/Unlock, EventDoor + EndedBody (#1242)

### DIFF
--- a/rulebooks/dnd5e/session/doors.go
+++ b/rulebooks/dnd5e/session/doors.go
@@ -216,6 +216,16 @@ func (m *Manager) Unlock(ctx context.Context, in *UnlockInput) (*UnlockOutput, e
 
 	beaten, total := false, 0
 	if locked {
+		// The authored ability resolves through the rulebook's own lookup
+		// (canonical "dex" and full spellings alike) — an ability it does
+		// not know is a CONTENT defect refused loudly, never a silent -5
+		// from an unknown key reading score zero (Copilot round, #1243).
+		ability, aerr := abilities.GetByID(lock.Ability)
+		if aerr != nil {
+			return nil, fmt.Errorf("unlock %q: lock names no rulebook ability (%q): %w",
+				in.Door, lock.Ability, ErrInvalidWorld)
+		}
+
 		sheet, err := m.loadAttackSheet(ctx, in.Member)
 		if err != nil {
 			return nil, fmt.Errorf("unlock: %w", err)
@@ -224,7 +234,7 @@ func (m *Manager) Unlock(ctx context.Context, in *UnlockInput) (*UnlockOutput, e
 		check, err := checks.MakeAbilityCheck(ctx, &checks.AbilityCheckInput{
 			Roller:   &diceSeam{roller: m.dice},
 			DC:       lock.DC,
-			Modifier: sheet.GetAbilityModifier(abilities.Ability(lock.Ability)),
+			Modifier: sheet.GetAbilityModifier(ability),
 		})
 		if err != nil {
 			// A foreign error (rpgerr): carried as text, never wrapped into

--- a/rulebooks/dnd5e/session/doors.go
+++ b/rulebooks/dnd5e/session/doors.go
@@ -1,0 +1,278 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+// doors.go carries the door verbs across the seam (rpg-project#268, design
+// rpg-project#269): Doors reads every door's live state, OpenDoor pushes a
+// shut one open, and Unlock is where the lock's verdict lives — the session
+// loads the sheet, rolls the check, and TELLS the composition Beaten. The
+// composition compares nothing (encounter.UnlockInput's law), and this seam
+// is the layer allowed to know that a total meeting the DC succeeds.
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/checks"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+)
+
+// DoorsInput asks for a session's doors.
+type DoorsInput struct {
+	// Session is the session to read.
+	Session string
+}
+
+// DoorsOutput carries every authored door's live state.
+type DoorsOutput struct {
+	// Doors, in the composition's own stable order.
+	Doors []Door `json:"doors"`
+}
+
+// Doors reports every door's identity and live state — the dynamic half of
+// the Atlas's doorways. The Atlas says where a door's edges are and never
+// changes; this says what each door is doing now. A host reads it once and
+// keeps it fresh from EventDoor beats.
+func (m *Manager) Doors(ctx context.Context, in *DoorsInput) (*DoorsOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("doors: %w", ErrNilInput)
+	}
+	enc, err := m.open(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("doors: %w", err)
+	}
+
+	doors := enc.Doors()
+	out := &DoorsOutput{Doors: make([]Door, 0, len(doors))}
+	for _, d := range doors {
+		out.Doors = append(out.Doors, projectDoor(d))
+	}
+	return out, nil
+}
+
+// OpenDoorInput names the door and who pushes it.
+type OpenDoorInput struct {
+	// Session is the session to act in.
+	Session string
+
+	// Member is who pushes it open — the beat's actor.
+	Member string
+
+	// Door is the door's identifier, as the Atlas's doorways name it.
+	Door string
+}
+
+// OpenDoorOutput reports the door as it now stands and what opening it
+// revealed.
+type OpenDoorOutput struct {
+	// Door is the door, open now.
+	Door Door `json:"door"`
+
+	// Discovered is what the refresh brought into each observer's view —
+	// an opened door is the whole reason the verb refreshes sight.
+	Discovered map[string]Discovery `json:"discovered,omitempty"`
+
+	// Formed is present when what the door revealed started a fight.
+	Formed *Formed `json:"formed,omitempty"`
+
+	// Seq is the door beat's sequence number.
+	Seq uint64 `json:"seq"`
+
+	Saved    SaveReport     `json:"saved"`
+	Delivery DeliveryReport `json:"delivery"`
+}
+
+// OpenDoor pushes a shut door open as Member.
+//
+// A locked door refuses with ErrLocked, naming the DC — Unlock is the way
+// through one. An already-open door refuses with ErrNoConnection, the
+// composition's own refusal translated.
+func (m *Manager) OpenDoor(ctx context.Context, in *OpenDoorInput) (*OpenDoorOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("opendoor: %w", ErrNilInput)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("opendoor: %w", ErrNoMemberID)
+	}
+	if in.Door == "" {
+		return nil, fmt.Errorf("opendoor: %w", ErrNoConnection)
+	}
+
+	scope, err := m.openForWrite(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("opendoor: %w", err)
+	}
+
+	opened, err := scope.enc.OpenDoor(&encounter.OpenDoorInput{
+		Door:  in.Door,
+		Actor: encounter.MemberID(in.Member),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("opendoor: %w", translate(err))
+	}
+
+	down, err := discoveryStanding(scope)
+	if err != nil {
+		return nil, fmt.Errorf("opendoor: %w", err)
+	}
+
+	report, delivery, err := m.commit(ctx, scope)
+	if err != nil {
+		return nil, fmt.Errorf("opendoor: %w", err)
+	}
+
+	return &OpenDoorOutput{
+		Door:       Door{ID: opened.Door, State: string(opened.State)},
+		Discovered: projectDiscoveries(opened.IntelDeltas, down),
+		Formed:     projectFormed(opened.Formed),
+		Seq:        opened.Seq,
+		Saved:      report,
+		Delivery:   delivery,
+	}, nil
+}
+
+// UnlockInput names the lock and whose hands try it.
+type UnlockInput struct {
+	// Session is the session to act in.
+	Session string
+
+	// Member is whose hands — and whose ability modifier — try the lock.
+	Member string
+
+	// Door is the door's identifier.
+	Door string
+}
+
+// UnlockOutput is the attempt, in the open: the roll is public down to the
+// number (full data until v1.0), and the beat every member hears carries the
+// same facts.
+type UnlockOutput struct {
+	// Beaten is whether the check beat the DC. The session rolled it; the
+	// composition was told this verdict and nothing else.
+	Beaten bool `json:"beaten"`
+
+	// Total is what the check totalled. No omitempty: zero is an answer
+	// (TestFalseIsAnAnswerOnTheWire's law).
+	Total int `json:"total"`
+
+	// DC is what it had to reach.
+	DC int `json:"dc"`
+
+	// Door is the door as it now stands: open when beaten — a beaten lock
+	// OPENS the door, it does not merely unlock it — unchanged and
+	// retryable when not.
+	Door Door `json:"door"`
+
+	// Discovered is what a beaten lock brought into view.
+	Discovered map[string]Discovery `json:"discovered,omitempty"`
+
+	// Formed is present when what the opened door revealed started a fight.
+	Formed *Formed `json:"formed,omitempty"`
+
+	// Seq is the door beat's sequence number.
+	Seq uint64 `json:"seq"`
+
+	Saved    SaveReport     `json:"saved"`
+	Delivery DeliveryReport `json:"delivery"`
+}
+
+// Unlock tries a locked door as Member: an ability check against the lock's
+// authored DC, rolled HERE.
+//
+// The modifier is the member's ability modifier for the lock's authored
+// ability (the reference tomb's is "dex") — tool proficiency is shelved with
+// the tomb's authoring, which names no tool (rpg-project#269 §6.4). A failed
+// attempt is an outcome, not an error: the door is unchanged, the attempt is
+// narrated, and the caller may try again.
+func (m *Manager) Unlock(ctx context.Context, in *UnlockInput) (*UnlockOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("unlock: %w", ErrNilInput)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("unlock: %w", ErrNoMemberID)
+	}
+	if in.Door == "" {
+		return nil, fmt.Errorf("unlock: %w", ErrNoConnection)
+	}
+
+	scope, err := m.openForWrite(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("unlock: %w", err)
+	}
+
+	// The lock is read before anything rolls: the DC and the ability are
+	// the composition's facts, and a door that is not locked is refused by
+	// the composition itself below, in its own words.
+	var lock encounter.Lock
+	var locked bool
+	for _, d := range scope.enc.Doors() {
+		if d.ID == in.Door {
+			lock, locked = d.State.Lock()
+			break
+		}
+	}
+
+	beaten, total := false, 0
+	if locked {
+		sheet, err := m.loadAttackSheet(ctx, in.Member)
+		if err != nil {
+			return nil, fmt.Errorf("unlock: %w", err)
+		}
+
+		check, err := checks.MakeAbilityCheck(ctx, &checks.AbilityCheckInput{
+			Roller:   &diceSeam{roller: m.dice},
+			DC:       lock.DC,
+			Modifier: sheet.GetAbilityModifier(abilities.Ability(lock.Ability)),
+		})
+		if err != nil {
+			// A foreign error (rpgerr): carried as text, never wrapped into
+			// our chain (translate's own law).
+			return nil, fmt.Errorf("unlock %q: check failed: %v", in.Door, err)
+		}
+		beaten, total = check.Success, check.Total
+	}
+
+	unlocked, err := scope.enc.Unlock(&encounter.UnlockInput{
+		Door:   in.Door,
+		Beaten: beaten,
+		Actor:  encounter.MemberID(in.Member),
+		Total:  total,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("unlock: %w", translate(err))
+	}
+
+	down, err := discoveryStanding(scope)
+	if err != nil {
+		return nil, fmt.Errorf("unlock: %w", err)
+	}
+
+	report, delivery, err := m.commit(ctx, scope)
+	if err != nil {
+		return nil, fmt.Errorf("unlock: %w", err)
+	}
+
+	return &UnlockOutput{
+		Beaten:     unlocked.Beaten,
+		Total:      total,
+		DC:         unlocked.DC,
+		Door:       Door{ID: unlocked.Door, State: string(unlocked.State)},
+		Discovered: projectDiscoveries(unlocked.IntelDeltas, down),
+		Formed:     projectFormed(unlocked.Formed),
+		Seq:        unlocked.Seq,
+		Saved:      report,
+		Delivery:   delivery,
+	}, nil
+}
+
+// projectDoor is the seam's one projection of a door: the sealed state
+// interface becomes a string kind, and the lock rides only while it is real.
+func projectDoor(d encounter.Door) Door {
+	out := Door{ID: d.ID, State: string(d.State.Kind())}
+	if lock, locked := d.State.Lock(); locked {
+		out.Lock = &DoorLock{DC: lock.DC, Ability: lock.Ability, Tool: lock.Tool}
+	}
+	return out
+}

--- a/rulebooks/dnd5e/session/doors_test.go
+++ b/rulebooks/dnd5e/session/doors_test.go
@@ -1,0 +1,267 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+// doors_test.go drives the door verbs (rpg-project#268): Doors reads the
+// live state the Atlas deliberately does not carry, OpenDoor pushes a shut
+// door open, and Unlock rolls the sheet against the authored DC and TELLS
+// the composition the verdict. The walk refusals are the rpg-toolkit#1135
+// split, seen from the host's side: a locked door says locked, a shut door
+// says shut, and neither hides behind "bad position".
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// deftCharacter is a sheet whose DEX the unlock check reads: score 14 is a
+// +2 modifier, so testDice's flat 10 totals 12 — exactly the reference
+// tomb's DC, and a tie goes to the roller.
+func deftCharacter(id string, dex int) *character.Data {
+	return &character.Data{
+		ID: id, PlayerID: "player-" + id, Name: "Delve", Level: 3,
+		ProficiencyBonus: 2, RaceID: races.Dwarf, ClassID: classes.Rogue,
+		HitPoints: 20, MaxHitPoints: 20, ArmorClass: 14,
+		AbilityScores: shared.AbilityScores{abilities.DEX: dex},
+	}
+}
+
+// gatedWorld is read_test's hexWorld with the gate in a caller-chosen state
+// and alice standing at its west cell, one step from crossing it.
+func gatedWorld(t fataler, state encounter.DoorState) *encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Striker: encounter.RefusingStriker{}, Sight: encEveryoneSees{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: pointyCanvas(),
+			Regions: []encounter.RegionInput{
+				rectRegion("corridor", 0, 0, 6, 6),
+				rectRegion("vault", 6, 0, 6, 6),
+			},
+			Walls: hexSeamWalls(6, 6, 0),
+			Doors: []encounter.DoorInput{{
+				ID:    "gate",
+				Edges: []encounter.DoorEdge{{From: hexCell(5, 0), To: hexCell(6, 0)}},
+				State: state,
+			}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Position: spatial.Position{X: 5, Y: 0}},
+		},
+		Endings: []encounter.EndingInput{
+			{Key: "out", Trigger: encounter.TriggerExternal{}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("building gated world: %v", err)
+	}
+	data := enc.ToData()
+	return &data
+}
+
+const tombDC = 12
+
+func tombLock() encounter.DoorState {
+	return encounter.DoorIsLocked(encounter.Lock{DC: tombDC, Ability: "dex"})
+}
+
+type DoorsSuite struct {
+	suite.Suite
+
+	stream *fakeStream
+	mgr    *session.Manager
+}
+
+func TestDoorsSuite(t *testing.T) {
+	suite.Run(t, new(DoorsSuite))
+}
+
+// startWith wires a fresh manager around the given world and cast, with the
+// stream recorded — the beats are half of what this suite pins.
+func (s *DoorsSuite) startWith(world *encounter.EncounterData, cast ...*character.Data) {
+	s.stream = &fakeStream{}
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, TurnDriver: session.Pass{},
+		Sessions: newFakeSessions(), Encounters: newFakeEncounters(),
+		Characters: newFakeCharacters(cast...), Events: s.stream,
+	})
+	s.Require().NoError(err)
+	s.mgr = mgr
+
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: world,
+	})
+	s.Require().NoError(err)
+}
+
+// doorEvents filters what the stream heard down to the door beats one
+// audience received, typed.
+func (s *DoorsSuite) doorEvents(audience string) []session.DoorBody {
+	s.T().Helper()
+
+	out := make([]session.DoorBody, 0)
+	for _, e := range s.stream.published {
+		if e.Kind != session.EventDoor || e.Recipient != audience {
+			continue
+		}
+		body, ok := e.Body.(session.DoorBody)
+		s.Require().True(ok, "a door event carries its typed body")
+		out = append(out, body)
+	}
+	return out
+}
+
+func (s *DoorsSuite) TestDoorsReadsTheLiveState() {
+	ctx := context.Background()
+
+	s.Run("an open gate has no lock to report", func() {
+		s.startWith(hexWorld(s.T()))
+		out, err := s.mgr.Doors(ctx, &session.DoorsInput{Session: "sess"})
+		s.Require().NoError(err)
+		s.Require().Len(out.Doors, 1)
+		s.Equal(session.Door{ID: "gate", State: "open"}, out.Doors[0])
+	})
+
+	s.Run("a locked gate reports its lock, DC and all", func() {
+		s.startWith(gatedWorld(s.T(), tombLock()))
+		out, err := s.mgr.Doors(ctx, &session.DoorsInput{Session: "sess"})
+		s.Require().NoError(err)
+		s.Require().Len(out.Doors, 1)
+		s.Equal(session.Door{ID: "gate", State: "locked",
+			Lock: &session.DoorLock{DC: tombDC, Ability: "dex"}}, out.Doors[0])
+	})
+}
+
+func (s *DoorsSuite) TestAWalkIntoTheDoorSaysWhatStoppedIt() {
+	ctx := context.Background()
+
+	s.Run("locked says locked — the fiction beat, not a bad cell", func() {
+		s.startWith(gatedWorld(s.T(), tombLock()))
+		_, err := s.mgr.Move(ctx, &session.MoveInput{
+			Session: "sess", Member: "alice", Path: []spatial.Position{hexCell(6, 0)}})
+		s.Require().ErrorIs(err, session.ErrLocked)
+		s.NotErrorIs(err, session.ErrBadPosition,
+			"a caller told bad-position goes looking for arithmetic that is fine")
+	})
+
+	s.Run("shut says shut — the remedy is OpenDoor, not new coordinates", func() {
+		s.startWith(gatedWorld(s.T(), encounter.DoorIsClosed()))
+		_, err := s.mgr.Move(ctx, &session.MoveInput{
+			Session: "sess", Member: "alice", Path: []spatial.Position{hexCell(6, 0)}})
+		s.Require().ErrorIs(err, session.ErrDoorShut)
+		s.NotErrorIs(err, session.ErrBadPosition)
+	})
+}
+
+func (s *DoorsSuite) TestOpenDoorOpensAndTheTableHears() {
+	ctx := context.Background()
+	s.startWith(gatedWorld(s.T(), encounter.DoorIsClosed()))
+
+	out, err := s.mgr.OpenDoor(ctx, &session.OpenDoorInput{
+		Session: "sess", Member: "alice", Door: "gate"})
+	s.Require().NoError(err)
+	s.Equal(session.Door{ID: "gate", State: "open"}, out.Door)
+
+	read, err := s.mgr.Doors(ctx, &session.DoorsInput{Session: "sess"})
+	s.Require().NoError(err)
+	s.Equal("open", read.Doors[0].State, "the read agrees with the verb")
+
+	beats := s.doorEvents("alice")
+	s.Require().Len(beats, 1)
+	s.Equal(session.DoorBody{Door: "gate", State: "open", Actor: "alice"}, beats[0],
+		"the beat names the door, the state, and whose hands")
+
+	_, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice", Path: []spatial.Position{hexCell(6, 0)}})
+	s.NoError(err, "and the way is open")
+}
+
+func (s *DoorsSuite) TestOpenDoorRefusesALockedOne() {
+	s.startWith(gatedWorld(s.T(), tombLock()))
+	_, err := s.mgr.OpenDoor(context.Background(), &session.OpenDoorInput{
+		Session: "sess", Member: "alice", Door: "gate"})
+	s.Require().ErrorIs(err, session.ErrLocked, "Unlock is the way through a lock")
+}
+
+func (s *DoorsSuite) TestUnlockRollsTheSheetAgainstTheDC() {
+	ctx := context.Background()
+	s.startWith(gatedWorld(s.T(), tombLock()), deftCharacter("alice", 14))
+
+	out, err := s.mgr.Unlock(ctx, &session.UnlockInput{
+		Session: "sess", Member: "alice", Door: "gate"})
+	s.Require().NoError(err)
+	s.True(out.Beaten, "10 rolled + 2 dex meets DC 12 — a tie goes to the roller")
+	s.Equal(tombDC, out.Total, "the total is public, down to the number")
+	s.Equal(tombDC, out.DC)
+	s.Equal("open", out.Door.State, "a beaten lock OPENS the door, it does not merely unlock it")
+
+	beats := s.doorEvents("alice")
+	s.Require().Len(beats, 1)
+	s.Equal(session.DoorBody{Door: "gate", State: "open", Actor: "alice",
+		DC: tombDC, Total: tombDC, Beaten: true}, beats[0],
+		"the attempt is narrated with its author and its numbers")
+}
+
+func (s *DoorsSuite) TestAFailedUnlockIsAnOutcomeNotAnError() {
+	ctx := context.Background()
+	s.startWith(gatedWorld(s.T(), tombLock()), deftCharacter("alice", 10))
+
+	out, err := s.mgr.Unlock(ctx, &session.UnlockInput{
+		Session: "sess", Member: "alice", Door: "gate"})
+	s.Require().NoError(err, "a failed check is an outcome, not an error")
+	s.False(out.Beaten, "10 rolled + 0 dex misses DC 12")
+	s.Equal(10, out.Total)
+	s.Equal("locked", out.Door.State, "unchanged")
+
+	beats := s.doorEvents("alice")
+	s.Require().Len(beats, 1)
+	s.Equal(session.DoorBody{Door: "gate", State: "locked", Actor: "alice",
+		DC: tombDC, Total: 10, Beaten: false}, beats[0],
+		"the miss is as much fiction as the hit")
+
+	again, err := s.mgr.Unlock(ctx, &session.UnlockInput{
+		Session: "sess", Member: "alice", Door: "gate"})
+	s.Require().NoError(err, "and the lock is retryable")
+	s.False(again.Beaten)
+}
+
+func (s *DoorsSuite) TestUnlockOfAnUnlockedDoorIsRefused() {
+	s.startWith(hexWorld(s.T()), deftCharacter("alice", 14))
+	_, err := s.mgr.Unlock(context.Background(), &session.UnlockInput{
+		Session: "sess", Member: "alice", Door: "gate"})
+	s.Require().ErrorIs(err, session.ErrNoConnection,
+		"the composition's own refusal, translated — there is no lock to try")
+}
+
+func (s *DoorsSuite) TestTheEndedBeatCarriesItsKey() {
+	ctx := context.Background()
+	s.startWith(hexWorld(s.T()))
+
+	_, err := s.mgr.End(ctx, &session.EndInput{Session: "sess", Ending: "out"})
+	s.Require().NoError(err)
+
+	var endeds []session.EndedBody
+	for _, e := range s.stream.published {
+		if e.Kind != session.EventEnded || e.Recipient != "alice" {
+			continue
+		}
+		body, ok := e.Body.(session.EndedBody)
+		s.Require().True(ok, "an ended event carries its typed body")
+		endeds = append(endeds, body)
+	}
+	s.Require().Len(endeds, 1)
+	s.Equal(session.EndedBody{Ending: "out"}, endeds[0],
+		"a client following the stream finally hears HOW the run ended")
+}

--- a/rulebooks/dnd5e/session/doors_test.go
+++ b/rulebooks/dnd5e/session/doors_test.go
@@ -237,6 +237,17 @@ func (s *DoorsSuite) TestAFailedUnlockIsAnOutcomeNotAnError() {
 	s.False(again.Beaten)
 }
 
+func (s *DoorsSuite) TestALockNamingNoRulebookAbilityIsRefusedLoudly() {
+	s.startWith(
+		gatedWorld(s.T(), encounter.DoorIsLocked(encounter.Lock{DC: tombDC, Ability: "luck"})),
+		deftCharacter("alice", 14))
+	_, err := s.mgr.Unlock(context.Background(), &session.UnlockInput{
+		Session: "sess", Member: "alice", Door: "gate"})
+	s.Require().ErrorIs(err, session.ErrInvalidWorld,
+		"a content defect, refused by name — never a silent -5 from an unknown key")
+	s.Contains(err.Error(), "luck")
+}
+
 func (s *DoorsSuite) TestUnlockOfAnUnlockedDoorIsRefused() {
 	s.startWith(hexWorld(s.T()), deftCharacter("alice", 14))
 	_, err := s.mgr.Unlock(context.Background(), &session.UnlockInput{

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -157,11 +157,17 @@ var (
 	// reason — a host that could only see "bad position" would have nothing to
 	// say and would send somebody hunting a bug in coordinates that are fine.
 	//
-	// NOT yet raised for a walk INTO a locked door. The composition refuses
-	// that with a placement error carrying the door's state as text only, so a
-	// blocked step still arrives here as ErrBadPosition (rpg-toolkit#1135).
-	// This is the translation of the door verb's own refusal until then.
+	// Raised for the door verb's refusal AND for a walk INTO a locked door —
+	// the composition names both with its own sentinel now
+	// (rpg-toolkit#1135), so a blocked step no longer hides behind
+	// ErrBadPosition.
 	ErrLocked = errors.New("door is locked")
+
+	// ErrDoorShut is returned when a walk crosses a door that is merely
+	// closed — shut but not locked. The other half of the rpg-toolkit#1135
+	// split: the cell is real and the way is shut, a fiction beat whose
+	// remedy is OpenDoor, not different coordinates.
+	ErrDoorShut = errors.New("door is shut")
 
 	// ErrNoConnection is the translation of a composition-side refusal to cross
 	// a doorway.

--- a/rulebooks/dnd5e/session/events.go
+++ b/rulebooks/dnd5e/session/events.go
@@ -256,6 +256,8 @@ func kindFor(beat string) EventKind {
 	// rename there would be a migration; a translation here is a line.
 	case "down":
 		return EventDowned
+	case "door":
+		return EventDoor
 	default:
 		return EventUnknown
 	}
@@ -291,6 +293,27 @@ func bodyFor(kind EventKind, payload []byte) EventBody {
 			return nil
 		}
 		return ExitedBody{Member: p.Member}
+	case EventEnded:
+		var p struct {
+			Ending string `json:"ending"`
+		}
+		if json.Unmarshal(payload, &p) != nil || p.Ending == "" {
+			return nil
+		}
+		return EndedBody{Ending: p.Ending}
+	case EventDoor:
+		var p struct {
+			Door   string `json:"door"`
+			State  string `json:"state"`
+			Actor  string `json:"actor"`
+			DC     int    `json:"dc"`
+			Total  int    `json:"total"`
+			Beaten bool   `json:"beaten"`
+		}
+		if json.Unmarshal(payload, &p) != nil || p.Door == "" || p.State == "" {
+			return nil
+		}
+		return DoorBody{Door: p.Door, State: p.State, Actor: p.Actor, DC: p.DC, Total: p.Total, Beaten: p.Beaten}
 	case EventTurnEnded:
 		var p struct {
 			Member string `json:"member"`
@@ -329,8 +352,8 @@ func bodyFor(kind EventKind, payload []byte) EventBody {
 		}
 		return DownedBody{Member: p.Member}
 	default:
-		// EventEnded, EventSceneOpened, EventTick: no body member exists for
-		// these — see EventBody's own doc.
+		// EventSceneOpened, EventTick: no body member exists for these — see
+		// EventBody's own doc.
 		return nil
 	}
 }

--- a/rulebooks/dnd5e/session/events_internal_test.go
+++ b/rulebooks/dnd5e/session/events_internal_test.go
@@ -134,6 +134,9 @@ func TestBodyForRefusesAMissingRequiredField(t *testing.T) {
 		{"struck with two targets", EventStruck, `{"beat":"struck","actor":"alice","targets":["bob","carol"],"attack":{"ref":"longsword"}}`},
 		{"struck with no attack ref", EventStruck, `{"beat":"struck","actor":"alice","targets":["bob"]}`},
 		{"missed with no actor", EventMissed, `{"beat":"missed","targets":["bob"],"attack":{"ref":"longsword"}}`},
+		{"ended with no ending", EventEnded, `{"beat":"ended"}`},
+		{"door with no door", EventDoor, `{"beat":"door","state":"open"}`},
+		{"door with no state", EventDoor, `{"beat":"door","door":"gate"}`},
 	}
 
 	for _, tc := range cases {
@@ -173,6 +176,15 @@ func TestJoinedAndExitedBodiesCarryTheMember(t *testing.T) {
 	}{
 		{"joined", `{"beat":"joined","member":"erin"}`, EventJoined, JoinedBody{Member: "erin"}},
 		{"exited", `{"beat":"exited","member":"erin"}`, EventExited, ExitedBody{Member: "erin"}},
+		// rpg-project#268: the close and the door are narrated from typed
+		// facts too. An ended beat carries its declared key; a door beat
+		// carries the door, its state, and — on an unlock attempt — the
+		// actor and the numbers (full data until v1.0).
+		{"ended", `{"beat":"ended","ending":"boss-down"}`, EventEnded, EndedBody{Ending: "boss-down"}},
+		{"door opened", `{"beat":"door","door":"gate","state":"open","actor":"erin"}`,
+			EventDoor, DoorBody{Door: "gate", State: "open", Actor: "erin"}},
+		{"door attempt", `{"beat":"door","door":"gate","state":"locked","actor":"erin","dc":12,"total":9,"beaten":false}`,
+			EventDoor, DoorBody{Door: "gate", State: "locked", Actor: "erin", DC: 12, Total: 9, Beaten: false}},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.33.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.33.1
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
@@ -26,5 +26,3 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
-
-replace github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter => /home/kirk/game-dev/rpg-toolkit/.worktrees/run-ending/rulebooks/dnd5e/encounter

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -26,3 +26,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter => /home/kirk/game-dev/rpg-toolkit/.worktrees/run-ending/rulebooks/dnd5e/encounter

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -20,6 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0 h1:8c/xoqxgXqRO3LxoEX
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0 h1:LxEJMtm4M3PMDnpRC61ooGvWKS/eRZImu/GTeTDCYuM=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0/go.mod h1:Y5eXfAAyQ0N4Sp07T5C7MxD2CwAwdAUi2zo5SyN60Ds=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.33.1 h1:4xF4l/oe8qOL9LUcaQ953BP6xLWVUsYlLt9vqwIhL3k=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.33.1/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0 h1:Ftc+y0UnhW0wTlovA6RFoYDL/6un1ZKJdc1p3SXGB0w=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0/go.mod h1:HzM2KKrpUlpOLfesRkxy8V8enQdmRzvsisZrEuB9BM8=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -20,8 +20,6 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0 h1:8c/xoqxgXqRO3LxoEX
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0 h1:LxEJMtm4M3PMDnpRC61ooGvWKS/eRZImu/GTeTDCYuM=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0/go.mod h1:Y5eXfAAyQ0N4Sp07T5C7MxD2CwAwdAUi2zo5SyN60Ds=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.33.0 h1:UJ5vlRYK/0QLrWut8pR/pmOeNJfP/nVPXbQNkK+nz5k=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.33.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0 h1:Ftc+y0UnhW0wTlovA6RFoYDL/6un1ZKJdc1p3SXGB0w=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0/go.mod h1:HzM2KKrpUlpOLfesRkxy8V8enQdmRzvsisZrEuB9BM8=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -439,17 +439,17 @@ func translate(err error) error {
 		errors.Is(err, encounter.ErrBadDoor):
 		return fmt.Errorf("%w", ErrNoConnection)
 	case errors.Is(err, encounter.ErrLocked):
-		// A door refusing to open because it is locked. Checked BEFORE
-		// ErrBadPlacement below: a locked door is a fiction beat with a DC
-		// behind it, and a caller told "bad position" would go looking for
-		// arithmetic that is fine.
-		//
-		// This catches the DOOR VERB's refusal only. A walk into a locked door
-		// still arrives as ErrBadPlacement, because the composition puts the
-		// door's state in text rather than in a sentinel (rpg-toolkit#1135).
-		// When that lands, the walk case joins this one and nothing else here
-		// has to change.
+		// A locked door — the door verb's refusal AND a walk into one, now
+		// that the composition names both with its own sentinel
+		// (rpg-toolkit#1135). Checked BEFORE ErrBadPlacement below: a locked
+		// door is a fiction beat with a DC behind it, and a caller told "bad
+		// position" would go looking for arithmetic that is fine.
 		return fmt.Errorf("%w", ErrLocked)
+	case errors.Is(err, encounter.ErrDoorShut):
+		// A merely-shut door in a walk's path — the other half of the same
+		// split: shut is a state a caller can change (OpenDoor), not a bad
+		// coordinate.
+		return fmt.Errorf("%w", ErrDoorShut)
 	case errors.Is(err, encounter.ErrBadPlacement):
 		return fmt.Errorf("%w", ErrBadPosition)
 	case errors.Is(err, encounter.ErrNoField), errors.Is(err, encounter.ErrInvalidData):

--- a/rulebooks/dnd5e/session/sentinels_test.go
+++ b/rulebooks/dnd5e/session/sentinels_test.go
@@ -76,6 +76,7 @@ var compositionSentinels = map[string]error{
 	"encounter.ErrNoDoor":                 encounter.ErrNoDoor,
 	"encounter.ErrBadDoor":                encounter.ErrBadDoor,
 	"encounter.ErrLocked":                 encounter.ErrLocked,
+	"encounter.ErrDoorShut":               encounter.ErrDoorShut,
 	"encounter.ErrNoRegion":               encounter.ErrNoRegion,
 	"encounter.ErrInBubble":               encounter.ErrInBubble,
 	"encounter.ErrNoBubble":               encounter.ErrNoBubble,

--- a/rulebooks/dnd5e/session/translate_internal_test.go
+++ b/rulebooks/dnd5e/session/translate_internal_test.go
@@ -47,12 +47,12 @@ func TestTranslateLetsNoCompositionSentinelThrough(t *testing.T) {
 		// arrive as ErrBadPosition — "that is not a place" and "the way is
 		// shut" send whoever reads them somewhere different.
 		{"locked door", encounter.ErrLocked, ErrLocked},
-		// NOTE: this table used to carry `ErrNoCrossing` for a step into an
-		// adjacent cell with no doorway joining it. The composition no longer
-		// distinguishes that case — a walk into a shut door comes back as a
-		// placement refusal carrying the door's state in TEXT — so the sentinel
-		// was removed rather than kept as one nothing can produce.
-		// rpg-toolkit#1135 is what would give it a source again.
+		// The other half of the rpg-toolkit#1135 split, landed: a walk into a
+		// merely-shut door arrives on the composition's own sentinel now, not
+		// as a placement refusal with the state in text. (This table once
+		// carried `ErrNoCrossing` for the sourceless version of this case;
+		// #1135 is what gave the distinction a source again.)
+		{"shut door", encounter.ErrDoorShut, ErrDoorShut},
 		{"bad placement", encounter.ErrBadPlacement, ErrBadPosition},
 		{"already in a fight", encounter.ErrInBubble, ErrInBubble},
 		{"not in a fight", encounter.ErrNoBubble, ErrNotInFight},

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -557,6 +557,14 @@ const (
 	// side by side while narrating one exchange.
 	EventDowned EventKind = "downed"
 
+	// EventDoor reports a door changing — opened, closed, or an unlock
+	// attempt, beaten or not. A failed attempt is as much fiction as a
+	// beaten one, and the composition writes both through one path
+	// (rpg-project#268). Every member of the encounter hears it: door
+	// knowledge is roster-wide until asymmetric perception
+	// (rpg-toolkit#1020) narrows it.
+	EventDoor EventKind = "door"
+
 	// EventUnknown is a beat this version does not recognise.
 	//
 	// Delivered rather than dropped on purpose: a client that cannot interpret
@@ -617,8 +625,8 @@ type Event struct {
 	// Body is the beat, typed: a sealed interface with one struct per kind
 	// that has one, decoded from the SAME payload this package already
 	// wrote rather than a second encoding of it (rpg-toolkit#941). Nil in
-	// three cases: a kind with no typed body member (ENDED, SCENE_OPENED,
-	// TICK, UNKNOWN); a beat this build's decoder does not recognise; and a
+	// three cases: a kind with no typed body member (SCENE_OPENED, TICK,
+	// UNKNOWN); a beat this build's decoder does not recognise; and a
 	// beat whose declared kind IS recognised but whose payload does not
 	// match that kind's required shape — bodyFor's own refusal rather than
 	// a zero-valued body (see TestBodyForRefusesAMissingRequiredField).
@@ -628,7 +636,7 @@ type Event struct {
 // EventBody is the beat, typed — a sealed interface with one struct per
 // kind Event.Body carries: TurnEndedBody, DownedBody, StruckBody,
 // MissedBody, FightStartedBody, FightEndedBody, MovedBody, JoinedBody,
-// ExitedBody. Sealed the way
+// ExitedBody, EndedBody, DoorBody. Sealed the way
 // DissolveCause is (dissolve.go) and for the same reason: a caller matches
 // on it with a type switch, and a second implementation declared outside
 // this package would be indistinguishable from these to anyone reading the
@@ -747,6 +755,66 @@ type ExitedBody struct {
 }
 
 func (ExitedBody) isEventBody() {}
+
+// EndedBody is EventEnded's typed body: the declared ending that fired.
+//
+// The key is a content string ("boss-down", "withdrawn", "abandoned"), not
+// an enum — what an ending MEANS is authored, and the client maps key to
+// sentence (rpg-project#269 §6.3). The full outcome is Status's answer;
+// this beat arrives on the WORLD clock, after the fight it may have grown
+// out of has dissolved (ruling §6.6).
+type EndedBody struct {
+	Ending string `json:"ending"`
+}
+
+func (EndedBody) isEventBody() {}
+
+// DoorBody is EventDoor's typed body: which door, what it is now, and — on
+// an unlock attempt — the numbers behind it.
+//
+// DC, Total and Beaten are set only on attempt beats; a plain open or close
+// carries DC zero. Actor is empty when the change has no author to narrate.
+// The total is public down to the number — full data until v1.0.
+type DoorBody struct {
+	Door   string `json:"door"`
+	State  string `json:"state"`
+	Actor  string `json:"actor,omitempty"`
+	DC     int    `json:"dc,omitempty"`
+	Total  int    `json:"total,omitempty"`
+	Beaten bool   `json:"beaten,omitempty"`
+}
+
+func (DoorBody) isEventBody() {}
+
+// Door is one door's identity and live state — the dynamic half of
+// [AtlasDoorway], which carries the same door's edges and never changes.
+// Read via [Manager.Doors] once, then updated from EventDoor beats.
+type Door struct {
+	// ID is the same identifier AtlasDoorway.Door carries.
+	ID string `json:"id"`
+
+	// State is "open", "closed" or "locked" — the composition's own kinds,
+	// projected as strings for the same reason MemberKind is.
+	State string `json:"state"`
+
+	// Lock is set only while State is "locked".
+	Lock *DoorLock `json:"lock,omitempty"`
+}
+
+// DoorLock is an authored lock, carried not interpreted — the DC is public
+// down to the number (full data until v1.0), and what beats it is
+// [Manager.Unlock]'s ruling, never a comparison the composition makes.
+type DoorLock struct {
+	// DC is the authored difficulty. No omitempty: zero would be an answer
+	// if an author wrote one (TestFalseIsAnAnswerOnTheWire's law).
+	DC int `json:"dc"`
+
+	// Ability is the opaque rulebook ref the check uses, e.g. "dex".
+	Ability string `json:"ability,omitempty"`
+
+	// Tool is the opaque item ref a lock may name; empty when none.
+	Tool string `json:"tool,omitempty"`
+}
 
 // SaveReport names which aggregates were persisted by a verb and which were
 // not.


### PR DESCRIPTION
Closes #1242. The session half of the run-ending slice — rpg-project#268, design rpg-project#269 (ruled), journey rpg-project#253. Pins encounter v0.33.1 (#1241's release).

**The verbs.** `Doors` reads every door's live state — the dynamic half the Atlas deliberately does not carry (its own doc anticipated exactly this read). `OpenDoor` and `Unlock` mirror the composition's tomb-tested verbs; `Unlock` is where the verdict lives: load the member's sheet, roll `checks.MakeAbilityCheck` through the existing `diceSeam` with the lock's authored ability modifier (ability mod only — tool proficiency shelved with the tomb's authoring, ruling §6.4), and TELL the composition `Beaten`. Told-not-compared holds on both sides of the seam.

**The vocabulary.** `EventDoor` + `DoorBody{door, state, actor, dc, total, beaten}` — the attempt narrated with its author and its numbers, both outcomes (full data until v1.0). `EventEnded` finally gets `EndedBody{Ending}`: a stream client can hear HOW the run ended without decoding payload bytes.

**The #1135 split, host side.** A walk into a locked door translates to `session.ErrLocked` (the stranded seam comment finally has its source); a merely-shut one gets the new `ErrDoorShut`. Both pinned in `doors_test.go` (a walk refused as fiction, never as `ErrBadPosition`), the translate exhaustiveness table, and the sentinel-leak suite.

Evidence: `go test ./...` green (session + workbench), `golangci-lint` 0 issues. New suite `doors_test.go` (state read, walk refusals both halves, open + narrate, unlock beaten/failed/retryable with the tie-goes-to-the-roller DC-12 case, unlocked-door refusal, typed ended beat); events/table pins extended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ruVTnkc9Jzu6KTAWGLzbu