### PR TITLE
feat(session): atlas carries offset height and wall height across the seam (#1247)

### DIFF
--- a/rulebooks/dnd5e/session/atlasmap_test.go
+++ b/rulebooks/dnd5e/session/atlasmap_test.go
@@ -112,9 +112,9 @@ func (s *AtlasMapSuite) TestNothingOnTheMapNamesARoom() {
 		"a doorway is a door's identity and two cells",
 	)
 	s.Equal(
-		[]string{"From", "To", "BlocksMovement", "BlocksLineOfSight"},
+		[]string{"From", "To", "BlocksMovement", "BlocksLineOfSight", "Height"},
 		fieldsOf(session.AtlasBoundary{}),
-		"a wall is two cells and what it stops",
+		"a wall is two cells, what it stops, and how tall it stands",
 	)
 }
 

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -549,9 +549,9 @@ const sightRadius = 4
 // diagonal through it. Which candidate pairs ARE crossings is the grid's
 // answer: a hex has six neighbours and they stagger with the row's parity,
 // so each is checked by distance rather than assumed.
-func hexSeam(east, rows, openRow int) []spatial.Boundary {
+func hexSeam(east, rows, openRow int) []encounter.WallInput {
 	grid := spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 1, SpanHeight: 1})
-	out := make([]spatial.Boundary, 0, rows*2)
+	out := make([]encounter.WallInput, 0, rows*2)
 	for row := 0; row < rows; row++ {
 		for _, dr := range []int{-1, 0, 1} {
 			to := row + dr
@@ -564,12 +564,12 @@ func hexSeam(east, rows, openRow int) []spatial.Boundary {
 			if !grid.IsAdjacent(cellAt(east-1, row), cellAt(east, to)) {
 				continue // not a crossing on this grid
 			}
-			out = append(out, spatial.Boundary{
+			out = append(out, encounter.WallInput{Boundary: spatial.Boundary{
 				From:              spatial.Position{X: float64(east - 1), Y: float64(row)},
 				To:                spatial.Position{X: float64(east), Y: float64(to)},
 				BlocksMovement:    true,
 				BlocksLineOfSight: true,
-			})
+			}})
 		}
 	}
 

--- a/rulebooks/dnd5e/session/convert.go
+++ b/rulebooks/dnd5e/session/convert.go
@@ -92,6 +92,7 @@ func projectAtlas(in encounter.Atlas) Atlas {
 			To:                b.To,
 			BlocksMovement:    b.BlocksMovement,
 			BlocksLineOfSight: b.BlocksLineOfSight,
+			Height:            b.Height,
 		})
 	}
 

