### PR TITLE
feat(session): expose replayable strike detail (#1239)

### DIFF
--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -12,6 +12,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
 )
@@ -430,17 +431,8 @@ func translateResolution(err error) error {
 }
 
 // recordFor turns a strike into the outcome the composition will stamp.
-//
-// CRITICAL IS NOT RECORDED, and the reason has an expiry date worth writing
-// down. ValueRoll is the RAW d20, so today a beat carrying roll:20 already says
-// the blow was critical — a reader derives it, and adding a kind for it would
-// be vocabulary earning nothing.
-//
-// That holds ONLY while every reachable attack crits on a natural 20 alone.
-// The machine already supports a crit threshold, so an expanded range — a
-// Champion's 19–20 — produces a critical hit at roll:19 that this beat cannot
-// tell from an ordinary one. THAT is the caller that earns recorded crit
-// vocabulary, and when it arrives this comment is where to start.
+// It copies resolution-owned facts once; replay decodes this record rather
+// than reconstructing damage or modifier attribution later.
 func recordFor(
 	in *AttackInput, struck resolution.StrikeOutcome, definition combatActions.Definition,
 ) *encounter.RecordInput {
@@ -456,7 +448,7 @@ func recordFor(
 	}
 
 	ref := attackRefFor(definition)
-	return &encounter.RecordInput{
+	recorded := &encounter.RecordInput{
 		Kind:     kind,
 		Actor:    encounter.MemberID(in.Attacker),
 		Targets:  []encounter.MemberID{encounter.MemberID(in.Target)},
@@ -464,6 +456,55 @@ func recordFor(
 		Critical: struck.Critical,
 		Attack:   &encounter.AttackIdentity{Ref: ref.Ref, Name: ref.Name, DamageType: string(ref.DamageType)},
 	}
+	if struck.Hit {
+		recorded.DamageComponents = recordDamageComponents(struck.DamageComponents)
+		recorded.AdvantageSources = recordAttackModifierSources(struck.Folded.AdvantageSources)
+		recorded.DisadvantageSources = recordAttackModifierSources(struck.Folded.DisadvantageSources)
+	}
+	return recorded
+}
+
+func recordDamageComponents(in []dnd5eEvents.DamageComponent) []encounter.DamageComponent {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]encounter.DamageComponent, 0, len(in))
+	for _, component := range in {
+		var sourceRef string
+		if component.SourceRef != nil {
+			sourceRef = component.SourceRef.String()
+		}
+		var multiplier *float64
+		if component.Multiplier != nil {
+			value := *component.Multiplier
+			multiplier = &value
+		}
+		out = append(out, encounter.DamageComponent{
+			Source: string(component.Source), SourceRef: sourceRef, Dice: component.Dice,
+			FinalRolls: append([]int(nil), component.FinalDiceRolls...),
+			FlatBonus:  component.FlatBonus, DamageType: string(component.DamageType),
+			Multiplier: multiplier,
+		})
+	}
+	return out
+}
+
+func recordAttackModifierSources(in []dnd5eEvents.AttackModifierSource) []encounter.AttackModifierSource {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]encounter.AttackModifierSource, 0, len(in))
+	for _, source := range in {
+		var sourceRef string
+		if source.SourceRef != nil {
+			sourceRef = source.SourceRef.String()
+		}
+		out = append(out, encounter.AttackModifierSource{
+			SourceRef: sourceRef,
+			SourceID:  source.SourceID,
+		})
+	}
+	return out
 }
 
 // loadAttackSheet reconstitutes the attacker's stored sheet for assembly and pricing.

