### PR TITLE
feat(encounter): compass facings, raised prop offsets, authored wall height (#1247)

### DIFF
--- a/rulebooks/dnd5e/encounter/atlas.go
+++ b/rulebooks/dnd5e/encounter/atlas.go
@@ -96,9 +96,9 @@ type AtlasProp struct {
 	// Facing and Offset are the same authored, uninterpreted presentational
 	// facts as [PropInput.Facing] and [PropInput.Offset], carried through
 	// unread. Neither is validated here either — dungeonspec is the layer
-	// that knows the field's orientation and checks the word against it.
+	// that owns the vocabulary and the bounds.
 	Facing string
-	Offset [2]float64
+	Offset [3]float64
 }
 
 // AtlasBoundary is one wall or barrier crossing, with both endpoints in
@@ -115,6 +115,11 @@ type AtlasBoundary struct {
 
 	// BlocksLineOfSight reports whether line of sight may cross this boundary.
 	BlocksLineOfSight bool
+
+	// Height is the authored wall-height multiplier, carried verbatim from
+	// [WallInput.Height] and unread by this module. 0 = not authored =
+	// standard height; see [WallInput.Height] for the full contract.
+	Height float64
 }
 
 // AtlasDoorway is one crossable pair of cells a door stands in.
@@ -194,6 +199,7 @@ func (e *Encounter) Atlas() (Atlas, error) {
 			To:                edge.To,
 			BlocksMovement:    w.BlocksMovement,
 			BlocksLineOfSight: w.BlocksLineOfSight,
+			Height:            w.Height,
 		})
 	}
 	sort.Slice(out.Boundaries, func(i, j int) bool {

--- a/rulebooks/dnd5e/encounter/canvas_test.go
+++ b/rulebooks/dnd5e/encounter/canvas_test.go
@@ -86,7 +86,7 @@ var (
 //
 // The wall is a FIELD fact now (rpg-project#256): both endpoints are authored
 // absolute cells, and nothing about which region "declared" it survives.
-func tombSeamWall(origin spatial.Position, width, height, gapRow int) []spatial.Boundary {
+func tombSeamWall(origin spatial.Position, width, height, gapRow int) []encounter.WallInput {
 	return seamWallRows(int(origin.X)+width-1, int(origin.Y), height, int(origin.Y)+gapRow)
 }
 
@@ -380,7 +380,7 @@ func TestAWallThatCannotBeDrawnIsRefusedAtConstruction(t *testing.T) {
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-				Regions: []encounter.RegionInput{rectRegion("hall", 4, 4, 6, 6)}, Walls: []spatial.Boundary{b},
+				Regions: []encounter.RegionInput{rectRegion("hall", 4, 4, 6, 6)}, Walls: []encounter.WallInput{{Boundary: b}},
 			},
 			Members: []encounter.MemberInput{
 				{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 4, Y: 4}},

--- a/rulebooks/dnd5e/encounter/clocks_internal_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_internal_test.go
@@ -155,21 +155,21 @@ func TestFormRejections(t *testing.T) {
 // "first light does not start the fight" has to say it. Diagonals are included
 // for the reason testwalls_test.go's squareSeamWall spells out: a square cell
 // has eight neighbours, and a wall of same-row edges leaks at every corner.
-func sealedSeam(atX, height int) []spatial.Boundary {
+func sealedSeam(atX, height int) []WallInput {
 	o := HexesArePointyTop()
-	out := make([]spatial.Boundary, 0, height*2)
+	out := make([]WallInput, 0, height*2)
 	for y := 0; y < height; y++ {
 		for _, dy := range []int{-1, 0, 1} {
 			to := y + dy
 			if to < 0 || to >= height || adjacencyGrid.Distance(HexCellAt(o, atX, y), HexCellAt(o, atX+1, to)) != 1 {
 				continue
 			}
-			out = append(out, spatial.Boundary{
+			out = append(out, WallInput{Boundary: spatial.Boundary{
 				From:              spatial.Position{X: float64(atX), Y: float64(y)},
 				To:                spatial.Position{X: float64(atX + 1), Y: float64(to)},
 				BlocksMovement:    true,
 				BlocksLineOfSight: true,
-			})
+			}})
 		}
 	}
 	return out

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -180,9 +180,9 @@ func rectRegion(id string, col, row, w, h int) encounter.RegionInput {
 // [0,rows), minus the straight crossing on the gap row — asked of the grid,
 // since a hex's crossings stagger and a parity table would be a second
 // answer to which cells touch.
-func seamWall(west, east, gap, rows int) []spatial.Boundary {
+func seamWall(west, east, gap, rows int) []encounter.WallInput {
 	grid := spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 1e6, SpanHeight: 1e6})
-	var out []spatial.Boundary
+	var out []encounter.WallInput
 	for row := 0; row < rows; row++ {
 		for _, dr := range []int{-1, 0, 1} {
 			to := row + dr
@@ -192,10 +192,10 @@ func seamWall(west, east, gap, rows int) []spatial.Boundary {
 			if grid.Distance(cellAt(west, row), cellAt(east, to)) != 1 {
 				continue
 			}
-			out = append(out, spatial.Boundary{
+			out = append(out, encounter.WallInput{Boundary: spatial.Boundary{
 				From: spatial.Position{X: float64(west), Y: float64(row)}, To: spatial.Position{X: float64(east), Y: float64(to)},
 				BlocksMovement: true, BlocksLineOfSight: true,
-			})
+			}})
 		}
 	}
 	return out

--- a/rulebooks/dnd5e/encounter/compilefield.go
+++ b/rulebooks/dnd5e/encounter/compilefield.go
@@ -50,7 +50,7 @@ type field struct {
 	// — this is what ToData writes back out.
 	regions []RegionInput
 	props   []PropInput
-	walls   []spatial.Boundary
+	walls   []WallInput
 
 	void        Void
 	orientation Orientation
@@ -255,8 +255,8 @@ func (f *field) compileProps(props []PropInput) error {
 
 // compileWalls checks every wall is an edge between two adjacent floor cells
 // and no edge is drawn twice.
-func (f *field) compileWalls(walls []spatial.Boundary) error {
-	f.walls = append([]spatial.Boundary(nil), walls...)
+func (f *field) compileWalls(walls []WallInput) error {
+	f.walls = append([]WallInput(nil), walls...)
 	seen := make(map[DoorEdge]bool, len(walls))
 
 	for i, w := range walls {

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -90,7 +90,7 @@ func vaultChaseChambers() []chamber {
 //
 // Counted in the chamber's own offset rows since rpg-toolkit#1127, so the range
 // is simply its full height.
-func vaultChaseHexSeamWall() []spatial.Boundary {
+func vaultChaseHexSeamWall() []encounter.WallInput {
 	return hexOffsetSeamWall(encounter.HexesArePointyTop(), 9, 0, 9, 5)
 }
 

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -186,7 +186,7 @@ type PropData struct {
 	// design, so there is no pointer here and no by-name refusal when
 	// absent — an old blob simply unmarshals both to their zero values.
 	Facing string     `json:"facing,omitempty"`
-	Offset [2]float64 `json:"offset"`
+	Offset [3]float64 `json:"offset"`
 }
 
 // PositionData is the persistent representation of spatial.Position.
@@ -201,6 +201,13 @@ type BoundaryData struct {
 	To                PositionData `json:"to"`
 	BlocksMovement    bool         `json:"blocks_movement,omitempty"`
 	BlocksLineOfSight bool         `json:"blocks_line_of_sight,omitempty"`
+
+	// Height is the authored wall-height multiplier; 0 = not authored =
+	// standard height ([WallInput.Height]). omitempty is safe for exactly
+	// that reason: an absent key and an authored 0 cannot both exist — 0 is
+	// not an authorable value ([1, 3] bounds) — so absent always means "not
+	// authored," never a lost fact.
+	Height float64 `json:"height,omitempty"`
 }
 
 // DoorData is the persistent representation of a door: what it is called,
@@ -546,6 +553,7 @@ func fieldDataFrom(f *field) FieldData {
 				To:                PositionData{X: w.To.X, Y: w.To.Y},
 				BlocksMovement:    w.BlocksMovement,
 				BlocksLineOfSight: w.BlocksLineOfSight,
+				Height:            w.Height,
 			}
 		}
 	}
@@ -1303,11 +1311,14 @@ func fieldInputFrom(fd FieldData) (FieldInput, error) {
 	}
 
 	for _, wd := range fd.Walls {
-		in.Walls = append(in.Walls, spatial.Boundary{
-			From:              spatial.Position{X: wd.From.X, Y: wd.From.Y},
-			To:                spatial.Position{X: wd.To.X, Y: wd.To.Y},
-			BlocksMovement:    wd.BlocksMovement,
-			BlocksLineOfSight: wd.BlocksLineOfSight,
+		in.Walls = append(in.Walls, WallInput{
+			Boundary: spatial.Boundary{
+				From:              spatial.Position{X: wd.From.X, Y: wd.From.Y},
+				To:                spatial.Position{X: wd.To.X, Y: wd.To.Y},
+				BlocksMovement:    wd.BlocksMovement,
+				BlocksLineOfSight: wd.BlocksLineOfSight,
+			},
+			Height: wd.Height,
 		})
 	}
 

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -80,7 +80,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 				rectRegion("hall", -2, 7, 6, 6),
 			},
 			Props: []encounter.PropInput{rubble(-9, 9)},
-			Walls: []spatial.Boundary{wall(-8, 9, -8, 10)},
+			Walls: []encounter.WallInput{wall(-8, 9, -8, 10)},
 			Doors: []encounter.DoorInput{openDoorway("door1", -3, 10, -2, 10)},
 		},
 		Members: []encounter.MemberInput{
@@ -115,7 +115,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 	// the open seam at first light and trigger detection forms a bubble —
 	// so this is the one place the bubbles array and intel's holdings are
 	// pinned as exact bytes.
-	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"active_idx":1,"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTMsInkiOjd9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotNSwieSI6N30=","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":5,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidHVybi1lbmRlZCIsIm1lbWJlciI6ImcxIiwibmV4dCI6InAxIn0="},{"seq":4,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"opaque","orientation":"pointy"},"regions":[{"id":"crypt","name":"crypt","cells":[{"x":-10,"y":7},{"x":-9,"y":7},{"x":-8,"y":7},{"x":-7,"y":7},{"x":-6,"y":7},{"x":-5,"y":7},{"x":-4,"y":7},{"x":-3,"y":7},{"x":-10,"y":8},{"x":-9,"y":8},{"x":-8,"y":8},{"x":-7,"y":8},{"x":-6,"y":8},{"x":-5,"y":8},{"x":-4,"y":8},{"x":-3,"y":8},{"x":-10,"y":9},{"x":-9,"y":9},{"x":-8,"y":9},{"x":-7,"y":9},{"x":-6,"y":9},{"x":-5,"y":9},{"x":-4,"y":9},{"x":-3,"y":9},{"x":-10,"y":10},{"x":-9,"y":10},{"x":-8,"y":10},{"x":-7,"y":10},{"x":-6,"y":10},{"x":-5,"y":10},{"x":-4,"y":10},{"x":-3,"y":10},{"x":-10,"y":11},{"x":-9,"y":11},{"x":-8,"y":11},{"x":-7,"y":11},{"x":-6,"y":11},{"x":-5,"y":11},{"x":-4,"y":11},{"x":-3,"y":11},{"x":-10,"y":12},{"x":-9,"y":12},{"x":-8,"y":12},{"x":-7,"y":12},{"x":-6,"y":12},{"x":-5,"y":12},{"x":-4,"y":12},{"x":-3,"y":12},{"x":-10,"y":13},{"x":-9,"y":13},{"x":-8,"y":13},{"x":-7,"y":13},{"x":-6,"y":13},{"x":-5,"y":13},{"x":-4,"y":13},{"x":-3,"y":13},{"x":-10,"y":14},{"x":-9,"y":14},{"x":-8,"y":14},{"x":-7,"y":14},{"x":-6,"y":14},{"x":-5,"y":14},{"x":-4,"y":14},{"x":-3,"y":14}],"archetype":"crypt","lighting":{"intensity":1}},{"id":"hall","name":"hall","cells":[{"x":-2,"y":7},{"x":-1,"y":7},{"x":0,"y":7},{"x":1,"y":7},{"x":2,"y":7},{"x":3,"y":7},{"x":-2,"y":8},{"x":-1,"y":8},{"x":0,"y":8},{"x":1,"y":8},{"x":2,"y":8},{"x":3,"y":8},{"x":-2,"y":9},{"x":-1,"y":9},{"x":0,"y":9},{"x":1,"y":9},{"x":2,"y":9},{"x":3,"y":9},{"x":-2,"y":10},{"x":-1,"y":10},{"x":0,"y":10},{"x":1,"y":10},{"x":2,"y":10},{"x":3,"y":10},{"x":-2,"y":11},{"x":-1,"y":11},{"x":0,"y":11},{"x":1,"y":11},{"x":2,"y":11},{"x":3,"y":11},{"x":-2,"y":12},{"x":-1,"y":12},{"x":0,"y":12},{"x":1,"y":12},{"x":2,"y":12},{"x":3,"y":12}],"archetype":"crypt","lighting":{"intensity":1}}],"props":[{"ref":"test:props:rubble","at":{"x":-9,"y":9},"blocks_movement":true,"blocks_line_of_sight":true,"offset":[0,0]}],"walls":[{"from":{"x":-8,"y":9},"to":{"x":-8,"y":10},"blocks_movement":true,"blocks_line_of_sight":true}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-5,"y":7}},{"id":"p1","kind":"player","cell":{"x":-13,"y":7}}],"doors":[{"id":"door1","edges":[{"from":{"x":-8,"y":10},"to":{"x":-7,"y":10}}],"state":"open"}],"endings":[{"key":"guarded","kind":"reached_position","at":{"x":-7,"y":10},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
+	expected := `{"clock":{"driver_progress":{"world":1},"high_water":1},"bubbles":[{"order":["g1","p1"],"active_idx":1,"round":1}],"intel":{"holdings":{"g1":{"p1":{"payload":"eyJ4IjotMTMsInkiOjd9","channel":"sight","at":1,"current_via":["sight"]}},"p1":{"g1":{"payload":"eyJ4IjotNSwieSI6N30=","channel":"sight","at":1,"current_via":["sight"]}}}},"log":{"next_seq":5,"entries":[{"seq":1,"audience":["p1","g1"],"tags":{"tag":"scene"},"payload":"eyJiZWF0Ijoic2NlbmUtb3BlbmVkIn0="},{"seq":2,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoiYnViYmxlLWZvcm1lZCIsIm9yZGVyIjpbImcxIiwicDEiXX0="},{"seq":3,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidHVybi1lbmRlZCIsIm1lbWJlciI6ImcxIiwibmV4dCI6InAxIn0="},{"seq":4,"at":1,"audience":["g1","p1"],"tags":{"tag":"clock"},"payload":"eyJiZWF0IjoidGljayIsInRpY2siOjF9"}]},"field":{"canvas":{"void":"opaque","orientation":"pointy"},"regions":[{"id":"crypt","name":"crypt","cells":[{"x":-10,"y":7},{"x":-9,"y":7},{"x":-8,"y":7},{"x":-7,"y":7},{"x":-6,"y":7},{"x":-5,"y":7},{"x":-4,"y":7},{"x":-3,"y":7},{"x":-10,"y":8},{"x":-9,"y":8},{"x":-8,"y":8},{"x":-7,"y":8},{"x":-6,"y":8},{"x":-5,"y":8},{"x":-4,"y":8},{"x":-3,"y":8},{"x":-10,"y":9},{"x":-9,"y":9},{"x":-8,"y":9},{"x":-7,"y":9},{"x":-6,"y":9},{"x":-5,"y":9},{"x":-4,"y":9},{"x":-3,"y":9},{"x":-10,"y":10},{"x":-9,"y":10},{"x":-8,"y":10},{"x":-7,"y":10},{"x":-6,"y":10},{"x":-5,"y":10},{"x":-4,"y":10},{"x":-3,"y":10},{"x":-10,"y":11},{"x":-9,"y":11},{"x":-8,"y":11},{"x":-7,"y":11},{"x":-6,"y":11},{"x":-5,"y":11},{"x":-4,"y":11},{"x":-3,"y":11},{"x":-10,"y":12},{"x":-9,"y":12},{"x":-8,"y":12},{"x":-7,"y":12},{"x":-6,"y":12},{"x":-5,"y":12},{"x":-4,"y":12},{"x":-3,"y":12},{"x":-10,"y":13},{"x":-9,"y":13},{"x":-8,"y":13},{"x":-7,"y":13},{"x":-6,"y":13},{"x":-5,"y":13},{"x":-4,"y":13},{"x":-3,"y":13},{"x":-10,"y":14},{"x":-9,"y":14},{"x":-8,"y":14},{"x":-7,"y":14},{"x":-6,"y":14},{"x":-5,"y":14},{"x":-4,"y":14},{"x":-3,"y":14}],"archetype":"crypt","lighting":{"intensity":1}},{"id":"hall","name":"hall","cells":[{"x":-2,"y":7},{"x":-1,"y":7},{"x":0,"y":7},{"x":1,"y":7},{"x":2,"y":7},{"x":3,"y":7},{"x":-2,"y":8},{"x":-1,"y":8},{"x":0,"y":8},{"x":1,"y":8},{"x":2,"y":8},{"x":3,"y":8},{"x":-2,"y":9},{"x":-1,"y":9},{"x":0,"y":9},{"x":1,"y":9},{"x":2,"y":9},{"x":3,"y":9},{"x":-2,"y":10},{"x":-1,"y":10},{"x":0,"y":10},{"x":1,"y":10},{"x":2,"y":10},{"x":3,"y":10},{"x":-2,"y":11},{"x":-1,"y":11},{"x":0,"y":11},{"x":1,"y":11},{"x":2,"y":11},{"x":3,"y":11},{"x":-2,"y":12},{"x":-1,"y":12},{"x":0,"y":12},{"x":1,"y":12},{"x":2,"y":12},{"x":3,"y":12}],"archetype":"crypt","lighting":{"intensity":1}}],"props":[{"ref":"test:props:rubble","at":{"x":-9,"y":9},"blocks_movement":true,"blocks_line_of_sight":true,"offset":[0,0,0]}],"walls":[{"from":{"x":-8,"y":9},"to":{"x":-8,"y":10},"blocks_movement":true,"blocks_line_of_sight":true}]},"members":[{"id":"g1","kind":"monster","cell":{"x":-5,"y":7}},{"id":"p1","kind":"player","cell":{"x":-13,"y":7}}],"doors":[{"id":"door1","edges":[{"from":{"x":-8,"y":10},"to":{"x":-7,"y":10}}],"state":"open"}],"endings":[{"key":"guarded","kind":"reached_position","at":{"x":-7,"y":10},"member":"p1"},{"key":"leave","kind":"external"}],"ever_members":["g1","p1"],"retention":32}`
 	s.Equal(expected, string(bs))
 }
 
@@ -165,6 +165,49 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 //
 // Both anchors are non-negative because the field compiles onto ONE grid and a
 // square grid starts at (0,0) — W5, rpg-toolkit#1106.
+// TestWallHeightSurvivesPersistenceAndAtlas — the authored multiplier rides
+// construction, the atlas, ToData, and Load without being read or repaired
+// anywhere in between (rpg-project#273): the atlas of a loaded encounter
+// carries the same heights the setup authored, and a wall that authored none
+// carries 0 at every stage.
+func (s *DataTestSuite) TestWallHeightSurvivesPersistenceAndAtlas() {
+	raised := wall(4, 1, 5, 1)
+	raised.Height = 2.5
+	setup := &encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Field: encounter.FieldInput{
+			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
+			Regions: []encounter.RegionInput{rectRegion("r1", 0, 1, 5, 5), rectRegion("r2", 5, 0, 5, 5)},
+			Walls:   []encounter.WallInput{raised, wall(4, 2, 5, 2)},
+		},
+		Members: []encounter.MemberInput{
+			{ID: "p1", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 2}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	}
+	enc, err := encounter.NewEncounter(setup)
+	s.Require().NoError(err)
+
+	heights := func(e *encounter.Encounter) []float64 {
+		atlas, err := e.Atlas()
+		s.Require().NoError(err)
+		s.Require().Len(atlas.Boundaries, 2)
+		out := make([]float64, 0, 2)
+		for _, b := range atlas.Boundaries {
+			out = append(out, b.Height)
+		}
+		return out
+	}
+	s.ElementsMatch([]float64{2.5, 0}, heights(enc), "the atlas carries the authored multiplier, and 0 where none was authored")
+
+	loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Data: enc.ToData(),
+	})
+	s.Require().NoError(err)
+	s.ElementsMatch([]float64{2.5, 0}, heights(loaded), "and the same numbers after a ToData/Load round trip")
+}
+
 func (s *DataTestSuite) TestSetupInputNotAliased() {
 	setup := &encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
@@ -172,7 +215,7 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("r1", 0, 1, 5, 5), rectRegion("r2", 5, 0, 5, 5)},
 			Props:   []encounter.PropInput{rubble(3, 4)},
-			Walls:   []spatial.Boundary{wall(4, 1, 5, 1)},
+			Walls:   []encounter.WallInput{wall(4, 1, 5, 1)},
 		},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 2}},
@@ -226,12 +269,12 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-				Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)}, Props: wallColumn(5, 3, 7), Walls: []spatial.Boundary{{
+				Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)}, Props: wallColumn(5, 3, 7), Walls: []encounter.WallInput{{Boundary: spatial.Boundary{
 					From:              spatial.Position{X: 3, Y: 3},
 					To:                spatial.Position{X: 3, Y: 4},
 					BlocksMovement:    true,
 					BlocksLineOfSight: true,
-				}},
+				}}},
 			},
 			Members: []encounter.MemberInput{
 				{
@@ -594,7 +637,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []spatial.Boundary{},
+				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
 			},
 			Members: []encounter.MemberInput{
 				{
@@ -635,7 +678,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []spatial.Boundary{},
+				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
 			},
 			Members: []encounter.MemberInput{
 				{
@@ -699,7 +742,7 @@ func (s *DataTestSuite) TestAliasImmunityToData() {
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []spatial.Boundary{},
+				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
 			},
 			Members: []encounter.MemberInput{
 				{
@@ -760,7 +803,7 @@ func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []spatial.Boundary{},
+				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
 			},
 			Members: []encounter.MemberInput{
 				{
@@ -1312,7 +1355,7 @@ func (s *DataTestSuite) TestMutation1ToDataAliases() {
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []spatial.Boundary{},
+				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
 			},
 			Members: []encounter.MemberInput{
 				{ID: "p1", Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 2}},
@@ -1350,7 +1393,7 @@ func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []spatial.Boundary{},
+				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
 			},
 			Members: []encounter.MemberInput{
 				{ID: "p1", Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 2}},
@@ -1379,7 +1422,7 @@ func (s *DataTestSuite) TestMutation3StowawayField() {
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []spatial.Boundary{},
+				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
 			},
 			Members: []encounter.MemberInput{
 				{ID: "p1", Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 2}},
@@ -1410,7 +1453,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []spatial.Boundary{},
+				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
 			},
 			Members: []encounter.MemberInput{
 				{ID: "p1", Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 2}},
@@ -1531,7 +1574,7 @@ func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
-				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 10, 10)}, Props: []encounter.PropInput{}, Walls: []spatial.Boundary{},
+				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 10, 10)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
 			},
 			Members: []encounter.MemberInput{
 				{ID: "p1", Kind: encounter.KindPlayer, Position: spatial.Position{X: 5, Y: 5}},

--- a/rulebooks/dnd5e/encounter/doors_test.go
+++ b/rulebooks/dnd5e/encounter/doors_test.go
@@ -71,7 +71,7 @@ var (
 // separate way through, so leaving them open would let sight round the corner
 // of a shut door and the test would be measuring the gap beside the door rather
 // than the door. The wall is everything the door is not.
-func seamWallExcept(atX, height int, doorRows ...int) []spatial.Boundary {
+func seamWallExcept(atX, height int, doorRows ...int) []encounter.WallInput {
 	return seamWallRows(atX, 0, height, doorRows...)
 }
 

--- a/rulebooks/dnd5e/encounter/dungeonspec/compile.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/compile.go
@@ -185,24 +185,34 @@ func propsOf(spec *Spec) []encounter.PropInput {
 			BlocksMovement: &blocksMovement, BlocksLineOfSight: &blocksLoS,
 			Facing: p.Facing,
 		}
-		// Validate has already confirmed len(p.Offset) is 0 or 2 by the time
-		// Compile runs; anything else is unreachable here.
-		if len(p.Offset) == 2 {
-			prop.Offset = [2]float64{p.Offset[0], p.Offset[1]}
+		// Validate has already confirmed len(p.Offset) is 0, 2 or 3 by the
+		// time Compile runs; anything else is unreachable here. A missing
+		// third component is height 0 — on the floor — by design.
+		if len(p.Offset) >= 2 {
+			prop.Offset = [3]float64{p.Offset[0], p.Offset[1], 0}
+			if len(p.Offset) == 3 {
+				prop.Offset[2] = p.Offset[2]
+			}
 		}
 		out = append(out, prop)
 	}
 	return out
 }
 
-// wallsOf carries every wall as an edge that blocks movement and sight.
-func wallsOf(spec *Spec) []spatial.Boundary {
-	out := make([]spatial.Boundary, 0, len(spec.Walls))
+// wallsOf carries every wall as an edge that blocks movement and sight, with
+// its authored height when the entry carried one — nil compiles to 0, the
+// carrier's own word for "not authored" ([encounter.WallInput.Height]).
+func wallsOf(spec *Spec) []encounter.WallInput {
+	out := make([]encounter.WallInput, 0, len(spec.Walls))
 	for _, w := range spec.Walls {
-		out = append(out, spatial.Boundary{
-			From: authored(w[0]), To: authored(w[1]),
+		wall := encounter.WallInput{Boundary: spatial.Boundary{
+			From: authored(w.Between[0]), To: authored(w.Between[1]),
 			BlocksMovement: true, BlocksLineOfSight: true,
-		})
+		}}
+		if w.Height != nil {
+			wall.Height = *w.Height
+		}
+		out = append(out, wall)
 	}
 	return out
 }

--- a/rulebooks/dnd5e/encounter/dungeonspec/compile_test.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/compile_test.go
@@ -104,10 +104,29 @@ walls:
 func (s *CompileSuite) TestWallsAreEdgesThatBlockBothWays() {
 	c := s.load(s.tomb)
 	s.Require().Len(c.Field.Walls, 28)
-	s.Equal(spatial.Boundary{
+	s.Equal(encounter.WallInput{Boundary: spatial.Boundary{
 		From: spatial.Position{X: 5, Y: 0}, To: spatial.Position{X: 6, Y: 0},
 		BlocksMovement: true, BlocksLineOfSight: true,
-	}, c.Field.Walls[0])
+	}}, c.Field.Walls[0], "a bare entry compiles at height 0: not authored, the standard height")
+}
+
+// TestAWallMayAuthorItsHeight — the object form carries its multiplier
+// through the compile verbatim; every bare sibling stays at 0, the carrier's
+// word for "not authored" (rpg-project#273).
+func (s *CompileSuite) TestAWallMayAuthorItsHeight() {
+	c := s.load(s.tombWith("  - [[5,1],[6,0]]", "  - { between: [[5,1],[6,0]], height: 2.5 }"))
+	s.Require().Len(c.Field.Walls, 28, "the object form is one wall, exactly as the bare form is")
+	raised := c.Field.Walls[1]
+	s.Equal(spatial.Position{X: 5, Y: 1}, raised.From)
+	s.Equal(spatial.Position{X: 6, Y: 0}, raised.To)
+	s.True(raised.BlocksMovement, "height changes nothing about what a wall blocks")
+	s.True(raised.BlocksLineOfSight, "a wall cannot be seen past at ANY height (Kirk's ruling)")
+	s.Equal(2.5, raised.Height)
+	for i, w := range c.Field.Walls {
+		if i != 1 {
+			s.Zero(w.Height, "walls[%d] authored no height", i)
+		}
+	}
 }
 
 // TestADoorIsMintedUnderTheDungeonsKeyInItsAuthoredState — `<key>/<id>`, so two

--- a/rulebooks/dnd5e/encounter/dungeonspec/dialect_test.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/dialect_test.go
@@ -135,6 +135,20 @@ func (s *DialectSuite) TestADungeonMustBeOneDocumentOfKnownKeys() {
 
 // TestValidate_PathsNameTheThing — the table: every refusal names the YAML
 // path of the thing that is wrong, because that is where the builder draws it.
+// TestWallObjectFormIsStrict — the wall object form keeps Decode's own
+// strictness even though a custom unmarshaler bypasses KnownFields: an
+// unknown key and an edgeless object are refusals naming the line, not facts
+// silently dropped.
+func (s *DialectSuite) TestWallObjectFormIsStrict() {
+	_, err := dungeonspec.Decode([]byte(s.tombWith("  - [[5,1],[6,0]]", "  - { between: [[5,1],[6,0]], hieght: 2 }")))
+	s.Require().Error(err, "a typo'd key is refused, not dropped")
+	s.Contains(err.Error(), "hieght")
+
+	_, err = dungeonspec.Decode([]byte(s.tombWith("  - [[5,1],[6,0]]", "  - { height: 2 }")))
+	s.Require().Error(err, "a wall object with no edge is not a wall")
+	s.Contains(err.Error(), "between")
+}
+
 func (s *DialectSuite) TestValidate_PathsNameTheThing() {
 	for _, tc := range []struct {
 		name string
@@ -161,8 +175,18 @@ func (s *DialectSuite) TestValidate_PathsNameTheThing() {
 			"place[0].blocks_los", "there is no default"},
 		{"a monster that says what it blocks", `at: [11,3], targeting: lowest-health }`, `at: [11,3], targeting: lowest-health, blocks_los: true }`,
 			"place[8].blocks_los", "not a prop"},
-		{"a facing from the wrong orientation's set", `at: [1,1], blocks_movement: true, blocks_los: false }`, `at: [1,1], blocks_movement: true, blocks_los: false, facing: n }`,
-			"place[0].facing", "pointy-top has no facing"},
+		{"a facing that is not a compass word", `at: [1,1], blocks_movement: true, blocks_los: false }`, `at: [1,1], blocks_movement: true, blocks_los: false, facing: north }`,
+			"place[0].facing", "not a compass direction"},
+		{"an offset height above the ceiling", `at: [1,1], blocks_movement: true, blocks_los: false }`, `at: [1,1], blocks_movement: true, blocks_los: false, offset: [0.1, 0, 3.5] }`,
+			"place[0].offset", "outside [0,3]"},
+		{"an offset height below the floor", `at: [1,1], blocks_movement: true, blocks_los: false }`, `at: [1,1], blocks_movement: true, blocks_los: false, offset: [0.1, 0, -0.2] }`,
+			"place[0].offset", "outside [0,3]"},
+		{"an offset of four numbers", `at: [1,1], blocks_movement: true, blocks_los: false }`, `at: [1,1], blocks_movement: true, blocks_los: false, offset: [0.1, 0, 0, 0] }`,
+			"place[0].offset", "must be [x,y] or [x,y,height]"},
+		{"a wall height below standard", "  - [[5,1],[6,0]]", "  - { between: [[5,1],[6,0]], height: 0.5 }",
+			"walls[1].height", "outside [1,3]"},
+		{"a wall height above the ceiling", "  - [[5,1],[6,0]]", "  - { between: [[5,1],[6,0]], height: 3.5 }",
+			"walls[1].height", "outside [1,3]"},
 		{"an offset component out of range", `at: [1,1], blocks_movement: true, blocks_los: false }`, `at: [1,1], blocks_movement: true, blocks_los: false, offset: [0.6, 0] }`,
 			"place[0].offset", "outside [-0.5,0.5]"},
 		{"an offset that is not two numbers", `at: [1,1], blocks_movement: true, blocks_los: false }`, `at: [1,1], blocks_movement: true, blocks_los: false, offset: [0.1] }`,

--- a/rulebooks/dnd5e/encounter/dungeonspec/facing_offset_test.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/facing_offset_test.go
@@ -37,15 +37,17 @@ func TestFacingOffsetSuite(t *testing.T) {
 
 // flatRoom is a minimal flat-top dungeon with one prop authoring the given
 // facing, so the OTHER six-name vocabulary (flat shows n|s|ne|nw|se|sw,
-// pointy shows e|w|ne|nw|se|sw) has a fixture of its own — the reference
-// tomb is pointy, and a wall drawn for one layout is not adjacent under the
-// other (dialect_test.go's TestTheSameWallIsARefusalUnderTheOtherLayout), so
-// an orientation case needs its own file rather than a tombWith substitution.
-func flatRoom(facing string) string {
+// pointy alike accept the same eight compass names, rpg-project#272) has a
+// fixture of its own — the reference tomb is pointy, and a wall drawn for one
+// layout is not adjacent under the other (dialect_test.go's
+// TestTheSameWallIsARefusalUnderTheOtherLayout), so an orientation case needs
+// its own file rather than a tombWith substitution. The one-region room here
+// has no walls, so the same shape is legal under either orientation.
+func orientedRoom(orientation, facing string) string {
 	return `
 version: 2
-key: flat-room
-orientation: flat
+key: oriented-room
+orientation: ` + orientation + `
 void: opaque
 regions:
   - id: room
@@ -60,30 +62,30 @@ place:
 `
 }
 
-// TestFacingVocabularyIsOrientationAware — the SIX names each layout has are
-// different sets, and a name from the wrong one is an ERROR, never a silent
-// snap to the nearest valid one (the design doc's ruling). Pointy's own
-// wrong-set refusal is dialect_test.go's "a facing from the wrong
-// orientation's set" row; this is flat's half, plus both orientations'
-// positive cases in one place.
-func (s *FacingOffsetSuite) TestFacingVocabularyIsOrientationAware() {
-	s.Run("flat-top accepts its own six", func() {
-		for _, f := range []string{"n", "s", "ne", "nw", "se", "sw"} {
-			spec, err := dungeonspec.Decode([]byte(flatRoom(f)))
-			s.Require().NoError(err)
-			s.Empty(dungeonspec.Validate(spec), "facing %q is valid under flat-top", f)
-		}
-	})
-	s.Run("flat-top refuses pointy's e and w", func() {
-		for _, f := range []string{"e", "w"} {
-			spec, err := dungeonspec.Decode([]byte(flatRoom(f)))
+// TestFacingVocabularyIsCompass — ONE eight-name true-compass set, the SAME
+// eight under BOTH orientations (rpg-project#272 ruling, superseding #261's
+// orientation-scoped sets — the rows that refused a name from "the wrong
+// orientation's set" flipped to acceptance, deliberately). A word outside the
+// set is an ERROR, never a silent snap to the nearest valid one.
+func (s *FacingOffsetSuite) TestFacingVocabularyIsCompass() {
+	all := []string{"n", "ne", "e", "se", "s", "sw", "w", "nw"}
+	for _, orientation := range []string{"flat", "pointy"} {
+		s.Run(orientation+"-top accepts all eight", func() {
+			for _, f := range all {
+				spec, err := dungeonspec.Decode([]byte(orientedRoom(orientation, f)))
+				s.Require().NoError(err)
+				s.Empty(dungeonspec.Validate(spec), "facing %q is valid under %s-top", f, orientation)
+			}
+		})
+		s.Run(orientation+"-top refuses a word outside the compass", func() {
+			spec, err := dungeonspec.Decode([]byte(orientedRoom(orientation, "north")))
 			s.Require().NoError(err)
 			errs := dungeonspec.Validate(spec)
 			s.Require().Len(errs, 1)
 			s.Equal("place[0].facing", errs[0].Path)
-			s.Contains(errs[0].Message, "flat-top has no facing")
-		}
-	})
+			s.Contains(errs[0].Message, "not a compass direction")
+		})
+	}
 }
 
 // TestFacedPropsFixture_RoundTripsThroughAtlas is the fixture the design
@@ -101,19 +103,19 @@ func (s *FacingOffsetSuite) TestFacedPropsFixture_RoundTripsThroughAtlas() {
 
 	facingOnly := byAt[spatial.Position{X: 1, Y: 1}]
 	s.Equal("e", facingOnly.Facing, "facing only")
-	s.Equal([2]float64{0, 0}, facingOnly.Offset, "no offset authored")
+	s.Equal([3]float64{0, 0}, facingOnly.Offset, "no offset authored")
 
 	offsetOnly := byAt[spatial.Position{X: 10, Y: 1}]
 	s.Equal("", offsetOnly.Facing, "offset only")
-	s.Equal([2]float64{0.3, 0.3}, offsetOnly.Offset)
+	s.Equal([3]float64{0.3, 0.3}, offsetOnly.Offset)
 
 	both := byAt[spatial.Position{X: 17, Y: 1}]
 	s.Equal("se", both.Facing, "both, at once")
-	s.Equal([2]float64{0.2, -0.1}, both.Offset)
+	s.Equal([3]float64{0.2, -0.1}, both.Offset)
 
 	neither := byAt[spatial.Position{X: 8, Y: 2}]
 	s.Equal("", neither.Facing, "a prop that says nothing carries nothing")
-	s.Equal([2]float64{0, 0}, neither.Offset)
+	s.Equal([3]float64{0, 0}, neither.Offset)
 
 	// The Atlas — built by running the compiled field through a live
 	// Encounter — carries the same words and numbers, at the absolute axial
@@ -124,8 +126,8 @@ func (s *FacingOffsetSuite) TestFacedPropsFixture_RoundTripsThroughAtlas() {
 	}
 	o := encounter.HexesArePointyTop()
 	s.Equal("e", atlasByAt[encounter.HexCellAt(o, 1, 1)].Facing, "the atlas carries the same word")
-	s.Equal([2]float64{0.3, 0.3}, atlasByAt[encounter.HexCellAt(o, 10, 1)].Offset)
+	s.Equal([3]float64{0.3, 0.3}, atlasByAt[encounter.HexCellAt(o, 10, 1)].Offset)
 	s.Equal("se", atlasByAt[encounter.HexCellAt(o, 17, 1)].Facing)
-	s.Equal([2]float64{0.2, -0.1}, atlasByAt[encounter.HexCellAt(o, 17, 1)].Offset, "and the same numbers")
+	s.Equal([3]float64{0.2, -0.1}, atlasByAt[encounter.HexCellAt(o, 17, 1)].Offset, "and the same numbers")
 	s.Equal("", atlasByAt[encounter.HexCellAt(o, 8, 2)].Facing, "and still nothing where nothing was authored")
 }

--- a/rulebooks/dnd5e/encounter/dungeonspec/golden_test.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/golden_test.go
@@ -201,7 +201,7 @@ func TestGolden_ReferenceTombV2MatchesV1Atlas(t *testing.T) {
 	// always means.
 	for _, p := range atlas.Props {
 		require.Equal(t, "", p.Facing, "the reference tomb authors no facing on %q", p.Ref)
-		require.Equal(t, [2]float64{0, 0}, p.Offset, "nor an offset on %q", p.Ref)
+		require.Equal(t, [3]float64{0, 0}, p.Offset, "nor an offset on %q", p.Ref)
 	}
 }
 

--- a/rulebooks/dnd5e/encounter/dungeonspec/spec.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/spec.go
@@ -45,6 +45,12 @@
 // length of the list.
 package dungeonspec
 
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
 // Spec is the authored dungeon, decoded and not yet checked. Every field is
 // exactly what the file said; nothing is defaulted, derived, or repaired.
 //
@@ -91,8 +97,9 @@ type Spec struct {
 
 	// Walls are edges between adjacent floor cells that block both movement
 	// and sight. The envelope is implied, never written: a crossing from
-	// floor into void is a crossing nobody can make.
-	Walls []EdgeSpec `yaml:"walls"`
+	// floor into void is a crossing nobody can make. Each entry is a bare
+	// edge or an object carrying an authored height — see [WallSpec].
+	Walls []WallSpec `yaml:"walls"`
 
 	// Doors are one state each over one or more edges (rpg-toolkit#1123).
 	Doors []DoorSpec `yaml:"doors"`
@@ -145,6 +152,66 @@ type LightingSpec struct {
 // [[col,row],[col,row]]. Undirected.
 type EdgeSpec [2][2]int
 
+// WallSpec is one authored wall entry. Two forms are legal (rpg-project#273):
+//
+//   - [[5,0],[6,0]]                          # bare edge — default height
+//   - { between: [[5,1],[6,1]], height: 2 }  # edge with an authored height
+//
+// The bare pair stays the common case and means default height; the object
+// form exists for the edge that carries more facts than its endpoints. The
+// EDGE carries the height rather than some named run because runs are
+// DERIVED — order-free, re-derived under editing — and giving them stored
+// identity would re-open everything the wall engine's order-invariance
+// closed. An edge is the one stable unit of authored fact.
+type WallSpec struct {
+	// Between is the crossing: two adjacent floor cells,
+	// [[col,row],[col,row]], exactly the bare form's pair.
+	Between EdgeSpec
+
+	// Height is the authored wall-height MULTIPLIER of the standard
+	// rendered wall height, REQUIRED in [1, 3] when authored — raise-only
+	// by ruling (rpg-project#273: "I am looking to raise the walls not
+	// lower them"), so a waist-high wall cannot be authored at all. Nil
+	// means not authored: the standard height, exactly what writing 1.0
+	// means — the two are the same fact by design. VISUAL ONLY: a wall
+	// blocks movement and sight identically at every height.
+	Height *float64
+}
+
+// UnmarshalYAML reads either wall form. A sequence node is the bare edge; a
+// mapping node is the object form. Unknown keys in the object form are
+// refused HERE because a custom unmarshaler bypasses the decoder's
+// KnownFields, and a typo silently dropped is exactly what Decode's
+// strictness exists to prevent.
+func (w *WallSpec) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.SequenceNode {
+		return value.Decode(&w.Between)
+	}
+	if value.Kind != yaml.MappingNode {
+		return fmt.Errorf("line %d: a wall is an edge [[col,row],[col,row]] or an object {between, height}", value.Line)
+	}
+	for i := 0; i < len(value.Content); i += 2 {
+		switch key := value.Content[i].Value; key {
+		case "between", "height":
+		default:
+			return fmt.Errorf("line %d: field %s not found in type dungeonspec.WallSpec", value.Content[i].Line, key)
+		}
+	}
+	var obj struct {
+		Between *EdgeSpec `yaml:"between"`
+		Height  *float64  `yaml:"height"`
+	}
+	if err := value.Decode(&obj); err != nil {
+		return err
+	}
+	if obj.Between == nil {
+		return fmt.Errorf("line %d: a wall object must name its edge in `between`", value.Line)
+	}
+	w.Between = *obj.Between
+	w.Height = obj.Height
+	return nil
+}
+
 // DoorSpec is one door: one state over one or more edges.
 type DoorSpec struct {
 	// ID names the door within this dungeon; the compiled door is
@@ -193,24 +260,30 @@ type PlaceSpec struct {
 	// and refused on anything else, for BlocksMovement's reason.
 	BlocksLoS *bool `yaml:"blocks_los,omitempty"`
 
-	// Facing is the prop's authored direction, one of the SIX names valid
-	// under the dungeon's own declared orientation — flat-top:
-	// n|s|ne|nw|se|sw, pointy-top: e|w|ne|nw|se|sw (rpg-project#261). A name
-	// from the wrong orientation's set is refused by name, never silently
+	// Facing is the prop's authored direction, one of the EIGHT true-compass
+	// names — n|ne|e|se|s|sw|w|nw — the SAME eight under BOTH orientations
+	// (rpg-project#272, superseding #261's orientation-scoped six-name
+	// sets: compass directions live in world space, and a prop must be able
+	// to stand squarely against an axis-true wall whatever way the hexes
+	// point). A name outside the set is refused by name, never silently
 	// snapped to the nearest valid one. Optional: omitted means the asset's
 	// own default facing. REFUSED on monsters, for BlocksMovement's reason —
 	// a monster faces dynamically in play; authored spawn facing is a shelf
 	// item for the Monster AI journey, not smuggled in here.
 	Facing string `yaml:"facing,omitempty"`
 
-	// Offset is a within-cell VISUAL nudge, [x,y] fractions of the cell
-	// size, each REQUIRED in [-0.5, 0.5] when authored (Kirk's ruling: "offset
-	// is visual only, agreed" — the prop still occupies its whole cell for
-	// movement and LOS). Optional: omitted means centered, which [0,0] also
-	// means — the two are the same fact by design. A SLICE, not a [2]float64,
-	// so a list of the wrong length is a validate-level defect naming
-	// place[i].offset rather than a decode-time line number. REFUSED on
-	// monsters, for Facing's reason.
+	// Offset is an authored VISUAL displacement: [x,y] within-cell nudge
+	// fractions of the cell size, each REQUIRED in [-0.5, 0.5] when
+	// authored (Kirk's ruling: "offset is visual only, agreed" — the prop
+	// still occupies its whole cell for movement and LOS), plus an OPTIONAL
+	// third component: height above the floor in the same cell-size unit,
+	// REQUIRED in [0, 3] when authored and deliberately NOT bound to the
+	// planar clamp (rpg-project#272: "height should be able to gun higher
+	// than the 5 ticks we allow on x and y"). Omitted means centered on the
+	// floor, which [0,0] and [0,0,0] also mean — all the same fact by
+	// design. A SLICE, not a fixed-size array, so a list of the wrong
+	// length is a validate-level defect naming place[i].offset rather than
+	// a decode-time line number. REFUSED on monsters, for Facing's reason.
 	//
 	// NIL, NOT LEN 0, IS "OMITTED": yaml.v3 leaves this nil when the key is
 	// absent but decodes `offset: []` to a non-nil, zero-length slice, and

--- a/rulebooks/dnd5e/encounter/dungeonspec/validate.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/validate.go
@@ -30,17 +30,15 @@ var (
 	// the author never sees.
 	targetings = map[string]bool{"closest": true, "lowest-health": true, "lowest-ac": true}
 
-	// facingsByOrientation is the SIX names each hex orientation actually
-	// has, and the two sets are DIFFERENT (rpg-project#261 ruling): a
-	// flat-top hex has flat top and bottom edges, so its facings are
-	// n|s|ne|nw|se|sw; a pointy-top hex has pointed top and bottom instead,
-	// so its facings are e|w|ne|nw|se|sw. A name from the wrong set is an
-	// ERROR, never a silent snap to the nearest valid one — the vocabulary
-	// and the rendered yaw both derive from the SAME declared orientation
-	// (ideas/dungeon-builder/prop-facing-offset.md).
-	facingsByOrientation = map[encounter.OrientationKind]map[string]bool{
-		encounter.OrientationFlatTop:   {"n": true, "s": true, "ne": true, "nw": true, "se": true, "sw": true},
-		encounter.OrientationPointyTop: {"e": true, "w": true, "ne": true, "nw": true, "se": true, "sw": true},
+	// facings is the ONE eight-name true-compass vocabulary, the same set
+	// under BOTH hex orientations (rpg-project#272 ruling, superseding
+	// #261's orientation-scoped six-name sets): compass directions live in
+	// world space, so which way the hexes point does not change which words
+	// exist. A name outside the set is an ERROR, never a silent snap to the
+	// nearest valid one (ideas/dungeon-builder/cardinal-facings.md).
+	facings = map[string]bool{
+		"n": true, "ne": true, "e": true, "se": true,
+		"s": true, "sw": true, "w": true, "nw": true,
 	}
 
 	keyShape = regexp.MustCompile(`^[a-z0-9-]+$`)
@@ -246,7 +244,10 @@ func (v *validation) walls() {
 	v.crossings = map[[2]spatial.Position]string{}
 	for i, w := range v.spec.Walls {
 		p := fmt.Sprintf("walls[%d]", i)
-		c, ok := v.edge(p, w)
+		if w.Height != nil && (*w.Height < 1 || *w.Height > 3) {
+			v.fail(p+".height", "height %g is outside [1,3]: walls raise, they never lower (rpg-project#273)", *w.Height)
+		}
+		c, ok := v.edge(p, w.Between)
 		if !ok {
 			continue
 		}
@@ -373,16 +374,20 @@ func (v *validation) place() {
 			if pl.BlocksLoS == nil {
 				v.fail(p+".blocks_los", "%q does not say whether it blocks line of sight, and there is no default", pl.Ref)
 			}
-			if pl.Facing != "" && !facingsByOrientation[v.orientation.Kind()][pl.Facing] {
-				v.fail(p+".facing", "%s-top has no facing %q", v.orientation.Kind(), pl.Facing)
+			if pl.Facing != "" && !facings[pl.Facing] {
+				v.fail(p+".facing", "%q is not a compass direction: a facing is one of n|ne|e|se|s|sw|w|nw", pl.Facing)
 			}
 			if pl.Offset != nil {
-				if len(pl.Offset) != 2 {
-					v.fail(p+".offset", "offset must be [x,y], got %d value(s)", len(pl.Offset))
+				if len(pl.Offset) != 2 && len(pl.Offset) != 3 {
+					v.fail(p+".offset", "offset must be [x,y] or [x,y,height], got %d value(s)", len(pl.Offset))
 				} else {
 					for j, c := range pl.Offset {
-						if c < -0.5 || c > 0.5 {
-							v.fail(p+".offset", "offset[%d] %g is outside [-0.5,0.5]", j, c)
+						if j < 2 {
+							if c < -0.5 || c > 0.5 {
+								v.fail(p+".offset", "offset[%d] %g is outside [-0.5,0.5]", j, c)
+							}
+						} else if c < 0 || c > 3 {
+							v.fail(p+".offset", "offset[2] %g is outside [0,3]", c)
 						}
 					}
 				}

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -189,26 +189,57 @@ type PropInput struct {
 	// REQUIRED, for the same reason and with the same refusal.
 	BlocksLineOfSight *bool
 
-	// Facing is the authored direction this prop faces, in the orientation's
-	// own six-name vocabulary — flat-top: n|s|ne|nw|se|sw; pointy-top:
-	// e|w|ne|nw|se|sw. Optional: "" means the asset's own default facing.
-	// dungeonspec validates the word against the field's declared
-	// [Orientation]; THIS MODULE NEVER DOES, and never turns it into an
-	// angle — angle math is a render concern, not this module's (rpg-project
-	// #261 ruling; ADR-0040's spirit that the wire/model names facts and the
-	// client derives pixels). Not a pointer, unlike the two flags above: a
-	// prop's facing is a presentational fact rather than a required answer,
-	// so "said nothing" and "said the default" are the same by design.
+	// Facing is the authored direction this prop faces, one of the EIGHT
+	// true-compass names — n|ne|e|se|s|sw|w|nw — valid under BOTH hex
+	// orientations (rpg-project#272 superseded #261's orientation-scoped
+	// six-name sets: compass directions live in world space). Optional: ""
+	// means the asset's own default facing. dungeonspec validates the word;
+	// THIS MODULE NEVER DOES, and never turns it into an angle — angle math
+	// is a render concern, not this module's (ADR-0040's spirit that the
+	// wire/model names facts and the client derives pixels). Not a pointer,
+	// unlike the two flags above: a prop's facing is a presentational fact
+	// rather than a required answer, so "said nothing" and "said the
+	// default" are the same by design.
 	Facing string
 
-	// Offset is a within-cell visual nudge: [x,y] fractions of the cell
-	// size, each in [-0.5, 0.5]. Optional: {0,0} means centered, which
-	// omitting the field also means — the two are the same fact by design,
-	// for Facing's reason. VISUAL ONLY (Kirk, rpg-project#261: "offset is
-	// visual only, agreed") — a prop still occupies its whole cell for
-	// [Encounter.Step] and for sight; this field never reaches Sight,
-	// Standing, or the turn loop, the same law Facing follows.
-	Offset [2]float64
+	// Offset is an authored visual displacement: [x,y] within-cell nudge
+	// fractions of the cell size, each in [-0.5, 0.5], plus a THIRD
+	// component — height above the floor in the same cell-size unit, in
+	// [0, 3] and deliberately not bound to its siblings' planar clamp
+	// (rpg-project#272: "height should be able to gun higher than the 5
+	// ticks we allow on x and y"). Optional: the zero value means centered
+	// on the floor, which omitting the field also means — the two are the
+	// same fact by design, for Facing's reason. VISUAL ONLY (Kirk,
+	// rpg-project#261: "offset is visual only, agreed") — a prop still
+	// occupies its whole cell for [Encounter.Step] and for sight; this
+	// field never reaches Sight, Standing, or the turn loop, the same law
+	// Facing follows.
+	Offset [3]float64
+}
+
+// WallInput is one authored wall: the crossing it blocks, plus the
+// presentational facts the crossing carries. The mechanics half is the
+// embedded [spatial.Boundary] — spatial stays the layer that knows what a
+// boundary DOES, and deliberately never learns what one looks like
+// (rpg-project#273: height is visual-only by ruling, so it lives here at the
+// composition, the same layering call that put Facing and Offset on
+// [PropInput] rather than on a spatial type).
+type WallInput struct {
+	// Boundary is the crossing itself: endpoints in the AUTHORED offset
+	// frame, plus what it blocks. See [FieldInput.Walls] for the frame and
+	// adjacency contract.
+	spatial.Boundary
+
+	// Height is the authored wall-height MULTIPLIER of the standard
+	// rendered wall height, in [1, 3] when authored — raise-only by ruling
+	// (rpg-project#273: "I am looking to raise the walls not lower them").
+	// 0 means not authored: a reader renders the standard height, exactly
+	// as if 1.0 were written — the two are the same fact by design, and
+	// nothing may multiply by the raw value. dungeonspec validates the
+	// bounds; this module carries the number unread, VISUAL ONLY: height
+	// never reaches Sight or movement — a wall cannot be seen past at any
+	// height (Kirk's ruling, rpg-project#274).
+	Height float64
 }
 
 // FieldInput describes the map: what the canvas declares, the regions that
@@ -244,7 +275,7 @@ type FieldInput struct {
 	//
 	// Endpoint ORDER is not carried: spatial normalizes an undirected pair on
 	// registration, so From and To describe the same edge either way round.
-	Walls []spatial.Boundary
+	Walls []WallInput
 
 	// Doors are the doors standing in this field's crossings — each a set of
 	// edges sharing one state (rpg-toolkit#1123), with edges in ABSOLUTE

--- a/rulebooks/dnd5e/encounter/props_test.go
+++ b/rulebooks/dnd5e/encounter/props_test.go
@@ -446,7 +446,7 @@ func (s *PropsSuite) TestFacingAndOffsetAreCarriedButNeverInterpreted() {
 			Props: []encounter.PropInput{
 				{Ref: "dnd5e:props:statue-reaper", At: propSeat(1, 1),
 					BlocksMovement: propTrue(), BlocksLineOfSight: propTrue(),
-					Facing: "not-a-real-direction", Offset: [2]float64{9, -9}},
+					Facing: "not-a-real-direction", Offset: [3]float64{9, -9}},
 				{Ref: "dnd5e:props:altar", At: propSeat(9, 3),
 					BlocksMovement: propTrue(), BlocksLineOfSight: propFalse()},
 			},
@@ -465,11 +465,11 @@ func (s *PropsSuite) TestFacingAndOffsetAreCarriedButNeverInterpreted() {
 
 	s.Equal("dnd5e:props:statue-reaper", props[0].Ref)
 	s.Equal("not-a-real-direction", props[0].Facing, "the exact word, uninterpreted")
-	s.Equal([2]float64{9, -9}, props[0].Offset, "the exact numbers, unbounded")
+	s.Equal([3]float64{9, -9}, props[0].Offset, "the exact numbers, unbounded")
 
 	s.Equal("dnd5e:props:altar", props[1].Ref)
 	s.Equal("", props[1].Facing, "said nothing")
-	s.Equal([2]float64{0, 0}, props[1].Offset, "and said zero/center: the same fact by design")
+	s.Equal([3]float64{0, 0}, props[1].Offset, "and said zero/center: the same fact by design")
 
 	_, err = enc.Step(&encounter.StepInput{Member: delver, To: propAbs(1, 1)})
 	s.Require().ErrorIs(err, encounter.ErrBadPlacement,
@@ -488,7 +488,7 @@ func (s *PropsSuite) TestFacingAndOffsetSurviveASave() {
 			Props: []encounter.PropInput{
 				{Ref: "dnd5e:props:statue-reaper", At: propSeat(propAtX, 4),
 					BlocksMovement: propTrue(), BlocksLineOfSight: propTrue(),
-					Facing: "ne", Offset: [2]float64{0.25, -0.4}},
+					Facing: "ne", Offset: [3]float64{0.25, -0.4}},
 			},
 		},
 		Members: []encounter.MemberInput{
@@ -501,7 +501,7 @@ func (s *PropsSuite) TestFacingAndOffsetSurviveASave() {
 	data := enc.ToData()
 	s.Require().Len(data.Field.Props, 1)
 	s.Equal("ne", data.Field.Props[0].Facing)
-	s.Equal([2]float64{0.25, -0.4}, data.Field.Props[0].Offset)
+	s.Equal([3]float64{0.25, -0.4}, data.Field.Props[0].Offset)
 
 	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
@@ -513,5 +513,5 @@ func (s *PropsSuite) TestFacingAndOffsetSurviveASave() {
 	s.Require().NoError(err)
 	s.Require().Len(atlas.Props, 1)
 	s.Equal("ne", atlas.Props[0].Facing, "still there after a reload")
-	s.Equal([2]float64{0.25, -0.4}, atlas.Props[0].Offset)
+	s.Equal([3]float64{0.25, -0.4}, atlas.Props[0].Offset)
 }

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -942,13 +942,13 @@ var twoRoomDoor = openDoorway("door1", 9, 5, 10, 5)
 // say before the field became one canvas (rpg-toolkit#1106) — and one these
 // fixtures now have to say, because with one canvas and no wall the two
 // chambers share an open seam ten cells wide.
-func twoRoomWall() []spatial.Boundary { return squareSeamWall(9, 10, 5) }
+func twoRoomWall() []encounter.WallInput { return squareSeamWall(9, 10, 5) }
 
 // twoRoomSealedWall is the same wall with NO opening — for the fixtures that
 // declare no doorway at all. Two chambers side by side with nothing joining
 // them is a solid partition, and saying so is now the fixture's job: it used to
 // be implied by their being different rooms.
-func twoRoomSealedWall() []spatial.Boundary { return squareSeamWall(9, 10) }
+func twoRoomSealedWall() []encounter.WallInput { return squareSeamWall(9, 10) }
 
 // twoRoomField is the field most of this file's two-room fixtures build:
 // room-a at the origin, room-b anchored immediately east of it, joined at

--- a/rulebooks/dnd5e/encounter/pursuit_test.go
+++ b/rulebooks/dnd5e/encounter/pursuit_test.go
@@ -66,7 +66,7 @@ var (
 // nothing for anybody to hide behind — which is the honest consequence of the
 // field being one canvas (rpg-toolkit#1106), and the reason this fixture has to
 // say where its walls are instead of relying on a room boundary to imply them.
-func pursuitSeamWall() []spatial.Boundary { return seamWallRows(25, 10, 6, 13) }
+func pursuitSeamWall() []encounter.WallInput { return seamWallRows(25, 10, 6, 13) }
 
 func (s *PursuitSuite) SetupTest() {
 	field := encounter.FieldInput{

--- a/rulebooks/dnd5e/encounter/region_test.go
+++ b/rulebooks/dnd5e/encounter/region_test.go
@@ -355,7 +355,7 @@ func (s *RegionSetupSuite) TestEdges_MustBeAdjacentUnderOrientation() {
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: o},
 				Regions: []encounter.RegionInput{rectRegion("window", 0, 0, size, size)},
-				Walls:   []spatial.Boundary{wall(a[0], a[1], b[0], b[1])},
+				Walls:   []encounter.WallInput{wall(a[0], a[1], b[0], b[1])},
 			},
 			Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 		})
@@ -402,7 +402,7 @@ func (s *RegionSetupSuite) TestEdges_MustBeAdjacentUnderOrientation() {
 
 // TestEdgesMustStandOnTheFloor — the envelope is implied, never written.
 func (s *RegionSetupSuite) TestEdgesMustStandOnTheFloor() {
-	build := func(walls []spatial.Boundary, doors []encounter.DoorInput) error {
+	build := func(walls []encounter.WallInput, doors []encounter.DoorInput) error {
 		_, err := encounter.NewEncounter(&encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
 			Field:   encounter.FieldInput{Canvas: pointyCanvas(), Regions: threeRegions(), Walls: walls, Doors: doors},
@@ -411,7 +411,7 @@ func (s *RegionSetupSuite) TestEdgesMustStandOnTheFloor() {
 		return err
 	}
 
-	err := build([]spatial.Boundary{wall(6, 4, 5, 4)}, nil)
+	err := build([]encounter.WallInput{wall(6, 4, 5, 4)}, nil)
 	s.Require().ErrorIs(err, encounter.ErrEdgeOffFloor)
 	s.Contains(err.Error(), "walls[0]")
 	s.Contains(err.Error(), "[5,4]")
@@ -424,7 +424,7 @@ func (s *RegionSetupSuite) TestEdgesMustStandOnTheFloor() {
 	s.Require().ErrorIs(err, encounter.ErrEdgeNotAdjacent)
 	s.ErrorIs(err, encounter.ErrBadDoor)
 
-	err = build([]spatial.Boundary{wall(6, 4, 7, 4), wall(7, 4, 6, 4)}, nil)
+	err = build([]encounter.WallInput{wall(6, 4, 7, 4), wall(7, 4, 6, 4)}, nil)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Contains(err.Error(), "listed twice", "the same edge either way round is the same edge")
 

--- a/rulebooks/dnd5e/encounter/regionfixtures_test.go
+++ b/rulebooks/dnd5e/encounter/regionfixtures_test.go
@@ -59,14 +59,14 @@ func cellAt(col, row int) spatial.Position {
 }
 
 // wall is one authored wall edge between two adjacent cells, blocking both
-// movement and sight.
-func wall(fromCol, fromRow, toCol, toRow int) spatial.Boundary {
-	return spatial.Boundary{
+// movement and sight, at default height.
+func wall(fromCol, fromRow, toCol, toRow int) encounter.WallInput {
+	return encounter.WallInput{Boundary: spatial.Boundary{
 		From:              spatial.Position{X: float64(fromCol), Y: float64(fromRow)},
 		To:                spatial.Position{X: float64(toCol), Y: float64(toRow)},
 		BlocksMovement:    true,
 		BlocksLineOfSight: true,
-	}
+	}}
 }
 
 // seamWallRows is seamWall over rows [row0, row0+rows), leaving the straight
@@ -74,12 +74,12 @@ func wall(fromCol, fromRow, toCol, toRow int) spatial.Boundary {
 // that are actually adjacent under pointy-top are emitted: a hex cell has six
 // neighbours, not eight, and compileField refuses an edge between two cells
 // that do not touch (ErrEdgeNotAdjacent).
-func seamWallRows(west, row0, rows int, gaps ...int) []spatial.Boundary {
+func seamWallRows(west, row0, rows int, gaps ...int) []encounter.WallInput {
 	open := make(map[int]bool, len(gaps))
 	for _, g := range gaps {
 		open[g] = true
 	}
-	var out []spatial.Boundary
+	var out []encounter.WallInput
 	for row := row0; row < row0+rows; row++ {
 		near := cellAt(west, row)
 		for _, dr := range []int{-1, 0, 1} {

--- a/rulebooks/dnd5e/encounter/step_test.go
+++ b/rulebooks/dnd5e/encounter/step_test.go
@@ -86,7 +86,7 @@ func stepAbs(origin, local spatial.Position) spatial.Position {
 // stepSeamWall is the wall along the seam between the two chambers: every
 // crossing from the west chamber's last column to the east chamber's first,
 // every row but the doorway's.
-func stepSeamWall() []spatial.Boundary {
+func stepSeamWall() []encounter.WallInput {
 	return seamWallRows(int(stepWestOrigin.X)+5, int(stepWestOrigin.Y), 6, int(stepWestOrigin.Y)+int(stepDoorWestLocal.Y))
 }
 

--- a/rulebooks/dnd5e/encounter/testwalls_test.go
+++ b/rulebooks/dnd5e/encounter/testwalls_test.go
@@ -131,7 +131,7 @@ func structFieldNames(v any) []string {
 // A gap row is one cell wide in both senses: only the straight crossing
 // (atX,g)-(atX+1,g) is left open, so a doorway is a doorway rather than a
 // diagonal shortcut around its own frame.
-func squareSeamWall(atX, height int, gapRows ...int) []spatial.Boundary {
+func squareSeamWall(atX, height int, gapRows ...int) []encounter.WallInput {
 	return seamWallRows(atX, 0, height, gapRows...)
 }
 
@@ -150,7 +150,7 @@ func squareSeamWall(atX, height int, gapRows ...int) []spatial.Boundary {
 // A gap row leaves only the straight crossing open, exactly as squareSeamWall's
 // does, so a doorway is a doorway rather than a diagonal shortcut around its
 // own frame.
-func hexOffsetSeamWall(o encounter.Orientation, atCol, rowMin, rowMax int, gapRows ...int) []spatial.Boundary {
+func hexOffsetSeamWall(o encounter.Orientation, atCol, rowMin, rowMax int, gapRows ...int) []encounter.WallInput {
 	gap := make(map[int]bool, len(gapRows))
 	for _, g := range gapRows {
 		gap[g] = true
@@ -158,7 +158,7 @@ func hexOffsetSeamWall(o encounter.Orientation, atCol, rowMin, rowMax int, gapRo
 
 	grid := spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 1e6, SpanHeight: 1e6})
 
-	out := make([]spatial.Boundary, 0, (rowMax-rowMin+1)*2)
+	out := make([]encounter.WallInput, 0, (rowMax-rowMin+1)*2)
 	for row := rowMin; row <= rowMax; row++ {
 		near := encounter.HexCellAt(o, atCol, row)
 		for _, dr := range []int{-1, 0, 1} {
@@ -172,12 +172,12 @@ func hexOffsetSeamWall(o encounter.Orientation, atCol, rowMin, rowMax int, gapRo
 			if grid.Distance(near, encounter.HexCellAt(o, atCol+1, to)) != 1 {
 				continue // not a crossing at all on this grid
 			}
-			out = append(out, spatial.Boundary{
+			out = append(out, encounter.WallInput{Boundary: spatial.Boundary{
 				From:              spatial.Position{X: float64(atCol), Y: float64(row)},
 				To:                spatial.Position{X: float64(atCol + 1), Y: float64(to)},
 				BlocksMovement:    true,
 				BlocksLineOfSight: true,
-			})
+			}})
 		}
 	}
 


### PR DESCRIPTION
Carrier half of the two reprioritized dungeon-builder slices (#1247; designs approved with Kirk's rulings on KirkDiggler/rpg-project#274). Wire twin: KirkDiggler/rpg-api-protos#254.

**KirkDiggler/rpg-project#272 — cardinal facings + raised offset**
- `dungeonspec` facing validation swaps to ONE eight-name true-compass set (`n|ne|e|se|s|sw|w|nw`), the SAME eight under BOTH hex orientations. The #261 orientation-scoped refusal rows flip to acceptance — deliberately, per the ruling; the refusal that remains is "not a compass word."
- `offset` accepts an optional third component: height above the floor in cell-size fractions, `[0, 3]`, deliberately not bound to the planar ±0.5 clamp. `PropInput`/`AtlasProp`/`PropData` widen `[2]float64 → [3]float64` (breaking is free pre-adoption; old persisted 2-element arrays still unmarshal, filling height 0).

**KirkDiggler/rpg-project#273 — authored wall height**
- `walls:` entries accept `{ between: [[c,r],[c,r]], height: 2 }` beside the bare pair (custom unmarshaler keeps Decode's strictness: unknown keys and edgeless objects refused).
- Height is a raise-only multiplier `[1, 3]` (`walls[i].height` bounds refusal, 0.5 is a named case), carried unread on the new encounter-owned **`WallInput`** — deliberately NOT on `spatial.Boundary`: spatial stays the layer that knows what a boundary DOES, height is visual-only by ruling. Rides `BoundaryData` (json `height,omitempty` — safe because 0 is unauthorable) and `AtlasBoundary`.
- Visual only: a wall blocks identically — and cannot be seen past — at every height. Nothing in Sight, Step, or the turn loop reads it.

**Tests**: vocabulary flip (8 names × both orientations + non-compass refusal); offset third-component bounds both ways + 4-number refusal; wall object form compile (multiplier verbatim, siblings 0); decode strictness; height bounds rows; Setup → Atlas → ToData → Load → Atlas round trip with heights intact; reference-tomb goldens unchanged (bare-pair files byte-identical, zero-value facing/offset assertions still pinned, offset persistence shape widens to `[0,0,0]` in the one rich golden).

`go test ./...` green across encounter + dungeonspec + workbench; golangci-lint 0 issues.

Session projection follows in its own PR (the #1227/#1228 shape) once this merges and tags.

— world-builder lane, on behalf of KirkDiggler