### PR TITLE
feat(encounter): carry replayable strike detail (#1238)

### DIFF
--- a/rulebooks/dnd5e/encounter/outcome.go
+++ b/rulebooks/dnd5e/encounter/outcome.go
@@ -6,6 +6,7 @@ package encounter
 import (
 	"encoding/json"
 	"fmt"
+	"math"
 	"sort"
 
 	"github.com/KirkDiggler/rpg-toolkit/play/record"
@@ -258,7 +259,8 @@ type RecordOutput struct {
 //
 // Errors: ErrNilInput, ErrClosed, ErrNoMember (empty or unknown actor, unknown
 // target), ErrInvalidData (a kind or value name this composition does not
-// know, or an Attack whose Ref or Name is empty), and anything the
+// know, an Attack whose Ref or Name is empty, or a non-finite damage
+// multiplier JSON cannot represent), and anything the
 // [Standing] capability answers with — including ErrNotMember for an answer
 // naming a stranger.
 //
@@ -310,6 +312,15 @@ func (e *Encounter) Record(in *RecordInput) (*RecordOutput, error) {
 		}
 	}
 	sort.Slice(names, func(i, j int) bool { return names[i] < names[j] })
+
+	if in.Kind == OutcomeStruck {
+		for i, component := range in.DamageComponents {
+			if component.Multiplier != nil &&
+				(math.IsNaN(*component.Multiplier) || math.IsInf(*component.Multiplier, 0)) {
+				return nil, fmt.Errorf("record: damage component %d multiplier: %w", i, ErrInvalidData)
+			}
+		}
+	}
 
 	payload := map[string]interface{}{
 		"beat":  string(in.Kind),

--- a/rulebooks/dnd5e/encounter/outcome.go
+++ b/rulebooks/dnd5e/encounter/outcome.go
@@ -77,12 +77,12 @@ const (
 
 // RecordInput is one rulebook outcome, offered to the story.
 //
-// THERE IS NO STRING FIELD HERE, and there will not be one. Every member is an
+// THERE IS NO PROSE FIELD HERE, and there will not be one. Every member is an
 // ID the composition validates against its own roster, the kind is a closed
-// enum, and the values are integers under closed keys. Prose is not something
-// this input can express — not discouraged, not filtered, INEXPRESSIBLE — so
-// no caller can narrate into a transcript that other players read, and no
-// future caller can start.
+// enum, and the remaining primitives are catalog/rulebook facts under a closed
+// shape. Prose is not something this input can express — not discouraged, not
+// filtered, INEXPRESSIBLE — so no caller can narrate into a transcript that
+// other players read, and no future caller can start.
 //
 // That is the difference between this and the general "append anything" hole
 // it replaces the need for. The composition stays the only author of its
@@ -115,6 +115,37 @@ type RecordInput struct {
 	// see AttackIdentity's own doc for exactly what this input does and
 	// does not check about that.
 	Attack *AttackIdentity
+
+	// DamageComponents are the ordered primitive facts that produced a struck
+	// outcome. Meaning belongs to the rulebook; this composition preserves the
+	// supplied order and values without interpreting them.
+	DamageComponents []DamageComponent
+
+	// AdvantageSources and DisadvantageSources identify the ordered sources the
+	// attack fold reported. They carry identifiers only, never the rules engine's
+	// human-readable Reason string.
+	AdvantageSources    []AttackModifierSource
+	DisadvantageSources []AttackModifierSource
+}
+
+// DamageComponent carries one ordered, rulebook-neutral damage contribution.
+// It uses only primitives this module can persist without importing the
+// rulebook packages that own their meaning.
+type DamageComponent struct {
+	Source     string   `json:"source"`
+	SourceRef  string   `json:"source_ref,omitempty"`
+	Dice       string   `json:"dice,omitempty"`
+	FinalRolls []int    `json:"final_rolls,omitempty"`
+	FlatBonus  int      `json:"flat_bonus"`
+	DamageType string   `json:"damage_type"`
+	Multiplier *float64 `json:"multiplier,omitempty"`
+}
+
+// AttackModifierSource identifies an entity/content source without carrying
+// prose. Empty strings mean that identifier was absent.
+type AttackModifierSource struct {
+	SourceRef string `json:"source_ref,omitempty"`
+	SourceID  string `json:"source_id,omitempty"`
 }
 
 // AttackIdentity names what was swung — ref, display name, and damage type —
@@ -303,6 +334,15 @@ func (e *Encounter) Record(in *RecordInput) (*RecordOutput, error) {
 	// state.
 	if in.Kind == OutcomeStruck {
 		payload["critical"] = in.Critical
+		if len(in.DamageComponents) > 0 {
+			payload["damage_components"] = in.DamageComponents
+		}
+		if len(in.AdvantageSources) > 0 {
+			payload["advantage_sources"] = in.AdvantageSources
+		}
+		if len(in.DisadvantageSources) > 0 {
+			payload["disadvantage_sources"] = in.DisadvantageSources
+		}
 	}
 	if in.Attack != nil {
 		if in.Attack.Ref == "" {

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -115,6 +115,61 @@ func (s *OutcomeTestSuite) TestARecordedStrikeCarriesWhatWasSwung() {
 	s.Equal("slashing", attack["damage_type"])
 }
 
+// TestARecordedStrikeCarriesOrderedDetail pins the closed primitive carrier
+// that lets session replay the rulebook's strike evidence without giving this
+// composition rule imports or a prose channel.
+func (s *OutcomeTestSuite) TestARecordedStrikeCarriesOrderedDetail() {
+	immunity := 0.0
+	in := &encounter.RecordInput{
+		Kind: encounter.OutcomeStruck, Actor: alice,
+		Targets: []encounter.MemberID{goblin},
+		DamageComponents: []encounter.DamageComponent{
+			{
+				Source: "weapon", SourceRef: "dnd5e:weapons:longsword",
+				Dice: "1d8", FinalRolls: []int{4}, FlatBonus: 0, DamageType: "slashing",
+			},
+			{
+				Source: "monster_trait", SourceRef: "dnd5e:monster-traits:immunity",
+				DamageType: "slashing", Multiplier: &immunity,
+			},
+		},
+		AdvantageSources: []encounter.AttackModifierSource{
+			{SourceRef: "dnd5e:conditions:hidden", SourceID: "alice"},
+		},
+		DisadvantageSources: []encounter.AttackModifierSource{
+			{SourceRef: "dnd5e:conditions:dodging", SourceID: "goblin"},
+		},
+	}
+
+	record := func() []byte {
+		enc := s.scene()
+		_, err := enc.Record(in)
+		s.Require().NoError(err)
+		story, serr := enc.Story(&encounter.StoryInput{Audience: goblin})
+		s.Require().NoError(serr)
+		s.Require().NotEmpty(story)
+		return story[len(story)-1].Payload
+	}
+
+	first := record()
+	second := record()
+	s.Equal(first, second, "identical ordered input produces identical story bytes")
+	s.NotContains(string(first), `"reason"`, "the carrier has no prose field")
+
+	var beat struct {
+		DamageComponents    []encounter.DamageComponent      `json:"damage_components"`
+		AdvantageSources    []encounter.AttackModifierSource `json:"advantage_sources"`
+		DisadvantageSources []encounter.AttackModifierSource `json:"disadvantage_sources"`
+	}
+	s.Require().NoError(json.Unmarshal(first, &beat))
+	s.Equal(in.DamageComponents, beat.DamageComponents)
+	s.Equal(in.AdvantageSources, beat.AdvantageSources)
+	s.Equal(in.DisadvantageSources, beat.DisadvantageSources)
+	s.Require().NotNil(beat.DamageComponents[1].Multiplier,
+		"zero is a present immunity multiplier, not an absent multiplier")
+	s.Zero(*beat.DamageComponents[1].Multiplier)
+}
+
 // TestARecordedMissCarriesNoCriticalKey pins that a miss's payload never
 // says "critical" at all — a whiff cannot crit, so there is nothing to
 // answer false about, unlike a hit where false is itself a meaningful
@@ -191,9 +246,17 @@ func (s *OutcomeTestSuite) TestTheTargetHearsItToo() {
 // Actor/Targets already occupy, not what a caller can SAY — and "no prose"
 // here now holds for presence exactly as it does for the fields beside it;
 // only meaning is still the rulebook's to guarantee.
+//
+// DAMAGE COMPONENTS AND MODIFIER SOURCES MAKE THE SAME TRADE (rpg-project#265).
+// Their nested fields are identifiers, dice notation, numbers, and closed
+// rulebook words carried as primitives. AttackModifierSource deliberately has
+// no Reason string: the rules engine's human-readable explanation does not
+// become caller-authored prose in this transcript.
 func (s *OutcomeTestSuite) TestAnOutcomeCarriesNoProse() {
-	s.Equal([]string{"Kind", "Actor", "Targets", "Values", "Critical", "Attack"},
-		structFieldNames(encounter.RecordInput{}),
+	s.Equal([]string{
+		"Kind", "Actor", "Targets", "Values", "Critical", "Attack",
+		"DamageComponents", "AdvantageSources", "DisadvantageSources",
+	}, structFieldNames(encounter.RecordInput{}),
 		"a new field on RecordInput needs an argument: free text here is prose "+
 			"in a transcript other players read")
 }

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -5,6 +5,7 @@ package encounter_test
 
 import (
 	"encoding/json"
+	"math"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -283,6 +284,24 @@ func (s *OutcomeTestSuite) TestRefusalsAreCheckedAgainstTheRoster() {
 		})
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
+
+	for _, tc := range []struct {
+		name       string
+		multiplier float64
+	}{
+		{"NaN multiplier", math.NaN()},
+		{"positive infinite multiplier", math.Inf(1)},
+		{"negative infinite multiplier", math.Inf(-1)},
+	} {
+		s.Run(tc.name, func() {
+			_, err := s.scene().Record(&encounter.RecordInput{
+				Kind: encounter.OutcomeStruck, Actor: alice,
+				DamageComponents: []encounter.DamageComponent{{Multiplier: &tc.multiplier}},
+			})
+			s.ErrorIs(err, encounter.ErrInvalidData,
+				"an unrepresentable JSON number is structural invalid data")
+		})
+	}
 
 	s.Run("an actor who is not a member", func() {
 		_, err := s.scene().Record(&encounter.RecordInput{


### PR DESCRIPTION
## Summary

- add a closed primitive carrier for ordered struck damage components
- persist ordered advantage/disadvantage source refs and source entity IDs
- preserve optional zero multipliers and deterministic story bytes

## Boundaries

- encounter imports no rulebook damage/event package
- human-readable modifier reasons remain in resolution and cannot enter `RecordInput`
- `Missed` and old aggregate-only struck payloads remain unchanged

## Verification

From `rulebooks/dnd5e/encounter`:

- focused RED/GREEN outcome tests
- `go test -race ./...`
- `golangci-lint run ./...`
- `git diff --check`
- no committed `replace`

Closes #1238. Parent: KirkDiggler/rpg-project#265.

— asset-pipeline agent, on behalf of KirkDiggler