--- a/rulebooks/dnd5e/session/attack_internal_test.go
+++ b/rulebooks/dnd5e/session/attack_internal_test.go
@@ -21,6 +21,7 @@ import (
 	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
@@ -72,19 +73,37 @@ func (d *scriptedDice) Roll(_ context.Context, _ int) (int, error) {
 	return roll, nil
 }
 
-// TestRecordUsesAggregateFromTypedStrikeOutcome pins the session boundary at
-// the real encounter recording seam: resolution may retain typed damage
-// evidence, but the story stores only the aggregate amount.
-func TestRecordUsesAggregateFromTypedStrikeOutcome(t *testing.T) {
+// TestRecordProjectsSelectedStrikeDetail pins the one session-to-encounter
+// projection. Resolution keeps richer internal evidence; the replay carrier
+// receives only the approved ordered subset and never modifier prose.
+func TestRecordProjectsSelectedStrikeDetail(t *testing.T) {
+	immunity := 0.0
 	struck := resolution.StrikeOutcome{
-		Roll:     15,
-		Total:    20,
-		TargetAC: 12,
-		Hit:      true,
-		Damage:   9,
+		Roll: 15, Total: 20, TargetAC: 12, Hit: true, Damage: 9,
 		DamageInstances: []damage.Instance{
 			{Amount: 5, Type: damage.Slashing},
 			{Amount: 4, Type: damage.Fire},
+		},
+		DamageComponents: []dnd5eEvents.DamageComponent{
+			{
+				Source: dnd5eEvents.DamageSourceWeapon, SourceRef: refs.Weapons.Longsword(), Dice: "1d8",
+				OriginalDiceRolls: []int{2}, FinalDiceRolls: []int{4},
+				Rerolls:   []dnd5eEvents.RerollEvent{{DieIndex: 0, Before: 2, After: 4, Reason: "ignored"}},
+				FlatBonus: 0, DamageType: damage.Slashing,
+				Properties: []damage.Property{damage.AddsAttackAbilityModifier}, IsCritical: true,
+			},
+			{
+				Source: dnd5eEvents.DamageSourceMonsterTrait, SourceRef: refs.MonsterTraits.Immunity(),
+				DamageType: damage.Slashing, Multiplier: &immunity,
+			},
+		},
+		Folded: dnd5eEvents.AttackChainEvent{
+			AdvantageSources: []dnd5eEvents.AttackModifierSource{
+				{SourceRef: refs.Conditions.Hidden(), SourceID: "alice", Reason: "Hidden"},
+			},
+			DisadvantageSources: []dnd5eEvents.AttackModifierSource{
+				{SourceRef: refs.Conditions.Dodging(), SourceID: "bob", Reason: "Dodging"},
+			},
 		},
 	}
 
@@ -104,13 +123,7 @@ func TestRecordUsesAggregateFromTypedStrikeOutcome(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// A minimal but real profile — Ref and Name non-empty, per
-	// rpg-toolkit#1172/#1175: Record refuses an Attack whose Ref or Name is
-	// empty. This test is about damage aggregation, not attack identity, so
-	// the profile is otherwise bare; DamageType stays unchecked and empty is
-	// still a legal answer for it.
 	definition := combatActions.Definition{Ref: *refs.Weapons.Longsword(), Name: "Longsword"}
-
 	recorded, err := enc.Record(recordFor(
 		&AttackInput{Attacker: "alice", Target: "bob"}, struck, definition,
 	))
@@ -120,12 +133,22 @@ func TestRecordUsesAggregateFromTypedStrikeOutcome(t *testing.T) {
 	story, err := enc.Story(&encounter.StoryInput{Audience: "bob"})
 	require.NoError(t, err)
 	require.NotEmpty(t, story)
+	payload := string(story[len(story)-1].Payload)
 	require.JSONEq(t,
 		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":9,`+
-			`"critical":false,"attack":{"ref":"longsword","name":"Longsword","damage_type":""}}`,
-		string(story[len(story)-1].Payload),
-		"the persisted encounter record carries the aggregate and no typed damage collection",
+			`"critical":false,"attack":{"ref":"longsword","name":"Longsword","damage_type":""},`+
+			`"damage_components":[`+
+			`{"source":"weapon","source_ref":"dnd5e:weapons:longsword","dice":"1d8","final_rolls":[4],"flat_bonus":0,"damage_type":"slashing"},`+
+			`{"source":"monster_trait","source_ref":"dnd5e:monster_traits:immunity","flat_bonus":0,"damage_type":"slashing","multiplier":0}],`+
+			`"advantage_sources":[{"source_ref":"dnd5e:conditions:hidden","source_id":"alice"}],`+
+			`"disadvantage_sources":[{"source_ref":"dnd5e:conditions:dodging","source_id":"bob"}]}`,
+		payload,
 	)
+	for _, excluded := range []string{
+		`"original_dice_rolls"`, `"rerolls"`, `"properties"`, `"is_critical"`, `"reason"`,
+	} {
+		require.NotContains(t, payload, excluded)
+	}
 }
 
 // halfBrokenCharacters writes the first sheet and refuses the second.

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -307,8 +307,10 @@ func (s *AttackTestSuite) TestProtectionReactsToANearbyAllysAttackOnTheSessionSt
 // Exact arithmetic rather than "damage is positive". A d20 of 15 plus a
 // proficient Strength longsword (+3 STR, +2 proficiency) totals 20 against
 // AC 12 — a hit, and the damage die scripted to 5 with the +3 modifier deals
-// 8. A loose assertion here would pass on an implementation that dropped the
-// modifier, halved the die, or resolved against the wrong sheet.
+// 8. The same beat now preserves the ordered weapon and ability components
+// resolution produced. A loose assertion here would pass on an implementation
+// that dropped the modifier, halved the die, or resolved against the wrong
+// sheet.
 func (s *AttackTestSuite) TestASwingLandsAndTheStoryRecordsIt() {
 	mgr := s.duel(&sequenceDice{rolls: []int{15, 5}})
 
@@ -329,7 +331,10 @@ func (s *AttackTestSuite) TestASwingLandsAndTheStoryRecordsIt() {
 	s.Equal("outcome", last.Tags["tag"])
 	s.JSONEq(
 		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":8,`+
-			`"critical":false,"attack":{"ref":"longsword","name":"Longsword","damage_type":"slashing"}}`,
+			`"critical":false,"attack":{"ref":"longsword","name":"Longsword","damage_type":"slashing"},`+
+			`"damage_components":[`+
+			`{"source":"weapon","source_ref":"dnd5e:weapons:longsword","dice":"1d8","final_rolls":[5],"flat_bonus":0,"damage_type":"slashing"},`+
+			`{"source":"ability","source_ref":"dnd5e:abilities:str","flat_bonus":3,"damage_type":"slashing"}]}`,
 		string(last.Payload))
 	s.Equal(session.AttackRef{Ref: "longsword", Name: "Longsword", DamageType: session.DamageSlashing}, out.Attack)
 }

--- a/rulebooks/dnd5e/session/events.go
+++ b/rulebooks/dnd5e/session/events.go
@@ -378,14 +378,17 @@ func (a beatAttack) toRef() AttackRef {
 // (recordFor's own shape); a beat with none does not type.
 func structBody(payload []byte, wantAmount bool) EventBody {
 	var p struct {
-		Actor    string     `json:"actor"`
-		Targets  []string   `json:"targets"`
-		Roll     int        `json:"roll"`
-		Total    int        `json:"total"`
-		Against  int        `json:"against"`
-		Amount   int        `json:"amount"`
-		Critical bool       `json:"critical"`
-		Attack   beatAttack `json:"attack"`
+		Actor               string                 `json:"actor"`
+		Targets             []string               `json:"targets"`
+		Roll                int                    `json:"roll"`
+		Total               int                    `json:"total"`
+		Against             int                    `json:"against"`
+		Amount              int                    `json:"amount"`
+		Critical            bool                   `json:"critical"`
+		Attack              beatAttack             `json:"attack"`
+		DamageComponents    []DamageComponent      `json:"damage_components"`
+		AdvantageSources    []AttackModifierSource `json:"advantage_sources"`
+		DisadvantageSources []AttackModifierSource `json:"disadvantage_sources"`
 	}
 	if json.Unmarshal(payload, &p) != nil ||
 		p.Actor == "" || len(p.Targets) != 1 || p.Attack.Ref == "" {
@@ -400,6 +403,8 @@ func structBody(payload []byte, wantAmount bool) EventBody {
 			Attacker: p.Actor, Target: p.Targets[0],
 			Roll: p.Roll, Total: p.Total, Against: p.Against, Damage: p.Amount,
 			Attack: p.Attack.toRef(), Critical: p.Critical,
+			DamageComponents: p.DamageComponents,
+			AdvantageSources: p.AdvantageSources, DisadvantageSources: p.DisadvantageSources,
 		}
 	}
 	return MissedBody{

--- a/rulebooks/dnd5e/session/events_internal_test.go
+++ b/rulebooks/dnd5e/session/events_internal_test.go
@@ -162,6 +162,43 @@ func TestBodyForAcceptsACompleteBeat(t *testing.T) {
 	}, body)
 }
 
+// TestStruckBodyDecodesReplayDetail pins the second half of the projection:
+// the exact primitive payload session authored becomes its own exported body,
+// with a present zero multiplier and the supplied ordering intact.
+func TestStruckBodyDecodesReplayDetail(t *testing.T) {
+	kind, body := decodeBeat([]byte(
+		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":8,` +
+			`"critical":false,"attack":{"ref":"longsword","name":"Longsword","damage_type":"slashing"},` +
+			`"damage_components":[` +
+			`{"source":"weapon","source_ref":"dnd5e:weapons:longsword","dice":"1d8","final_rolls":[4],"flat_bonus":0,"damage_type":"slashing"},` +
+			`{"source":"monster_trait","damage_type":"slashing","flat_bonus":0,"multiplier":0}],` +
+			`"advantage_sources":[{"source_ref":"dnd5e:conditions:hidden","source_id":"alice"}],` +
+			`"disadvantage_sources":[{"source_ref":"dnd5e:conditions:dodging","source_id":"bob"}]}`))
+	require.Equal(t, EventStruck, kind)
+
+	got, ok := body.(StruckBody)
+	require.True(t, ok, "rich struck payload produces StruckBody, got %T", body)
+	require.Len(t, got.DamageComponents, 2)
+	zero := 0.0
+	require.Equal(t, []DamageComponent{
+		{
+			Source: "weapon", SourceRef: "dnd5e:weapons:longsword", Dice: "1d8",
+			FinalRolls: []int{4}, DamageType: DamageSlashing,
+		},
+		{
+			Source: "monster_trait", DamageType: DamageSlashing, Multiplier: &zero,
+		},
+	}, got.DamageComponents)
+	require.NotNil(t, got.DamageComponents[1].Multiplier)
+	require.Zero(t, *got.DamageComponents[1].Multiplier)
+	require.Equal(t,
+		[]AttackModifierSource{{SourceRef: "dnd5e:conditions:hidden", SourceID: "alice"}},
+		got.AdvantageSources)
+	require.Equal(t,
+		[]AttackModifierSource{{SourceRef: "dnd5e:conditions:dodging", SourceID: "bob"}},
+		got.DisadvantageSources)
+}
+
 // TestJoinedAndExitedBodiesCarryTheMember pins bodyFor's newest arms
 // (rpg-project#260 slice 4, item 2): the encounter composition's join/exit
 // beats already carry "member" (encounter.go's Join and Exit), so this is

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.33.1
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0 h1:8c/xoqxgXqRO3LxoEX
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0 h1:LxEJMtm4M3PMDnpRC61ooGvWKS/eRZImu/GTeTDCYuM=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0/go.mod h1:Y5eXfAAyQ0N4Sp07T5C7MxD2CwAwdAUi2zo5SyN60Ds=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.33.1 h1:4xF4l/oe8qOL9LUcaQ953BP6xLWVUsYlLt9vqwIhL3k=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.33.1/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.0 h1:TJCQjYO0YQX3+BK2wZQ9Kebib0PEqIxqT/2VUmtbsO4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0 h1:Ftc+y0UnhW0wTlovA6RFoYDL/6un1ZKJdc1p3SXGB0w=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0/go.mod h1:HzM2KKrpUlpOLfesRkxy8V8enQdmRzvsisZrEuB9BM8=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/session/monster_turn_test.go
+++ b/rulebooks/dnd5e/session/monster_turn_test.go
@@ -529,6 +529,18 @@ func (s *MonsterTurnTestSuite) TestLiveDeliveryAndStoryCatchUpAreByteEqual() {
 		}
 	}
 	s.Require().NotEmpty(live, "join, spawn and the driven turn must all have addressed fighter")
+	foundRichStrike := false
+	for _, event := range live {
+		if event.Kind != session.EventStruck {
+			continue
+		}
+		body, ok := event.Body.(session.StruckBody)
+		s.Require().True(ok, "live struck event carries StruckBody, got %T", event.Body)
+		s.Require().NotEmpty(body.DamageComponents,
+			"the driven strike must carry the detail whose replay equality this test guards")
+		foundRichStrike = true
+	}
+	s.True(foundRichStrike, "this deterministic driven turn lands a strike")
 
 	caughtUp, err := mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "fighter", FromSeq: 1})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -672,6 +672,27 @@ type DownedBody struct {
 
 func (DownedBody) isEventBody() {}
 
+// DamageComponent is the replayable subset of one resolved damage component.
+// Its order and values come from resolution; consumers display rather than
+// recalculate it.
+type DamageComponent struct {
+	Source     string     `json:"source"`
+	SourceRef  string     `json:"source_ref,omitempty"`
+	Dice       string     `json:"dice,omitempty"`
+	FinalRolls []int      `json:"final_rolls,omitempty"`
+	FlatBonus  int        `json:"flat_bonus"`
+	DamageType DamageType `json:"damage_type"`
+	Multiplier *float64   `json:"multiplier,omitempty"`
+}
+
+// AttackModifierSource identifies one replayable advantage/disadvantage
+// source. Human-readable rules-engine reasons deliberately do not cross this
+// seam.
+type AttackModifierSource struct {
+	SourceRef string `json:"source_ref,omitempty"`
+	SourceID  string `json:"source_id,omitempty"`
+}
+
 // StruckBody is EventStruck's typed body: an attack landed. The numbers
 // AttackOutput gives the attacker, here for every witness, plus what was
 // swung.
@@ -689,6 +710,11 @@ type StruckBody struct {
 	// Attack is what was swung — ref, name, damage type.
 	Attack   AttackRef `json:"attack"`
 	Critical bool      `json:"critical"`
+	// DamageComponents are ordered inputs to the authoritative aggregate Damage.
+	DamageComponents []DamageComponent `json:"damage_components,omitempty"`
+	// AdvantageSources and DisadvantageSources preserve the fold's attribution.
+	AdvantageSources    []AttackModifierSource `json:"advantage_sources,omitempty"`
+	DisadvantageSources []AttackModifierSource `json:"disadvantage_sources,omitempty"`
 }
 
 func (StruckBody) isEventBody() {}


### PR DESCRIPTION
## Summary

- pin released encounter `v0.34.0`
- project the approved subset of resolution damage components and modifier sources once in `recordFor`
- decode that persisted shape into session-owned `StruckBody` types
- prove a real live driven strike and `Story` catch-up remain equal

## Boundaries

Original rolls, rerolls, properties, per-component critical state, `Reason`, and `DamageInstances` do not cross. Missed events remain aggregate and unchanged.

## Verification

From `rulebooks/dnd5e/session`:

- focused RED/GREEN projection and replay tests
- real attack story assertion
- live-versus-Story equality test with non-empty damage components
- `go test -race ./...`
- `golangci-lint run ./...`
- `git diff --check`
- no committed `replace`

Closes #1239. Parent: KirkDiggler/rpg-project#265.

— asset-pipeline agent, on behalf of KirkDiggler