--- a/rulebooks/dnd5e/session/convert_internal_test.go
+++ b/rulebooks/dnd5e/session/convert_internal_test.go
@@ -31,7 +31,7 @@ func TestPropFacingAndOffsetCrossTheSeam(t *testing.T) {
 			{
 				Ref: "dnd5e:props:statue-reaper", At: spatial.Position{X: 3, Y: 4},
 				BlocksMovement: true, BlocksLineOfSight: true,
-				Facing: "se", Offset: [2]float64{0.2, -0.1},
+				Facing: "se", Offset: [3]float64{0.2, -0.1, 0.6},
 			},
 			{
 				Ref: "dnd5e:props:candles", At: spatial.Position{X: 5, Y: 6},
@@ -44,8 +44,29 @@ func TestPropFacingAndOffsetCrossTheSeam(t *testing.T) {
 
 	require.Len(t, out.Props, 2)
 	require.Equal(t, "se", out.Props[0].Facing, "the exact authored word, uninterpreted")
-	require.Equal(t, [2]float64{0.2, -0.1}, out.Props[0].Offset, "the exact authored numbers")
+	require.Equal(t, [3]float64{0.2, -0.1, 0.6}, out.Props[0].Offset, "the exact authored numbers, height included")
 
 	require.Equal(t, "", out.Props[1].Facing, "said nothing")
-	require.Equal(t, [2]float64{0, 0}, out.Props[1].Offset, "and said zero/center: the same fact by design")
+	require.Equal(t, [3]float64{0, 0, 0}, out.Props[1].Offset, "and said zero/center-on-the-floor: the same fact by design")
+}
+
+// TestWallHeightCrossesTheSeam — the authored multiplier is copied verbatim
+// (rpg-project#273), and a wall that authored none carries 0: the reader's
+// word for "render the standard height", never a number to multiply by.
+func TestWallHeightCrossesTheSeam(t *testing.T) {
+	in := encounter.Atlas{
+		Orientation: encounter.HexesArePointyTop(),
+		Boundaries: []encounter.AtlasBoundary{
+			{From: spatial.Position{X: 2, Y: 3}, To: spatial.Position{X: 3, Y: 3},
+				BlocksMovement: true, BlocksLineOfSight: true, Height: 2.5},
+			{From: spatial.Position{X: 2, Y: 4}, To: spatial.Position{X: 3, Y: 4},
+				BlocksMovement: true, BlocksLineOfSight: true},
+		},
+	}
+
+	out := projectAtlas(in)
+
+	require.Len(t, out.Boundaries, 2)
+	require.Equal(t, 2.5, out.Boundaries[0].Height, "the exact authored multiplier")
+	require.Zero(t, out.Boundaries[1].Height, "no height authored: the standard height")
 }

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.1-0.20260825071152-11fd766254bc
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.35.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.1-0.20260825071152-11fd766254bc
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0 h1:8c/xoqxgXqRO3LxoEX
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0 h1:LxEJMtm4M3PMDnpRC61ooGvWKS/eRZImu/GTeTDCYuM=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0/go.mod h1:Y5eXfAAyQ0N4Sp07T5C7MxD2CwAwdAUi2zo5SyN60Ds=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.0 h1:TJCQjYO0YQX3+BK2wZQ9Kebib0PEqIxqT/2VUmtbsO4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.1-0.20260825071152-11fd766254bc h1:D8l02JUqtCowOUjnP2nqUcxtpfKjOg65vIs2H2tehN4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.1-0.20260825071152-11fd766254bc/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0 h1:Ftc+y0UnhW0wTlovA6RFoYDL/6un1ZKJdc1p3SXGB0w=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0/go.mod h1:HzM2KKrpUlpOLfesRkxy8V8enQdmRzvsisZrEuB9BM8=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -20,8 +20,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0 h1:8c/xoqxgXqRO3LxoEX
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0 h1:LxEJMtm4M3PMDnpRC61ooGvWKS/eRZImu/GTeTDCYuM=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0/go.mod h1:Y5eXfAAyQ0N4Sp07T5C7MxD2CwAwdAUi2zo5SyN60Ds=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.1-0.20260825071152-11fd766254bc h1:D8l02JUqtCowOUjnP2nqUcxtpfKjOg65vIs2H2tehN4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.34.1-0.20260825071152-11fd766254bc/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.35.0 h1:fMhz1HN0i9DxkyJLI2CLYdC/ePNo66N1dz3UFUXu/j8=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.35.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0 h1:Ftc+y0UnhW0wTlovA6RFoYDL/6un1ZKJdc1p3SXGB0w=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0/go.mod h1:HzM2KKrpUlpOLfesRkxy8V8enQdmRzvsisZrEuB9BM8=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/session/testprops_test.go
+++ b/rulebooks/dnd5e/session/testprops_test.go
@@ -80,7 +80,7 @@ func hexCell(col, row int) spatial.Position {
 // and column Width is the east chamber's first. Only real crossings are
 // emitted: on hex, which pairs are adjacent staggers with the column's parity,
 // so the candidates are filtered by actual cube distance rather than assumed.
-func hexSeamWalls(westWidth, rows, openRow int) []spatial.Boundary {
+func hexSeamWalls(westWidth, rows, openRow int) []encounter.WallInput {
 	return hexSeamWallsFrom(westWidth, 0, rows, openRow)
 }
 
@@ -88,9 +88,9 @@ func hexSeamWalls(westWidth, rows, openRow int) []spatial.Boundary {
 // than 0: the wall between authored column east-1 and column east, over rows
 // [row0, row0+rows), leaving the straight crossing on openRow open (-1 for a
 // solid wall).
-func hexSeamWallsFrom(east, row0, rows, openRow int) []spatial.Boundary {
+func hexSeamWallsFrom(east, row0, rows, openRow int) []encounter.WallInput {
 	westWidth := east
-	out := make([]spatial.Boundary, 0, rows*2)
+	out := make([]encounter.WallInput, 0, rows*2)
 	for row := row0; row < row0+rows; row++ {
 		for _, dr := range []int{-1, 0, 1} {
 			to := row + dr
@@ -103,12 +103,12 @@ func hexSeamWallsFrom(east, row0, rows, openRow int) []spatial.Boundary {
 			if hexSteps(hexCell(westWidth-1, row), hexCell(westWidth, to)) != 1 {
 				continue // not a crossing on this grid
 			}
-			out = append(out, spatial.Boundary{
+			out = append(out, encounter.WallInput{Boundary: spatial.Boundary{
 				From:              spatial.Position{X: float64(westWidth - 1), Y: float64(row)},
 				To:                spatial.Position{X: float64(westWidth), Y: float64(to)},
 				BlocksMovement:    true,
 				BlocksLineOfSight: true,
-			})
+			}})
 		}
 	}
 

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -187,28 +187,31 @@ type AtlasProp struct {
 	// BlocksLineOfSight reports whether sight passes through its cell.
 	BlocksLineOfSight bool `json:"blocks_line_of_sight"`
 
-	// Facing is the authored direction this prop faces, in the field's own
-	// orientation vocabulary — carried verbatim from
-	// [encounter.AtlasProp.Facing] and never interpreted here (rpg-project
-	// #261). Optional: "" means the asset's own default facing. Angle math
-	// is a render concern, not this seam's — the wire names the fact, the
-	// client derives pixels.
+	// Facing is the authored direction this prop faces, one of the eight
+	// true-compass names — carried verbatim from [encounter.AtlasProp.Facing]
+	// and never interpreted here (rpg-project#261, vocabulary redefined by
+	// rpg-project#272: the SAME eight names under both orientations).
+	// Optional: "" means the asset's own default facing. Angle math is a
+	// render concern, not this seam's — the wire names the fact, the client
+	// derives pixels.
 	Facing string `json:"facing,omitempty"`
 
-	// Offset is a within-cell VISUAL nudge, [x,y] fractions of the cell
-	// size, carried verbatim from [encounter.AtlasProp.Offset]. {0,0} means
-	// centered — the SAME fact a prop that authored no offset carries, by
-	// design (rpg-project#261).
+	// Offset is an authored VISUAL displacement, carried verbatim from
+	// [encounter.AtlasProp.Offset]: [x,y] within-cell nudge fractions of
+	// the cell size, plus a third component — height above the floor in the
+	// same unit (rpg-project#272), not bound to the planar ±0.5 clamp. The
+	// zero value means centered on the floor — the SAME fact a prop that
+	// authored no offset carries, by design (rpg-project#261).
 	//
 	// No omitempty: Go's encoding/json cannot omit a fixed-size array
 	// regardless of the tag (verified — the key is always written), so a
-	// reading client checks the VALUE for {0,0} rather than the key for
-	// absence, the same way [Lighting.Intensity]'s own zero is an answer
-	// rather than a gap.
+	// reading client checks the VALUE for the zero value rather than the
+	// key for absence, the same way [Lighting.Intensity]'s own zero is an
+	// answer rather than a gap.
 	//
 	// VISUAL ONLY — a prop still occupies its whole cell for movement and
 	// line of sight; this never reaches a rule.
-	Offset [2]float64 `json:"offset"`
+	Offset [3]float64 `json:"offset"`
 }
 
 // AtlasBoundary is one wall or barrier crossing between adjacent cells.
@@ -224,6 +227,18 @@ type AtlasBoundary struct {
 
 	// BlocksLineOfSight reports whether sight may cross.
 	BlocksLineOfSight bool `json:"blocks_line_of_sight"`
+
+	// Height is the authored wall-height MULTIPLIER of the standard
+	// rendered wall height, carried verbatim from
+	// [encounter.AtlasBoundary.Height] and never interpreted here
+	// (rpg-project#273). 0 means not authored: a reader renders the
+	// STANDARD height — exactly as if 1.0 were written — and never
+	// multiplies by the raw value; the authored bounds are [1, 3]
+	// (raise-only, by ruling), so 0 cannot be an authored fact. omitempty
+	// is safe for exactly that reason. VISUAL ONLY: a wall blocks movement
+	// and sight identically at every height — a wall cannot be seen past
+	// at ANY height (Kirk's ruling, rpg-project#274).
+	Height float64 `json:"height,omitempty"`
 }
 
 // AtlasDoorway is one crossable pair of cells. The two are adjacent in

--- a/rulebooks/dnd5e/session/wirecontract_test.go
+++ b/rulebooks/dnd5e/session/wirecontract_test.go
@@ -68,6 +68,40 @@ func TestFalseIsAnAnswerOnTheWire(t *testing.T) {
 	}
 }
 
+// TestWallHeightOmitemptyIsDeliberateOnTheWire pins the height field's BYTES
+// both ways, because its contract is the opposite of its two bool siblings
+// above: for blocks_movement/blocks_line_of_sight, false must be SAID; for
+// height, zero must be UNSAID. That asymmetry is safe only because 0 is
+// unauthorable (the YAML bounds are [1,3], raise-only — rpg-project#273), so
+// an absent key can only ever mean "not authored, render the standard
+// height". A nonzero authored multiplier must be emitted verbatim, and the
+// default case must omit the key — a tag regression in either direction
+// passes every Go-value test, so this asserts the bytes.
+func TestWallHeightOmitemptyIsDeliberateOnTheWire(t *testing.T) {
+	atlas := session.Atlas{
+		Boundaries: []session.AtlasBoundary{
+			{From: spatial.Position{X: 0, Y: 0}, To: spatial.Position{X: 1, Y: 0},
+				BlocksMovement: true, BlocksLineOfSight: true, Height: 2.5},
+			{From: spatial.Position{X: 0, Y: 1}, To: spatial.Position{X: 1, Y: 1},
+				BlocksMovement: true, BlocksLineOfSight: true},
+		},
+	}
+
+	raw, err := json.Marshal(atlas)
+	require.NoError(t, err)
+
+	var wire struct {
+		Walls []map[string]json.RawMessage `json:"boundaries"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &wire))
+	require.Len(t, wire.Walls, 2)
+
+	require.Contains(t, wire.Walls[0], "height", "an authored multiplier is emitted: %s", raw)
+	require.Equal(t, "2.5", string(wire.Walls[0]["height"]), "verbatim, never rescaled")
+	require.NotContains(t, wire.Walls[1], "height",
+		"no authored height omits the key — a reader maps absence to the standard height: %s", raw)
+}
+
 // TestEmptyDeclarationsIsAnAnswerOnTheWire is TestFalseIsAnAnswerOnTheWire's
 // own claim asked of a LIST rather than a bool: on the world clock,
 // AffordOutput.Declarations is empty because the economy does not apply, not


### PR DESCRIPTION
Projection half of the two dungeon-builder slices (#1247; rulings on KirkDiggler/rpg-project#274), following #1248 in the #1227/#1228 shape.

- `AtlasProp.Offset` widens to `[x, y, height]`, carried verbatim (rpg-project#272).
- `AtlasBoundary` gains `Height` (json `height,omitempty`): the authored raise-only multiplier, `0` = not authored → a reader renders the STANDARD height and never multiplies by the raw value (rpg-project#273). The wire-shape field-list test pins the new field; a seam test asserts the multiplier and the 0 both cross intact.

**Merge gate**: encounter is pinned at a pseudo-version of #1248's branch so this builds honestly today; once #1248 merges and tags, the pin swaps to the real tag before this merges (the #1229 lesson — never leave the seam on a pseudo-version).

`go test ./...` green; golangci-lint 0 issues.

— world-builder lane, on behalf of KirkDiggler