### PR TITLE
feat(session): production combat offers and character status

### DIFF
--- a/docs/architecture/components/rulebook-dnd5e-session.md
+++ b/docs/architecture/components/rulebook-dnd5e-session.md
@@ -75,7 +75,8 @@ shortfall. Missing position for a live candidate fails closed. Projection
 copies each candidate `Why`, so caller mutation cannot alter internal preflight
 state. The same private target-preflight function is used by Afford and
 regenerated Attack execution; an injected-refusal regression proves they move
-together.
+together. Normal target/reach changes therefore refuse as `ErrStaleDeclaration`;
+`ErrOutOfReach` remains final defensive resolution validation.
 
 `AttackRef.Ref` is the complete catalog identity (`dnd5e:weapons:longsword`),
 not a bare ID. The same helper projects Declaration, AttackOutput, and the
@@ -94,8 +95,10 @@ Blockers are per verb rather than an incomplete declaration list:
 | no budget / no available target | compiled but unavailable, non-empty ID | independently compiled | unaffected |
 
 Every blocker keeps its fixed target kind and has empty ID, absent AttackRef,
-and empty candidates. EndTurn has no character-sheet, standing, or economy
-gate.
+and empty candidates. Attack and turn-clock Move strictly load the actor once;
+`combat.IsDown`, declaration compilation, pricing, and execution all use that
+same sheet snapshot. World-clock Move keeps its independent standing gate.
+EndTurn has no character-sheet, standing, or economy gate.
 
 ## Selector trust boundary
 

--- a/docs/architecture/components/rulebook-dnd5e-session.md
+++ b/docs/architecture/components/rulebook-dnd5e-session.md
@@ -1,8 +1,8 @@
 ---
 name: rulebooks/dnd5e/session module
-description: The game server's single integration surface — a manager composing the encounter behind repositories, with inner types held off the boundary so the insides can be replaced without the host changing
-updated: 2026-08-13
-confidence: high — written alongside the implementation (#938, #943); every claim below is pinned by a test in the module
+description: The game server's single integration surface — ID-based verbs over repositories, with compiled combat offers regenerated at execution and inner runtime types held off the host boundary
+updated: 2026-08-25
+confidence: high — selector, boundary, blocker-matrix, no-mutation, and full module gates are executable tests
 ---
 
 # rulebooks/dnd5e/session module
@@ -11,145 +11,149 @@ confidence: high — written alongside the implementation (#938, #943); every cl
 **Module:** `github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session`
 **Grade:** A-
 
-The host's one point of contact with the toolkit. A game server implements two
-repositories and an event stream, and thereafter holds no domain object: it
-names things and calls verbs.
+The host's one point of contact with live D&D 5e play. A game server supplies
+key-value repositories for sessions, encounters, and characters, plus event,
+dice, and unplayed-turn capabilities. It then calls verbs with IDs and stores
+data; it never holds a runtime encounter, character, clock, resolution, or
+compiled offer.
 
-## Where it sits
+## Layer and boundary
 
 ```
-rpg-api ──implements──▶ repositories (Get/Save)
+rpg-api ──implements──▶ SessionRepository / EncounterRepository / CharacterRepository
    └────────calls──────▶ session.Manager
                               │
-                         encounter (the world)
+                    encounter composition
                               │
               ┌───────┬───────┼────────┐
             clock   intel   record   spatial
+                              │
+                    D&D 5e resolution/rules
 ```
 
-The encounter composition is the **world** — geometry, placement, perception,
-story, endings. This module is the **table**: entity roster, event fan-out,
-resolution, and interrupt custody. It holds wiring and lifetime, never rules.
+The encounter composition is the world: geometry, placement, perception,
+story, clocks, and endings. Session is the host seam and courier. D&D rules
+stay in rulebook packages; session loads their data, invokes them, saves dirty
+aggregates, and projects seam-owned values.
 
-## Why it exists
+S2 is mechanical. `boundary_test.go` parses every exported declaration and
+rejects inner toolkit runtime types. The explicit exceptions are four stable
+or persisted values: `spatial.Position`, `character.Data`,
+`encounter.EncounterData`, and `monster.Data`; each has a written reason.
+`sentinels_test.go` closes the AST test's error-channel blind spot by proving
+reachable inner sentinels do not escape through `errors.Is`.
 
-Not to add capability. To make the toolkit's insides replaceable without the
-host changing a line, so waves of internal rework cost rpg-api a version bump
-rather than a migration.
+Every write verb remains **load → validate/select → act → save → return**. The
+manager caches no session state between calls (S1).
 
-That is a falsifiable claim, and it is gated two ways:
+## Current combat offer contract
 
-- **`boundary_test.go`** parses the package's own source and fails if any
-  toolkit type is reachable from an exported declaration. Verified against a
-  real leak, not a synthetic one; carries a meta-pin so it cannot silently stop
-  biting. Its allow list has three entries, each with a written reason — all of
-  them persistence shapes the host already stores, never a domain type.
-- **`gorelease-dnd5e-session`** in `compat.yml` gates every release.
+`Afford(session, member)` is the server-authored action surface. On an active
+turn it returns exactly one current compiled variant for each supported verb:
 
-The boundary test has one known blind spot, closed by hand: sentinel errors are
-not types in signatures, so the composition's sentinels are translated and a
-test asserts the inner ones are unreachable through returned errors.
+| Verb | Selector target | Compiled data | Final execution input |
+|---|---|---|---|
+| Attack | member | complete priced `actions.Definition`, matching resolution cost/readied payer, full-ref `AttackRef`, and one preflight row per live candidate | echoed ID + selected member |
+| Move | path | readied actor sheet and remaining movement; path price is unknown until execution | echoed ID + path |
+| EndTurn | none | clock-derived selector only | echoed ID |
 
-## Verb surface
+The first production wave has no magic and no speculative generic action
+executor. Dodge, Dash, Disengage, features, items, reactions, spells, spell
+slots, concentration, and magical target kinds do not become clickable offers
+through this contract.
 
-| Verb | Purpose |
-|---|---|
-| `StartSession` | Begin a session in a copy of an authored world |
-| `Join` / `Exit` | Enter and leave |
-| `Move` | Walk a path, cell by cell |
-| `Traverse` | Cross a connection |
-| `End` | Close through a declared external ending |
-| `Answer` | Resolve an open window and resume what was waiting on it |
-| `Atlas` / `Status` / `View` / `Story` / `Pending` | Reads |
+A compiled Attack definition includes a defensive clone of the **actual**
+`SpendProfile` before selector generation. The matching resolution cost holds a
+second clone. Changing the price therefore changes the selector, and execution
+cannot select one costless weapon definition and independently compile another
+priced definition.
 
-Every verb is **load → act → save → return**. Nothing is cached between calls,
-which is what lets several servers serve one session with no coordination —
-pinned by two managers interleaving writes over shared stores.
+Attack candidates are every current live sight holding (`CurrentVia` non-empty)
+except the actor, sorted by member ID. Stale memories and undisclosed members
+are absent. Out-of-reach candidates remain present with their target-specific
+shortfall. Missing position for a live candidate fails closed. Projection
+copies each candidate `Why`, so caller mutation cannot alter internal preflight
+state. The same private target-preflight function is used by Afford and
+regenerated Attack execution; an injected-refusal regression proves they move
+together.
 
-## Design decisions worth knowing
+`AttackRef.Ref` is the complete catalog identity (`dnd5e:weapons:longsword`),
+not a bare ID. The same helper projects Declaration, AttackOutput, and the
+Struck/Missed beat.
 
-**Move takes a path, not a destination.** The composition's own `Move` is a
-single hop; walking is what makes the cells in between real, which anything
-triggered by *entering a cell* depends on. `len(Steps) < len(Path)` is the
-honest signal that something stopped the walk — not an error, because the
-movement that happened is what was asked for up to the point the world changed.
+## Blocker matrix
 
-**Adjacency is delegated to spatial's grid**, never hand-rolled: axial (1,1) is
-cube distance 2 but Chebyshev distance 1, and that substitution has shipped as
-a real defect here before.
+Blockers are per verb rather than an incomplete declaration list:
 
-**Write order is chosen for its failure mode.** The encounter is written first
-and the session second, because the two half-failures are not symmetric.
-World-without-window is a stoppage in which every persisted fact is true;
-window-without-world would resume past cells nobody walked — corruption that
-looks like progress. `SaveReport` names both halves, and resume re-validates
-against the world it actually loads, so even the survivable failure becomes a
-clean rejection rather than a wrong walk.
+| Refusal | Attack | Move | EndTurn |
+|---|---|---|---|
+| not active | blocked before sheet load | blocked before sheet load | blocked |
+| downed | blocked | blocked | clock-valid EndTurn remains compiled |
+| unreadable character | `UNREADABLE`, empty ID | `UNREADABLE`, empty ID | unaffected |
+| unreadable Attack | `UNREADABLE`, empty ID | independently compiled | unaffected |
+| no budget / no available target | compiled but unavailable, non-empty ID | independently compiled | unaffected |
 
-**The converter layer is isolated in `convert.go`** and guarded structurally:
-every exported field on an inner type must be carried across or listed with a
-reason. A hand-written converter's real failure is silently dropping a field
-when an inner type grows one.
+Every blocker keeps its fixed target kind and has empty ID, absent AttackRef,
+and empty candidates. EndTurn has no character-sheet, standing, or economy
+gate.
 
-## The interrupt spine
+## Selector trust boundary
 
-A resolution can stop, persist, and resume — a walk today, anything later.
+Declaration IDs are deterministic opaque selectors, not authorization tokens
+or idempotency keys. They hash the RFC 8785 canonical selector document with
+full SHA-256/base64url under the `v1.` prefix. Attack's variant is its validated,
+priced complete definition; Move and EndTurn use sealed variant strings.
+Collision detection fails closed.
 
-**The walk is a re-enterable phase machine.** It holds nothing across a
-suspension: an explicit phase index and the path live in a value that is written
-to storage and read back, so a window outlives the process that opened it. A
-straight-line loop could only have suspended by parking a goroutine, and a
-parked goroutine is a resolution that dies with the process.
+The mutating verb reloads current state and regenerates the relevant compiled
+offer before mutation:
 
-**Custody is `play/interrupt`'s**, not this module's. It poses windows,
-validates answers, and persists a ledger. This module supplies the phase
-discipline and the projection; `interrupt.LedgerData` crosses the boundary as a
-stored shape, never `interrupt.Window` or `interrupt.Option` in a signature.
+- Attack and EndTurn require a non-empty ID.
+- Turn-clock Move requires its current Move ID.
+- World-clock Move requires an empty ID because world Afford is an empty list.
+- A non-empty turn Move ID that arrives after transition to world is stale and
+  cannot become a free move.
+- Unknown, mismatched, now-unavailable, or target-invalid selection returns
+  `ErrStaleDeclaration` before dice, movement, writes, or story.
+- Omission returns `ErrNoDeclarationID`.
 
-**The freeze is structural.** World-changing verbs open through
-`openForChange`, which refuses while a window is open; `Answer` opens through
-`openForWrite`, because a frozen session is what it exists to operate on.
-Forgetting the freeze requires actively choosing the other opener. Read verbs
-stay available — what is frozen is change, not observation — and the rejection
-is a typed `*FrozenError` naming the window and its audience, so a blocked
-caller is not sent hunting for what the error already knew.
+The intentional pre-selection precedence is explicit: basic identity/path
+validation, `NotYourTurn`, and `Downed` remain the real earlier verb refusals.
+EndTurn also preserves `NotInFight`/`NotYourTurn` before selector matching.
+Resolution retains final defensive validation after selection.
 
-**`Prompt` carries the moment, never the mechanism.** No field names which
-checkpoint fired. Clients render what the player sees and branch on
-`OptionKind`, so new checkpoint kinds arrive without any client learning a new
-reason code — which is the whole reason S5 insists on one suspension shape.
+## Persistence and failure ordering
 
-**Enumeration is sorted, not iteration-ordered** (C8): what a checkpoint
-enumerates is a function of persisted data, so a reloaded resolution poses its
-windows identically.
+Attack passes the selected readied payer and priced definition into resolution.
+Payment can dirty the attacker even on a miss; damage can dirty the target.
+Dirty sheets are saved before the resulting beat is recorded because standing
+consults those stores. `SaveError` names every durable aggregate when a later
+world save fails, preventing unsafe retries.
 
-## Known gaps
+Move pays the complete selected path before entering its first cell and saves
+the readied walker only after the walk succeeds. A path-level overrun remains
+`ErrCannotAfford`; an unavailable Move declaration is stale earlier. World Move
+never loads or mutates the economy.
 
-Three are the composition's, filed rather than worked around, because
-re-deriving any of them here would put a second implementation of a rule
-outside the module that owns it:
+## Known/deferred minors
 
-- **#940** — every beat is addressed to every member, so the fan-out is correct
-  to contract and over-broad in game terms.
-- **#941** — story tags are coarser than beats, so event kind is currently read
-  from the payload: the one place this module interprets a body it does not own,
-  and it fails *silently* if that shape changes.
-- **#933** — `Members()` reports a member's room but not their cell, forcing a
-  full snapshot per walk.
+- Turn speed is seeded from base sheet speed; condition-adjusted haste/slow
+  belongs at a rule-capable speed projection.
+- `ErrBadCost` is a defensive programmer-facing resolution translation while
+  some offer-build consistency failures (for example a live candidate missing
+  position) remain wrapped internal errors. Aligning those sentinel shapes is
+  deferred; selector execution does not require a new public distinction.
 
-In each case, fixing it where the rule lives fixes this module for free.
+## Verification
 
-## Deferred by design
+```sh
+cd rulebooks/dnd5e/session
+go test ./... -count=1
+golangci-lint run ./...
+../../../scripts/verify.sh rulebooks/dnd5e/session
+```
 
-`CharacterRepository` arrives with entities, not now: `character` lives inside
-the large `rulebooks/dnd5e` module, and declaring it early would take a
-permanent dependency on combat, conditions, and spells for a repository nothing
-calls. Adding a `Config` field later is compatible; removing one a host has
-implemented is not.
-
-A session-level `Frozen` blob is deferred for the same reason, and the design
-expected one. The frozen resolution rides in the window that suspended it,
-because today one checkpoint opens one window and the state belongs to that
-window. Shared state across several windows of one resolution — plausible when
-reactions land — is an additive field at that point, and inventing it now would
-commit a persisted shape before anything could tell us whether it is right.
+Key regressions cover priced selector identity, selector recurrence/collision,
+fixed input shapes, stale no-mutation behavior, shared target preflight,
+per-verb blockers, world/turn Move transition, sheet-free EndTurn, full-ref
+Attack identity, S2 signatures, and inner-sentinel non-leakage.

--- a/docs/architecture/components/rulebook-dnd5e-session.md
+++ b/docs/architecture/components/rulebook-dnd5e-session.md
@@ -117,8 +117,11 @@ full SHA-256/base64url under the `v1.` prefix. Attack's variant is its validated
 priced complete definition; Move and EndTurn use sealed variant strings.
 Collision detection fails closed.
 
-The mutating verb reloads current state and regenerates the relevant compiled
-offer before mutation:
+The mutating verb reloads current state and regenerates only its relevant
+compiled offer before mutation. Attack rebuilds its priced definition, targets,
+and cast; turn-clock Move rebuilds only Move from the shared actor
+blocker/readying path and does not read Attack price, target view, or resolution
+participants; EndTurn remains its direct clock-only offer.
 
 - Attack and EndTurn require a non-empty ID.
 - Turn-clock Move requires its current Move ID.

--- a/docs/architecture/components/rulebook-dnd5e-session.md
+++ b/docs/architecture/components/rulebook-dnd5e-session.md
@@ -53,7 +53,7 @@ turn it returns exactly one current compiled variant for each supported verb:
 
 | Verb | Selector target | Compiled data | Final execution input |
 |---|---|---|---|
-| Attack | member | complete priced `actions.Definition`, matching resolution cost/readied payer, full-ref `AttackRef`, and one preflight row per live candidate | echoed ID + selected member |
+| Attack | member | complete priced `actions.Definition`, matching resolution cost/readied payer, full-ref `AttackRef`, one preflight row per live candidate, and one strictly preflighted raw resolution cast | echoed ID + selected member |
 | Move | path | readied actor sheet and remaining movement; path price is unknown until execution | echoed ID + path |
 | EndTurn | none | clock-derived selector only | echoed ID |
 
@@ -66,7 +66,9 @@ A compiled Attack definition includes a defensive clone of the **actual**
 `SpendProfile` before selector generation. The matching resolution cost holds a
 second clone. Changing the price therefore changes the selector, and execution
 cannot select one costless weapon definition and independently compile another
-priced definition.
+priced definition. The collision guard compares RFC 8785-canonical variant
+bytes, so equivalent embedded JSON object order is recurrence rather than a
+false collision.
 
 Attack candidates are every current live sight holding (`CurrentVia` non-empty)
 except the actor, sorted by member ID. Stale memories and undisclosed members
@@ -75,8 +77,14 @@ shortfall. Missing position for a live candidate fails closed. Projection
 copies each candidate `Why`, so caller mutation cannot alter internal preflight
 state. The same private target-preflight function is used by Afford and
 regenerated Attack execution; an injected-refusal regression proves they move
-together. Normal target/reach changes therefore refuse as `ErrStaleDeclaration`;
-`ErrOutOfReach` remains final defensive resolution validation.
+together. Offer compilation also gathers every roster member's raw sheet once
+and validates the cast through the same public strict loaders/attach APIs
+resolution uses. A missing/unreadable candidate keeps its row with `UNREADABLE`;
+an unreadable non-target dependency disables Attack globally while preserving
+other candidate reach facts. Selected execution reuses that exact raw cast and
+never refetches participant data. Normal target/reach changes therefore refuse
+as `ErrStaleDeclaration`; `ErrOutOfReach` remains final defensive resolution
+validation.
 
 `AttackRef.Ref` is the complete catalog identity (`dnd5e:weapons:longsword`),
 not a bare ID. The same helper projects Declaration, AttackOutput, and the
@@ -92,6 +100,7 @@ Blockers are per verb rather than an incomplete declaration list:
 | downed | blocked | blocked | clock-valid EndTurn remains compiled |
 | unreadable character | `UNREADABLE`, empty ID | `UNREADABLE`, empty ID | unaffected |
 | unreadable Attack | `UNREADABLE`, empty ID | independently compiled | unaffected |
+| unreadable target/cast participant | compiled but unavailable; candidate/global `UNREADABLE`, rows retained | independently compiled | unaffected |
 | no budget / no available target | compiled but unavailable, non-empty ID | independently compiled | unaffected |
 
 Every blocker keeps its fixed target kind and has empty ID, absent AttackRef,
@@ -118,6 +127,8 @@ offer before mutation:
   cannot become a free move.
 - Unknown, mismatched, now-unavailable, or target-invalid selection returns
   `ErrStaleDeclaration` before dice, movement, writes, or story.
+- A repository returning a `SessionData.ID` different from the requested key is
+  `ErrBadRepository`; selector scope always uses the requested canonical key.
 - Omission returns `ErrNoDeclarationID`.
 
 The intentional pre-selection precedence is explicit: basic identity/path

--- a/docs/architecture/components/rulebook-dnd5e.md
+++ b/docs/architecture/components/rulebook-dnd5e.md
@@ -1,7 +1,7 @@
 ---
 name: rulebooks/dnd5e module
 description: D&D 5e rules implementation — the consumer-facing surface rpg-api imports across 31 sub-packages (character/ alone in 24 files)
-updated: 2026-08-23
+updated: 2026-08-25
 confidence: high — verified by directory listing, grep over public symbols, rpg-api import-graph audit 049, and Wave 2.11d shipped-code verification
 ---
 
@@ -84,6 +84,29 @@ The toolkit owns the rules; rpg-api orchestrates load → call → save.
 | `shared/` | Shared type aliases (EquipmentID, etc.) | — |
 | `events/` | D&D event payloads, topics, and `ConditionBehavior` | High |
 | `integration/` | Full encounter integration tests (Barbarian/Fighter/Monk/Rogue) | High |
+
+## Owner-private character status projection (#1246)
+
+`character.StatusView` is the immutable, display-ready owner projection beside
+`EquipmentView`. It reports level, current/maximum HP, base speed, sorted owned
+features, active conditions, and non-magical resource counts for the current
+Barbarian/Fighter/Monk/Rogue builds. Values are detached; callers never receive
+a live feature, condition, or resource object.
+
+The identity chain is explicit rather than persistence-driven:
+
+- every `events.ConditionBehavior` implements `Ref() *core.Ref`;
+- rulebook condition descriptors map canonical refs to names/details;
+- feature status providers report their own ref/name/detail and optional
+  resource relationship without serializing feature JSON;
+- private Second Wind and Action Surge resources use stable keys, while Ki
+  consumers report the shared Ki key through the owner reader;
+- matching resource rows deduplicate by key and conflicting facts fail the
+  whole projection.
+
+Unknown/unrenderable loaded effects fail loudly instead of disappearing.
+`SpellSlots` and legacy `ClassResources` are excluded: this wave is explicitly
+non-magical and does not reserve a magic status or action shelf.
 
 ## go.mod status
 
@@ -483,7 +506,7 @@ silently never spent.
 Per audit Section 3 Claim 1, the activation surface has **two halves**:
 
 - **Features** implement `core.Action[T]` (Activate / CanActivate). When a player triggers Rage, rpg-api calls into the feature's Activate flow.
-- **Conditions** implement `dnd5eEvents.ConditionBehavior` (Apply / Remove / IsApplied / ToJSON). They subscribe to the bus when applied and modify chains as events flow through.
+- **Conditions** implement `dnd5eEvents.ConditionBehavior` (`Ref` / Apply / Remove / IsApplied / ToJSON). `Ref` gives live effects canonical identity for status projection; Apply/Remove manage their bus subscriptions and ToJSON remains persistence only.
 
 A feature can both implement Action **and** apply a Condition as part of its
 Activate flow. Rage is the canonical case: `Rage.Activate` (an Action)

--- a/docs/architecture/components/rulebook-dnd5e.md
+++ b/docs/architecture/components/rulebook-dnd5e.md
@@ -101,12 +101,20 @@ The identity chain is explicit rather than persistence-driven:
   resource relationship without serializing feature JSON;
 - private Second Wind and Action Surge resources use stable keys, while Ki
   consumers report the shared Ki key through the owner reader;
-- matching resource rows deduplicate by key and conflicting facts fail the
-  whole projection.
+- the resource catalog is closed by class: Barbarian owns RageCharges+HitDice,
+  Fighter HitDice, Monk Ki+HitDice, and Rogue HitDice; private Second Wind and
+  Action Surge belong only to Fighter, while Rage/Ki feature reports must match
+  their class-owned pools;
+- provider key and name are validated before matching resource rows deduplicate;
+  unknown/spell-like keys, cross-class keys, and any name/count conflict fail
+  the whole projection.
 
 Unknown/unrenderable loaded effects fail loudly instead of disappearing.
 `SpellSlots` and legacy `ClassResources` are excluded: this wave is explicitly
-non-magical and does not reserve a magic status or action shelf.
+non-magical and does not reserve a magic status or action shelf. Strict
+`character.Load` also rejects negative/over-maximum owner and feature-private
+resource persistence before construction; the legacy lenient loader drops a
+malformed resource/feature rather than normalizing it into plausible counts.
 
 ## go.mod status
 

--- a/docs/status.md
+++ b/docs/status.md
@@ -25,14 +25,19 @@ history and must not be read as current support.
 The D&D 5e module now gives every live condition a canonical `Ref`, projects
 immutable feature/condition/non-magical-resource `character.StatusView` data,
 and fails on unknown or conflicting display facts rather than inspecting or
-dropping persistence JSON. Spell slots and legacy class resources are excluded;
-this wave adds no magic system.
+dropping persistence JSON. Its four-build resource catalog is closed by class,
+feature key, and canonical name; strict loads reject malformed owner/private
+bounds while the legacy lenient loader drops them without normalization. Spell
+slots and legacy class resources are excluded; this wave adds no magic system.
 
 The independently versioned session module projects one compiled Attack, Move,
 and EndTurn offer per current turn. Attack selectors hash the complete validated
-definition **with its actual cloned SpendProfile**; execution regenerates and
-reuses that selected definition, matching cost/readied sheet, and shared target
-preflight. Attack/EndTurn require echoed IDs, turn Move requires one, and world
+definition **with its actual cloned SpendProfile**; collision equality uses
+RFC 8785-canonical variant bytes. Compilation gathers and strictly preflights one
+raw resolution cast, projecting unreadable candidates/dependencies before a
+client can select the offer; execution reuses that exact cast without refetching
+participants. It also reuses the selected definition, matching cost/readied
+sheet, and shared target preflight. Attack/EndTurn require echoed IDs, turn Move requires one, and world
 Move requires empty. Unknown, mismatched, unavailable, or target-invalid
 selection is `ErrStaleDeclaration` before dice/movement/write/story; omission is
 `ErrNoDeclarationID`. EndTurn remains clock-only under the per-verb blocker

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,8 +1,8 @@
 ---
 name: rpg-toolkit status
 description: Where we are with rpg-toolkit — active work, paused, known rough edges, per-subsystem confidence
-updated: 2026-08-23
-confidence: high — retirement state verified on 2026-08-23; older delivery entries are retained as dated history and are not current-state claims
+updated: 2026-08-25
+confidence: high — active #1246 boundaries and gates are verified in their owning modules; older delivery entries are retained as dated history and are not current-state claims
 ---
 
 # rpg-toolkit: Where We Are
@@ -20,6 +20,25 @@ characters assemble them, and resolution dispatches by typed profile arm.
 Executable character/monster action packages and producer-specific resolution
 compilers are retired. Older sections below retain the legacy module's delivery
 history and must not be read as current support.
+
+**#1246 — production session combat offers and owner-private status (active).**
+The D&D 5e module now gives every live condition a canonical `Ref`, projects
+immutable feature/condition/non-magical-resource `character.StatusView` data,
+and fails on unknown or conflicting display facts rather than inspecting or
+dropping persistence JSON. Spell slots and legacy class resources are excluded;
+this wave adds no magic system.
+
+The independently versioned session module projects one compiled Attack, Move,
+and EndTurn offer per current turn. Attack selectors hash the complete validated
+definition **with its actual cloned SpendProfile**; execution regenerates and
+reuses that selected definition, matching cost/readied sheet, and shared target
+preflight. Attack/EndTurn require echoed IDs, turn Move requires one, and world
+Move requires empty. Unknown, mismatched, unavailable, or target-invalid
+selection is `ErrStaleDeclaration` before dice/movement/write/story; omission is
+`ErrNoDeclarationID`. EndTurn remains clock-only under the per-verb blocker
+matrix, and AttackRef is full `core.Ref.String()` through declaration, response,
+and typed beat. No release version is predicted here; merge/tag publication
+remains the repository release process.
 
 ## Historical top-level encounter delivery record
 

--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -772,6 +772,22 @@ var emptyResource = combat.NewRecoverableResource(combat.RecoverableResourceConf
 	Maximum: 0,
 })
 
+// ResourceStatus implements features.ResourceReader by reading the character's
+// actual resources map with presence. It never falls back to GetResource's
+// absent-key zero value: a key the sheet does not carry reports ok=false so a
+// feature's Status (and the StatusView projection) can tell a missing pool
+// from an empty one and fail loudly rather than silently reporting zeros.
+func (c *Character) ResourceStatus(key coreResources.ResourceKey) (int, int, bool) {
+	if c.resources == nil {
+		return 0, 0, false
+	}
+	r, ok := c.resources[key]
+	if !ok {
+		return 0, 0, false
+	}
+	return r.Current(), r.Maximum(), true
+}
+
 // GetResource returns the resource for the given key.
 // If the resource doesn't exist, returns an empty resource (not nil).
 // Use IsEmpty() to check if the resource exists and has uses available.

--- a/rulebooks/dnd5e/character/data.go
+++ b/rulebooks/dnd5e/character/data.go
@@ -116,9 +116,10 @@ type RecoverableResourceData struct {
 // rpg-toolkit#965 and #966 retire the verb methods that need the character to
 // be holding a bus of its own.
 //
-// This path is forgiving where Load is strict: a condition, feature, or
-// inventory item it cannot make sense of is dropped and the load continues,
-// which is the behaviour every existing caller has. Read that as a warning
+// This path is forgiving where Load is strict: a condition, feature, inventory
+// item, or character-owned resource with malformed bounds is dropped and the
+// load continues, which is the behaviour every existing caller has. Malformed
+// resource counts are never clamped into a valid-looking entry. Read that as a warning
 // rather than a feature — it means a sheet can come back from a round trip
 // missing something nobody removed (rpg-toolkit#948). Load refuses instead,
 // and names the blob.

--- a/rulebooks/dnd5e/character/economy_dirty_test.go
+++ b/rulebooks/dnd5e/character/economy_dirty_test.go
@@ -402,6 +402,13 @@ func (f *stubFeature) Name() string             { return "Stub" }
 
 func (f *stubFeature) ActionType() coreCombat.ActionType { return f.actionType }
 
+// Status satisfies features.StatusProvider. The stub owns no resource and
+// reports a minimal, honest status surface so it can stand in for a real
+// feature wherever the character StatusView projection is exercised.
+func (f *stubFeature) Status(*features.StatusInput) (*features.StatusOutput, error) {
+	return &features.StatusOutput{Status: &features.Status{Ref: *stubFeatureRef, Name: "Stub"}}, nil
+}
+
 func (f *stubFeature) CanActivate(_ context.Context, _ core.Entity, _ features.FeatureInput) error {
 	return nil
 }

--- a/rulebooks/dnd5e/character/load.go
+++ b/rulebooks/dnd5e/character/load.go
@@ -59,7 +59,9 @@ type loadedEffect struct {
 //
 // Load is strict where [LoadFromData] is forgiving: a persisted blob it cannot
 // make sense of — a condition, a feature, an inventory item — fails the load,
-// and the error names the blob. LoadFromData drops that blob and carries on,
+// and the error names the blob. Invalid character-owned resource bounds
+// (negative current/maximum or current above maximum) fail before a resource is
+// constructed. LoadFromData drops that blob or malformed resource and carries on,
 // which is the behaviour its callers have today and keep. The divergence is
 // deliberate. A loader that continues past what it cannot read hands back a
 // sheet that is quietly missing something, and the next save persists the
@@ -291,7 +293,11 @@ func loadSheet(d *Data, policy effectPolicy) (*Character, error) {
 		char.conditions = append(char.conditions, effect.behavior)
 	}
 
-	char.resources = loadResources(d.Resources, char.id)
+	loadedResources, err := loadResources(d.Resources, char.id, policy)
+	if err != nil {
+		return nil, err
+	}
+	char.resources = loadedResources
 
 	// Re-register standard combat abilities (not persisted, always available)
 	initStandardCombatAbilities(char)
@@ -408,14 +414,28 @@ func loadEffects(raw []json.RawMessage, policy effectPolicy) ([]loadedEffect, er
 }
 
 // loadResources rebuilds the character's recoverable resources at their
-// persisted values. They are inert until a [SheetKeeper] puts them on a bus,
-// which is what makes them recover on a rest.
+// persisted values. Strict loads reject malformed bounds before construction;
+// lenient loads drop those entries rather than allowing a constructor or failed
+// Use call to normalize them into valid-looking counts. Valid resources are
+// inert until a [SheetKeeper] puts them on a bus, which makes them recover on a rest.
 func loadResources(
-	persisted map[coreResources.ResourceKey]RecoverableResourceData, characterID string,
-) map[coreResources.ResourceKey]*combat.RecoverableResource {
+	persisted map[coreResources.ResourceKey]RecoverableResourceData,
+	characterID string,
+	policy effectPolicy,
+) (map[coreResources.ResourceKey]*combat.RecoverableResource, error) {
 	loaded := make(map[coreResources.ResourceKey]*combat.RecoverableResource, len(persisted))
 
 	for key, resData := range persisted {
+		if err := validatePersistedResource(key, resData); err != nil {
+			if policy == strictEffects {
+				return nil, err
+			}
+			// The lenient loader keeps its forgiving policy by dropping the
+			// malformed entry. It must not feed bad bounds to constructors whose
+			// clamping/failed Use path would turn them into valid-looking counts.
+			continue
+		}
+
 		resource := combat.NewRecoverableResource(combat.RecoverableResourceConfig{
 			ID:          string(key),
 			Maximum:     resData.Maximum,
@@ -423,16 +443,35 @@ func loadResources(
 			ResetType:   resData.ResetType,
 		})
 
-		// Set current value if different from maximum
 		if resData.Current != resData.Maximum {
 			deficit := resData.Maximum - resData.Current
-			_ = resource.Use(deficit) // Ignore error - we know the value is valid
+			if err := resource.Use(deficit); err != nil {
+				// Bounds were validated above, so reaching this is an internal
+				// disagreement between validation and the resource primitive.
+				return nil, rpgerr.Wrapf(err, "failed to restore resource %s", key)
+			}
 		}
 
 		loaded[key] = resource
 	}
 
-	return loaded
+	return loaded, nil
+}
+
+func validatePersistedResource(
+	key coreResources.ResourceKey, data RecoverableResourceData,
+) error {
+	if data.Current < 0 || data.Maximum < 0 {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"resource %s has negative persisted bounds: current=%d maximum=%d",
+			key, data.Current, data.Maximum)
+	}
+	if data.Current > data.Maximum {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"resource %s persisted current %d exceeds maximum %d",
+			key, data.Current, data.Maximum)
+	}
+	return nil
 }
 
 // peekEffectRef reads the ref a persisted effect routes on, which is the same

--- a/rulebooks/dnd5e/character/load_test.go
+++ b/rulebooks/dnd5e/character/load_test.go
@@ -274,6 +274,111 @@ func (s *PureLoadTestSuite) TestLoadRejectsNilData() {
 	s.Require().Error(err)
 }
 
+func (s *PureLoadTestSuite) TestStrictLoadRejectsPersistedOwnerResourceBoundsBeforeStatusView() {
+	tests := []struct {
+		name string
+		data RecoverableResourceData
+	}{
+		{name: "negative current", data: RecoverableResourceData{Current: -1, Maximum: 3}},
+		{name: "negative maximum", data: RecoverableResourceData{Current: 0, Maximum: -1}},
+		{name: "current above maximum", data: RecoverableResourceData{Current: 4, Maximum: 3}},
+	}
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			data := &Data{
+				ID: "fighter-bounds", ClassID: classes.Fighter,
+				Resources: map[coreResources.ResourceKey]RecoverableResourceData{resources.HitDice: tc.data},
+			}
+			loaded, err := Load(s.ctx, data)
+			s.Require().Error(err)
+			s.Nil(loaded, "strict load must reject before a StatusView can expose normalized counts")
+			s.Contains(err.Error(), string(resources.HitDice))
+		})
+	}
+}
+
+func (s *PureLoadTestSuite) TestLenientLoadDropsMalformedOwnerResourcesWithoutNormalizingThem() {
+	tests := []RecoverableResourceData{
+		{Current: -1, Maximum: 3},
+		{Current: 0, Maximum: -1},
+		{Current: 4, Maximum: 3},
+	}
+	for _, malformed := range tests {
+		data := &Data{
+			ID: "fighter-lenient-bounds", ClassID: classes.Fighter,
+			Resources: map[coreResources.ResourceKey]RecoverableResourceData{
+				resources.HitDice: malformed,
+			},
+		}
+		loaded, err := LoadFromData(s.ctx, data, events.NewEventBus())
+		s.Require().NoError(err)
+
+		out, err := loaded.StatusView(&StatusViewInput{})
+		s.Require().NoError(err)
+		s.Require().NotNil(out)
+		s.Empty(out.View.Resources,
+			"malformed persisted counts are dropped, never clamped into a valid-looking row")
+		s.Empty(loaded.ToData().Resources)
+	}
+}
+
+func (s *PureLoadTestSuite) TestStrictLoadRejectsFeaturePrivateResourceBoundsBeforeStatusView() {
+	tests := []struct {
+		name string
+		blob func() json.RawMessage
+	}{
+		{
+			name: "second wind negative uses",
+			blob: func() json.RawMessage {
+				raw, err := json.Marshal(features.SecondWindData{
+					Ref: refs.Features.SecondWind(), ID: "second_wind", Name: "Second Wind",
+					CharacterID: "fighter-private", Uses: -1, MaxUses: 1,
+				})
+				s.Require().NoError(err)
+				return raw
+			},
+		},
+		{
+			name: "action surge uses above maximum",
+			blob: func() json.RawMessage {
+				raw, err := json.Marshal(features.ActionSurgeData{
+					Ref: refs.Features.ActionSurge(), ID: "action_surge", Name: "Action Surge",
+					CharacterID: "fighter-private", Uses: 2, MaxUses: 1,
+				})
+				s.Require().NoError(err)
+				return raw
+			},
+		},
+	}
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			data := &Data{ID: "fighter-private", ClassID: classes.Fighter, Features: []json.RawMessage{tc.blob()}}
+			loaded, err := Load(s.ctx, data)
+			s.Require().Error(err)
+			s.Nil(loaded, "strict load must reject before malformed private uses reach StatusView")
+		})
+	}
+}
+
+func (s *PureLoadTestSuite) TestLenientLoadDropsMalformedFeaturePrivateResource() {
+	raw, err := json.Marshal(features.SecondWindData{
+		Ref: refs.Features.SecondWind(), ID: "second_wind", Name: "Second Wind",
+		CharacterID: "fighter-private-lenient", Uses: 2, MaxUses: 1,
+	})
+	s.Require().NoError(err)
+	loaded, err := LoadFromData(s.ctx, &Data{
+		ID: "fighter-private-lenient", ClassID: classes.Fighter, Features: []json.RawMessage{raw},
+	}, events.NewEventBus())
+	s.Require().NoError(err)
+
+	out, err := loaded.StatusView(&StatusViewInput{})
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+	s.Empty(out.View.Features)
+	s.Empty(out.View.Resources)
+	s.Empty(loaded.ToData().Features, "existing lenient policy drops the malformed feature blob")
+}
+
 // Two fields of Data survive no loader, because the sheet has nowhere to put
 // them and ToData does not write them. Pinned so the round-trip guarantee above
 // is read with its actual scope, and so closing the gap (a change to ToData,

--- a/rulebooks/dnd5e/character/sheet_keeper_test.go
+++ b/rulebooks/dnd5e/character/sheet_keeper_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
@@ -26,6 +27,8 @@ import (
 type keptCondition struct {
 	applied bool
 }
+
+func (c *keptCondition) Ref() *core.Ref { return refs.Conditions.Dodging() }
 
 func (c *keptCondition) IsApplied() bool { return c.applied }
 

--- a/rulebooks/dnd5e/character/status_view.go
+++ b/rulebooks/dnd5e/character/status_view.go
@@ -9,9 +9,11 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/features"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
 )
 
@@ -86,7 +88,9 @@ type ResourceView struct {
 // level, hit points, base speed, features, conditions, and resources. It is
 // built from the live sheet and feature Status reports — never from
 // persistence JSON — and excludes spell slots and legacy class resources by
-// construction.
+// construction. Its resource catalog is closed to the current four builds:
+// Barbarian (RageCharges/HitDice), Fighter (HitDice plus private Second Wind
+// and Action Surge), Monk (Ki/HitDice), and Rogue (HitDice).
 type StatusView struct {
 	// Level is the character's level.
 	Level int
@@ -126,8 +130,9 @@ type StatusViewOutput struct {
 // points, base speed, features, conditions, and resources. It reads the live
 // sheet and each feature's non-mutating Status surface — never persistence
 // JSON — and never publishes. Every validation failure (unknown condition ref,
-// malformed feature status, conflicting duplicate resource key, negative or
-// over-maximum resource) returns an error with no partial output.
+// malformed feature status, unknown/cross-class resource key, provider name
+// mismatch, conflicting duplicate resource, negative or over-maximum count)
+// returns an error with no partial output.
 func (c *Character) StatusView(_ *StatusViewInput) (*StatusViewOutput, error) {
 	featureViews, featureReports, err := c.projectFeatures()
 	if err != nil {
@@ -139,7 +144,10 @@ func (c *Character) StatusView(_ *StatusViewInput) (*StatusViewOutput, error) {
 		return nil, err
 	}
 
-	ownerRows := c.ownerResourceReports()
+	ownerRows, err := c.ownerResourceReports()
+	if err != nil {
+		return nil, err
+	}
 	resourceViews, err := mergeResources(ownerRows, featureReports)
 	if err != nil {
 		return nil, err
@@ -183,23 +191,26 @@ func (c *Character) projectFeatures() ([]FeatureView, []resourceReport, error) {
 				"feature %s reported an empty name", featureID(f))
 		}
 
+		if err := validateFeatureResource(c.classID, st.Ref, st.Resource); err != nil {
+			return nil, nil, err
+		}
+
 		var key *coreResources.ResourceKey
 		if st.Resource != nil {
 			k := st.Resource.Key
 			key = &k
-			// Validate the feature's own counts before merging so a private
-			// resource (Second Wind, Action Surge) is rejected here rather than
-			// silently merged with bad values.
-			if err := validateReport(resourceReport{
-				Key: st.Resource.Key, Current: st.Resource.Current, Maximum: st.Resource.Maximum,
-			}); err != nil {
-				return nil, nil, err
-			}
-			reports = append(reports, resourceReport{
+			report := resourceReport{
 				Key:     st.Resource.Key,
+				Name:    st.Resource.Name,
 				Current: st.Resource.Current,
 				Maximum: st.Resource.Maximum,
-			})
+			}
+			// Validate the provider's key, name, and counts before merging so
+			// deduplication can never hide malformed or conflicting facts.
+			if err := validateReport(report); err != nil {
+				return nil, nil, err
+			}
+			reports = append(reports, report)
 		}
 		views = append(views, FeatureView{
 			Ref:         st.Ref,
@@ -248,27 +259,38 @@ func (c *Character) projectConditions() ([]ConditionView, error) {
 // (every entry in c.resources, including standalone Hit Dice) as reports ready
 // for merging. Spell slots and legacy class resources are never read here, so
 // they are excluded by construction.
-func (c *Character) ownerResourceReports() []resourceReport {
+func (c *Character) ownerResourceReports() ([]resourceReport, error) {
 	if c.resources == nil {
-		return nil
+		return nil, nil
 	}
 	rows := make([]resourceReport, 0, len(c.resources))
 	for key, r := range c.resources {
+		if !ownerResourceAllowed(c.classID, key) {
+			return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"resource %s is not in the %s status-view owner catalog", key, c.classID)
+		}
+		name, ok := resources.DisplayName(key)
+		if !ok {
+			return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"resource %s has no status-view display catalog entry", key)
+		}
 		rows = append(rows, resourceReport{
 			Key:     key,
+			Name:    name,
 			Current: r.Current(),
 			Maximum: r.Maximum(),
 		})
 	}
-	return rows
+	return rows, nil
 }
 
-// resourceReport is the internal, name-less projection of one resource the
-// projection is considering: its key and current/maximum counts. The display
-// name is always derived from the key via resources.DisplayName, so a report
-// never carries a feature-authored name.
+// resourceReport is the internal projection of one resource the projection is
+// considering: its key, provider/catalog name, and current/maximum counts.
+// Keeping the reported name until after validation makes a same-key/count
+// conflicting name observable rather than silently replacing it during dedup.
 type resourceReport struct {
 	Key     coreResources.ResourceKey
+	Name    string
 	Current int
 	Maximum int
 }
@@ -276,7 +298,7 @@ type resourceReport struct {
 // mergeResources builds the sorted ResourceView slice from owner rows plus
 // feature-reported rows. Owner rows always appear. A feature report whose key
 // matches an owner row dedupes against it — keeping the owner row — but must
-// agree on current and maximum or the merge fails loudly. A feature report
+// agree on name, current, and maximum or the merge fails loudly. A feature report
 // whose key is not in the owner rows (Second Wind, Action Surge) is added.
 // Negative counts, current > maximum, and conflicts all error with no partial
 // output.
@@ -303,11 +325,12 @@ func mergeResources(ownerRows []resourceReport, reports []resourceReport) ([]Res
 		}
 		if owner, exists := byKey[rep.Key]; exists {
 			// Same key already present from the owner (or an earlier feature
-			// report). The counts must agree or the sheet is lying.
-			if owner.Current != rep.Current || owner.Maximum != rep.Maximum {
+			// report). Name and counts must all agree or the sheet is lying.
+			if owner.Name != rep.Name || owner.Current != rep.Current || owner.Maximum != rep.Maximum {
 				return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
-					"conflicting resource %s: owner reports %d/%d but feature reports %d/%d",
-					rep.Key, owner.Current, owner.Maximum, rep.Current, rep.Maximum)
+					"conflicting resource %s: existing reports %q %d/%d but feature reports %q %d/%d",
+					rep.Key, owner.Name, owner.Current, owner.Maximum,
+					rep.Name, rep.Current, rep.Maximum)
 			}
 			// Agreeing duplicate: keep the existing row, do not add a second.
 			continue
@@ -319,12 +342,7 @@ func mergeResources(ownerRows []resourceReport, reports []resourceReport) ([]Res
 	out := make([]ResourceView, 0, len(order))
 	for _, key := range order {
 		row := byKey[key]
-		out = append(out, ResourceView{
-			Key:     row.Key,
-			Name:    resources.DisplayName(row.Key),
-			Current: row.Current,
-			Maximum: row.Maximum,
-		})
+		out = append(out, ResourceView(row))
 	}
 
 	sort.Slice(out, func(i, j int) bool {
@@ -333,8 +351,18 @@ func mergeResources(ownerRows []resourceReport, reports []resourceReport) ([]Res
 	return out, nil
 }
 
-// validateReport rejects negative counts and current > maximum.
+// validateReport rejects keys and names outside the closed display catalog,
+// negative counts, and current > maximum.
 func validateReport(r resourceReport) error {
+	name, ok := resources.DisplayName(r.Key)
+	if !ok {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"resource %s has no status-view display catalog entry", r.Key)
+	}
+	if r.Name != name {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"resource %s reports name %q, catalog requires %q", r.Key, r.Name, name)
+	}
 	if r.Current < 0 || r.Maximum < 0 {
 		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
 			"resource %s has negative counts: current=%d maximum=%d", r.Key, r.Current, r.Maximum)
@@ -344,6 +372,68 @@ func validateReport(r resourceReport) error {
 			"resource %s current %d exceeds maximum %d", r.Key, r.Current, r.Maximum)
 	}
 	return nil
+}
+
+func ownerResourceAllowed(class classes.Class, key coreResources.ResourceKey) bool {
+	switch class {
+	case classes.Barbarian:
+		return key == resources.RageCharges || key == resources.HitDice
+	case classes.Fighter, classes.Rogue:
+		return key == resources.HitDice
+	case classes.Monk:
+		return key == resources.Ki || key == resources.HitDice
+	default:
+		return false
+	}
+}
+
+func validateFeatureResource(
+	class classes.Class, ref core.Ref, status *features.ResourceStatus,
+) error {
+	expectedClass, expectedKey, expectsResource := featureResourceCatalog(ref)
+	if status == nil {
+		if expectsResource {
+			return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"feature %s reported no required resource %s", ref.String(), expectedKey)
+		}
+		return nil
+	}
+	if !expectsResource {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"feature %s reports resource %s outside the status-view catalog", ref.String(), status.Key)
+	}
+	if class != expectedClass {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"feature %s resource %s belongs to %s, not %s", ref.String(), status.Key, expectedClass, class)
+	}
+	if status.Key != expectedKey {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"feature %s reports resource %s, catalog requires %s", ref.String(), status.Key, expectedKey)
+	}
+	name, ok := resources.DisplayName(status.Key)
+	if !ok || status.Name != name {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"feature %s resource %s reports name %q, catalog requires %q",
+			ref.String(), status.Key, status.Name, name)
+	}
+	return nil
+}
+
+func featureResourceCatalog(ref core.Ref) (classes.Class, coreResources.ResourceKey, bool) {
+	switch ref.String() {
+	case refs.Features.Rage().String():
+		return classes.Barbarian, resources.RageCharges, true
+	case refs.Features.SecondWind().String():
+		return classes.Fighter, resources.SecondWind, true
+	case refs.Features.ActionSurge().String():
+		return classes.Fighter, resources.ActionSurge, true
+	case refs.Features.FlurryOfBlows().String(),
+		refs.Features.PatientDefense().String(),
+		refs.Features.StepOfTheWind().String():
+		return classes.Monk, resources.Ki, true
+	default:
+		return "", "", false
+	}
 }
 
 // featureID returns a feature's ID for error attribution, falling back to its

--- a/rulebooks/dnd5e/character/status_view.go
+++ b/rulebooks/dnd5e/character/status_view.go
@@ -1,0 +1,371 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/features"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+)
+
+// HitPointView is the immutable projection of the character's hit points.
+type HitPointView struct {
+	// Current is the character's current hit points.
+	Current int
+
+	// Maximum is the character's maximum hit points.
+	Maximum int
+}
+
+// FeatureView is the immutable projection of one character feature: its
+// canonical ref, never-empty display name, optional server-authored detail,
+// and an optional owned resource key. It is a detached value — mutating the
+// sheet after a StatusView call does not change a previously returned view.
+type FeatureView struct {
+	// Ref is the feature's canonical ref.
+	Ref core.Ref
+
+	// Name is the feature's display name. Never empty.
+	Name string
+
+	// Detail is optional, server/toolkit-composed display text. May be empty.
+	Detail string
+
+	// ResourceKey is the stable key of the resource this feature owns or
+	// shares, or nil for a feature that owns no resource (Reckless Attack,
+	// Deflect Missiles). A pointer so nil is distinguishable from an empty
+	// key.
+	ResourceKey *coreResources.ResourceKey
+}
+
+// ConditionView is the immutable projection of one active condition: its
+// canonical ref, never-empty display name, optional detail, and an optional
+// source member. The source member is nil for self-owned class conditions
+// (fighting styles, Unarmored Defense, Martial Arts, Sneak Attack) and is
+// populated when a condition names an external party member as its source.
+type ConditionView struct {
+	// Ref is the condition's canonical ref.
+	Ref core.Ref
+
+	// Name is the condition's display name. Never empty.
+	Name string
+
+	// Detail is optional, server/toolkit-composed display text. May be empty.
+	Detail string
+
+	// SourceMember is the optional party-member ID a condition names as its
+	// source. Nil for self-owned class conditions.
+	SourceMember *string
+}
+
+// ResourceView is the immutable projection of one owned resource: its stable
+// key, rulebook-owned display name, and current/maximum counts.
+type ResourceView struct {
+	// Key is the stable, opaque core/resources.ResourceKey.
+	Key coreResources.ResourceKey
+
+	// Name is the rulebook-owned display name (resources.DisplayName). Never
+	// empty for a known key.
+	Name string
+
+	// Current is the currently available amount.
+	Current int
+
+	// Maximum is the resource's capacity.
+	Maximum int
+}
+
+// StatusView is the immutable, no-magic projection of a character's status:
+// level, hit points, base speed, features, conditions, and resources. It is
+// built from the live sheet and feature Status reports — never from
+// persistence JSON — and excludes spell slots and legacy class resources by
+// construction.
+type StatusView struct {
+	// Level is the character's level.
+	Level int
+
+	// HitPoints is the character's current/maximum hit points.
+	HitPoints HitPointView
+
+	// BaseSpeedFeet is the character's base walking speed in feet, before
+	// condition modifiers.
+	BaseSpeedFeet int
+
+	// Features is the character's features, sorted by Ref.String().
+	Features []FeatureView
+
+	// Conditions is the character's active conditions, sorted by Ref.String().
+	Conditions []ConditionView
+
+	// Resources is the character's owned resources (owner-owned plus
+	// feature-private), sorted by key.
+	Resources []ResourceView
+}
+
+// StatusViewInput is the input to (*Character).StatusView. Reserved for
+// future, server-authored detail; today it carries nothing the projection
+// cannot derive from the sheet itself.
+type StatusViewInput struct{}
+
+// StatusViewOutput wraps the projected StatusView. A pointer so a future
+// caller can tell "projection failed" (nil) from "projection succeeded with
+// an empty view" (non-nil).
+type StatusViewOutput struct {
+	// View is the projected status. Never nil when err is nil.
+	View *StatusView
+}
+
+// StatusView projects the character's immutable, no-magic status: level, hit
+// points, base speed, features, conditions, and resources. It reads the live
+// sheet and each feature's non-mutating Status surface — never persistence
+// JSON — and never publishes. Every validation failure (unknown condition ref,
+// malformed feature status, conflicting duplicate resource key, negative or
+// over-maximum resource) returns an error with no partial output.
+func (c *Character) StatusView(_ *StatusViewInput) (*StatusViewOutput, error) {
+	featureViews, featureReports, err := c.projectFeatures()
+	if err != nil {
+		return nil, err
+	}
+
+	conditionViews, err := c.projectConditions()
+	if err != nil {
+		return nil, err
+	}
+
+	ownerRows := c.ownerResourceReports()
+	resourceViews, err := mergeResources(ownerRows, featureReports)
+	if err != nil {
+		return nil, err
+	}
+
+	view := &StatusView{
+		Level:         c.level,
+		HitPoints:     HitPointView{Current: c.hitPoints, Maximum: c.maxHitPoints},
+		BaseSpeedFeet: c.GetSpeed(),
+		Features:      featureViews,
+		Conditions:    conditionViews,
+		Resources:     resourceViews,
+	}
+	return &StatusViewOutput{View: view}, nil
+}
+
+// projectFeatures builds the sorted FeatureView slice and the parallel
+// resource-report slice from a single Status call per feature. A feature
+// whose Status returns an error, or whose report has an empty ref or name,
+// fails the whole projection.
+func (c *Character) projectFeatures() ([]FeatureView, []resourceReport, error) {
+	views := make([]FeatureView, 0, len(c.features))
+	reports := make([]resourceReport, 0, len(c.features))
+
+	for _, f := range c.features {
+		out, err := f.Status(&features.StatusInput{Owner: c})
+		if err != nil {
+			return nil, nil, rpgerr.Wrapf(err, "feature %s reported malformed status", featureID(f))
+		}
+		if out == nil || out.Status == nil {
+			return nil, nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"feature %s reported no status", featureID(f))
+		}
+		st := out.Status
+		if st.Ref == (core.Ref{}) {
+			return nil, nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"feature %s reported an empty ref", featureID(f))
+		}
+		if st.Name == "" {
+			return nil, nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"feature %s reported an empty name", featureID(f))
+		}
+
+		var key *coreResources.ResourceKey
+		if st.Resource != nil {
+			k := st.Resource.Key
+			key = &k
+			// Validate the feature's own counts before merging so a private
+			// resource (Second Wind, Action Surge) is rejected here rather than
+			// silently merged with bad values.
+			if err := validateReport(resourceReport{
+				Key: st.Resource.Key, Current: st.Resource.Current, Maximum: st.Resource.Maximum,
+			}); err != nil {
+				return nil, nil, err
+			}
+			reports = append(reports, resourceReport{
+				Key:     st.Resource.Key,
+				Current: st.Resource.Current,
+				Maximum: st.Resource.Maximum,
+			})
+		}
+		views = append(views, FeatureView{
+			Ref:         st.Ref,
+			Name:        st.Name,
+			Detail:      st.Detail,
+			ResourceKey: key,
+		})
+	}
+
+	sort.Slice(views, func(i, j int) bool {
+		return views[i].Ref.String() < views[j].Ref.String()
+	})
+	return views, reports, nil
+}
+
+// projectConditions builds the sorted ConditionView slice from each active
+// condition's ref, looked up in the rulebook-owned display catalog. An unknown
+// ref fails the whole projection with no partial output.
+func (c *Character) projectConditions() ([]ConditionView, error) {
+	views := make([]ConditionView, 0, len(c.conditions))
+	for _, cond := range c.conditions {
+		ref := cond.Ref()
+		if ref == nil {
+			return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "condition reported a nil ref")
+		}
+		display, ok := conditions.DisplayFor(*ref)
+		if !ok {
+			return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+				"condition ref %s is not in the status-view display catalog", ref.String())
+		}
+		views = append(views, ConditionView{
+			Ref:          *ref,
+			Name:         display.Name,
+			Detail:       display.Detail,
+			SourceMember: conditionSourceMember(cond),
+		})
+	}
+
+	sort.Slice(views, func(i, j int) bool {
+		return views[i].Ref.String() < views[j].Ref.String()
+	})
+	return views, nil
+}
+
+// ownerResourceReports collects the character's owner-owned resource rows
+// (every entry in c.resources, including standalone Hit Dice) as reports ready
+// for merging. Spell slots and legacy class resources are never read here, so
+// they are excluded by construction.
+func (c *Character) ownerResourceReports() []resourceReport {
+	if c.resources == nil {
+		return nil
+	}
+	rows := make([]resourceReport, 0, len(c.resources))
+	for key, r := range c.resources {
+		rows = append(rows, resourceReport{
+			Key:     key,
+			Current: r.Current(),
+			Maximum: r.Maximum(),
+		})
+	}
+	return rows
+}
+
+// resourceReport is the internal, name-less projection of one resource the
+// projection is considering: its key and current/maximum counts. The display
+// name is always derived from the key via resources.DisplayName, so a report
+// never carries a feature-authored name.
+type resourceReport struct {
+	Key     coreResources.ResourceKey
+	Current int
+	Maximum int
+}
+
+// mergeResources builds the sorted ResourceView slice from owner rows plus
+// feature-reported rows. Owner rows always appear. A feature report whose key
+// matches an owner row dedupes against it — keeping the owner row — but must
+// agree on current and maximum or the merge fails loudly. A feature report
+// whose key is not in the owner rows (Second Wind, Action Surge) is added.
+// Negative counts, current > maximum, and conflicts all error with no partial
+// output.
+func mergeResources(ownerRows []resourceReport, reports []resourceReport) ([]ResourceView, error) {
+	byKey := make(map[coreResources.ResourceKey]resourceReport, len(ownerRows))
+	order := make([]coreResources.ResourceKey, 0, len(ownerRows)+len(reports))
+
+	// Owner rows first; they define the base set.
+	for _, row := range ownerRows {
+		if err := validateReport(row); err != nil {
+			return nil, err
+		}
+		if _, exists := byKey[row.Key]; !exists {
+			order = append(order, row.Key)
+		}
+		byKey[row.Key] = row
+	}
+
+	// Feature reports: dedupe against owner rows by key, fail on conflict,
+	// otherwise add.
+	for _, rep := range reports {
+		if err := validateReport(rep); err != nil {
+			return nil, err
+		}
+		if owner, exists := byKey[rep.Key]; exists {
+			// Same key already present from the owner (or an earlier feature
+			// report). The counts must agree or the sheet is lying.
+			if owner.Current != rep.Current || owner.Maximum != rep.Maximum {
+				return nil, rpgerr.Newf(rpgerr.CodeInvalidArgument,
+					"conflicting resource %s: owner reports %d/%d but feature reports %d/%d",
+					rep.Key, owner.Current, owner.Maximum, rep.Current, rep.Maximum)
+			}
+			// Agreeing duplicate: keep the existing row, do not add a second.
+			continue
+		}
+		byKey[rep.Key] = rep
+		order = append(order, rep.Key)
+	}
+
+	out := make([]ResourceView, 0, len(order))
+	for _, key := range order {
+		row := byKey[key]
+		out = append(out, ResourceView{
+			Key:     row.Key,
+			Name:    resources.DisplayName(row.Key),
+			Current: row.Current,
+			Maximum: row.Maximum,
+		})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].Key < out[j].Key
+	})
+	return out, nil
+}
+
+// validateReport rejects negative counts and current > maximum.
+func validateReport(r resourceReport) error {
+	if r.Current < 0 || r.Maximum < 0 {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"resource %s has negative counts: current=%d maximum=%d", r.Key, r.Current, r.Maximum)
+	}
+	if r.Current > r.Maximum {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"resource %s current %d exceeds maximum %d", r.Key, r.Current, r.Maximum)
+	}
+	return nil
+}
+
+// featureID returns a feature's ID for error attribution, falling back to its
+// ref string when GetID is empty.
+func featureID(f features.Feature) string {
+	if f == nil {
+		return "<nil>"
+	}
+	if id := f.GetID(); id != "" {
+		return id
+	}
+	if ref := f.Ref(); ref != nil {
+		return ref.String()
+	}
+	return "<unknown>"
+}
+
+// conditionSourceMember returns the optional party-member ID a condition names
+// as its source, or nil for self-owned class conditions. No current condition
+// in the four-build set names an external source, so this is nil today; the
+// seam exists so a future condition (e.g. Helped) can opt in without changing
+// the projection's shape.
+func conditionSourceMember(_ dnd5eEvents.ConditionBehavior) *string {
+	return nil
+}

--- a/rulebooks/dnd5e/character/status_view_test.go
+++ b/rulebooks/dnd5e/character/status_view_test.go
@@ -1,0 +1,668 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/backgrounds"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character/choices"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/features"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/fightingstyles"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/languages"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/proficiencies"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/skills"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+)
+
+// TestStatusViewProjectsFighterWithoutPersistenceJSON confirms the fighter
+// StatusView is built from the live sheet and feature Status reports — never
+// from persistence JSON. A level-3 fighter carries Second Wind (level 1) and
+// Action Surge (level 2), both feature-private resources, plus Hit Dice.
+func TestStatusViewProjectsFighterWithoutPersistenceJSON(t *testing.T) {
+	fighter := newLevel3Fighter(t)
+
+	out, err := fighter.StatusView(&StatusViewInput{})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.View)
+
+	view := out.View
+	require.Equal(t, fighter.GetLevel(), view.Level)
+	require.Equal(t, fighter.GetHitPoints(), view.HitPoints.Current)
+	require.Equal(t, fighter.GetMaxHitPoints(), view.HitPoints.Maximum)
+	require.Equal(t, fighter.GetSpeed(), view.BaseSpeedFeet)
+
+	keys := resourceKeys(view.Resources)
+	require.Contains(t, keys, resources.SecondWind, "Second Wind is feature-private and must appear")
+	require.Contains(t, keys, resources.ActionSurge, "Action Surge is feature-private and must appear")
+	require.Contains(t, keys, resources.HitDice, "Hit Dice is owner-owned and must appear")
+
+	// Exactly one row per key — no duplicates.
+	require.Equal(t, len(keys), len(uniqueKeys(keys)), "resources must not duplicate keys")
+
+	// The fighter's fighting style condition is projected as a condition view.
+	require.NotEmpty(t, view.Conditions)
+	require.Equal(t,
+		refs.Conditions.FightingStyleDefense().String(),
+		view.Conditions[0].Ref.String(),
+	)
+
+	// Features are sorted by ref string: action_surge before second_wind.
+	require.NotEmpty(t, view.Features)
+	require.Equal(t,
+		refs.Features.ActionSurge().String(),
+		view.Features[0].Ref.String(),
+	)
+}
+
+// TestStatusViewMonkReportsOneKiRowDespiteThreeConsumers confirms the level-3
+// monk projects exactly one resources.Ki row even though Flurry of Blows,
+// Patient Defense, and Step of the Wind all report the shared Ki pool.
+func TestStatusViewMonkReportsOneKiRowDespiteThreeConsumers(t *testing.T) {
+	monk := newLevel3Monk(t)
+
+	out, err := monk.StatusView(&StatusViewInput{})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.View)
+
+	keys := resourceKeys(out.View.Resources)
+	kiRows := 0
+	for _, k := range keys {
+		if k == resources.Ki {
+			kiRows++
+		}
+	}
+	require.Equal(t, 1, kiRows, "exactly one Ki row despite three consuming features")
+
+	// The single Ki row carries the owner's level-3 maximum.
+	var kiRow *ResourceView
+	for i := range out.View.Resources {
+		if out.View.Resources[i].Key == resources.Ki {
+			kiRow = &out.View.Resources[i]
+			break
+		}
+	}
+	require.NotNil(t, kiRow)
+	require.Equal(t, "Ki", kiRow.Name)
+	require.Equal(t, 3, kiRow.Maximum)
+
+	// Three Ki-consuming features are each projected, plus Deflect Missiles.
+	featureRefs := refStrings(featuresToRefs(out.View.Features))
+	require.Contains(t, featureRefs, refs.Features.FlurryOfBlows().String())
+	require.Contains(t, featureRefs, refs.Features.PatientDefense().String())
+	require.Contains(t, featureRefs, refs.Features.StepOfTheWind().String())
+	require.Contains(t, featureRefs, refs.Features.DeflectMissiles().String())
+
+	// Features are deterministically sorted by ref string.
+	require.Equal(t, sortedCopy(featureRefs), featureRefs)
+}
+
+// TestStatusViewBarbarianProjectsRageChargesAndRecklessAttack confirms the
+// barbarian's owner-owned RageCharges dedupes against the Rage feature's
+// report (same key, same facts) and Reckless Attack projects without a
+// resource.
+func TestStatusViewBarbarianProjectsRageChargesAndRecklessAttack(t *testing.T) {
+	barbarian := newLevel3Barbarian(t)
+
+	out, err := barbarian.StatusView(&StatusViewInput{})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.View)
+
+	keys := resourceKeys(out.View.Resources)
+	require.Contains(t, keys, resources.RageCharges)
+	require.Contains(t, keys, resources.HitDice)
+
+	rageRows := 0
+	for _, k := range keys {
+		if k == resources.RageCharges {
+			rageRows++
+		}
+	}
+	require.Equal(t, 1, rageRows, "RageCharges dedupes to one row")
+
+	featureRefs := refStrings(featuresToRefs(out.View.Features))
+	require.Contains(t, featureRefs, refs.Features.Rage().String())
+	require.Contains(t, featureRefs, refs.Features.RecklessAttack().String())
+
+	// Reckless Attack owns no resource, so its FeatureView has a nil key.
+	for _, f := range out.View.Features {
+		if f.Ref.String() == refs.Features.RecklessAttack().String() {
+			require.Nil(t, f.ResourceKey, "Reckless Attack owns no resource")
+		}
+	}
+}
+
+// TestStatusViewRogueProjectsSneakAttackCondition confirms the rogue's Sneak
+// Attack condition (carried under a feature ref) is projected via the
+// rulebook-owned display catalog, and the rogue has no feature-private
+// resources.
+func TestStatusViewRogueProjectsSneakAttackCondition(t *testing.T) {
+	rogue := newLevel3Rogue(t)
+
+	out, err := rogue.StatusView(&StatusViewInput{})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.View)
+
+	// Sneak Attack is a condition named by a feature ref.
+	foundSneakAttack := false
+	for _, c := range out.View.Conditions {
+		if c.Ref.String() == refs.Features.SneakAttack().String() {
+			require.Equal(t, "Sneak Attack", c.Name)
+			foundSneakAttack = true
+		}
+	}
+	require.True(t, foundSneakAttack, "Sneak Attack condition must be projected")
+
+	// Rogue has only the owner-owned Hit Dice resource.
+	keys := resourceKeys(out.View.Resources)
+	require.ElementsMatch(t, []coreResources.ResourceKey{resources.HitDice}, keys)
+}
+
+// TestStatusViewRejectsConflictingDuplicateResourceKey confirms that a
+// feature-reported resource whose key matches an owner row but whose counts
+// differ fails loudly with no partial view.
+func TestStatusViewRejectsConflictingDuplicateResourceKey(t *testing.T) {
+	// Drive the merge directly: an owner Ki row that disagrees with a
+	// feature-reported Ki row must fail loudly with no partial output.
+	ownerRows := []resourceReport{
+		{Key: resources.Ki, Current: 3, Maximum: 3},
+	}
+	reports := []resourceReport{
+		{Key: resources.Ki, Current: 2, Maximum: 3},
+	}
+
+	views, err := mergeResources(ownerRows, reports)
+	require.Error(t, err)
+	require.Nil(t, views, "no partial output on conflict")
+}
+
+// TestStatusViewRejectsNegativeResource confirms a negative current or maximum
+// on an owner row fails without partial output.
+func TestStatusViewRejectsNegativeResource(t *testing.T) {
+	_, err := mergeResources(
+		[]resourceReport{{Key: resources.Ki, Current: -1, Maximum: 3}},
+		nil,
+	)
+	require.Error(t, err)
+}
+
+// TestStatusViewRejectsCurrentAboveMaximum confirms current > maximum fails.
+func TestStatusViewRejectsCurrentAboveMaximum(t *testing.T) {
+	_, err := mergeResources(
+		[]resourceReport{{Key: resources.Ki, Current: 4, Maximum: 3}},
+		nil,
+	)
+	require.Error(t, err)
+}
+
+// TestStatusViewRejectsUnknownConditionRef confirms an unknown condition ref
+// returns an error and no partial view.
+func TestStatusViewRejectsUnknownConditionRef(t *testing.T) {
+	fighter := newLevel3Fighter(t)
+
+	// Append a condition with a ref the display catalog does not know.
+	fighter.conditions = append(fighter.conditions, &stubCondition{
+		ref: &core.Ref{Module: refs.Module, Type: refs.TypeConditions, ID: "totally_unknown"},
+	})
+
+	out, err := fighter.StatusView(&StatusViewInput{})
+	require.Error(t, err)
+	require.Nil(t, out, "no partial output on unknown condition ref")
+}
+
+// TestStatusViewRejectsMalformedFeatureStatus confirms a feature whose Status
+// returns an error fails the whole projection without partial output.
+func TestStatusViewRejectsMalformedFeatureStatus(t *testing.T) {
+	fighter := newLevel3Fighter(t)
+	// Inject a feature that always errors on Status. It implements the full
+	// Feature surface via stubStatusFeature.
+	fighter.features = append(fighter.features, &malformedStatusFeature{})
+
+	out, err := fighter.StatusView(&StatusViewInput{})
+	require.Error(t, err)
+	require.Nil(t, out, "no partial output on malformed feature status")
+}
+
+// TestStatusViewExcludesSpellSlotsAndClassResources confirms that non-empty
+// SpellSlots and legacy ClassResources never surface as status resources —
+// excluded by construction, locked by test.
+func TestStatusViewExcludesSpellSlotsAndClassResources(t *testing.T) {
+	fighter := newLevel3Fighter(t)
+
+	fighter.spellSlots = map[int]SpellSlotData{
+		1: {Max: 2, Used: 0},
+	}
+	fighter.classResources = map[shared.ClassResourceType]ResourceData{
+		shared.ClassResourceType(1): {Name: "sorcery_points", Current: 1, Max: 1},
+	}
+
+	out, err := fighter.StatusView(&StatusViewInput{})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	for _, r := range out.View.Resources {
+		require.NotEqual(t, coreResources.ResourceKey("spell_slots"), r.Key)
+		require.NotEqual(t, coreResources.ResourceKey("sorcery_points"), r.Key)
+	}
+}
+
+// TestStatusViewConditionsSortedByRef confirms conditions are sorted by ref.
+func TestStatusViewConditionsSortedByRef(t *testing.T) {
+	fighter := newLevel3Fighter(t)
+	// Add a second known condition (Dodging) alongside the fighting style.
+	fighter.conditions = append(fighter.conditions, mustNewDodgingCondition(fighter.GetID()))
+
+	out, err := fighter.StatusView(&StatusViewInput{})
+	require.NoError(t, err)
+
+	condRefs := refStrings(conditionsToRefs(out.View.Conditions))
+	require.Equal(t, sortedCopy(condRefs), condRefs, "conditions sorted by ref string")
+}
+
+// TestStatusViewResourcesSortedByKey confirms resources are sorted by key.
+func TestStatusViewResourcesSortedByKey(t *testing.T) {
+	monk := newLevel3Monk(t)
+
+	out, err := monk.StatusView(&StatusViewInput{})
+	require.NoError(t, err)
+
+	keys := resourceKeys(out.View.Resources)
+	require.Equal(t, sortedKeysCopy(keys), keys, "resources sorted by key")
+}
+
+// TestStatusViewReturnsDetachedValues confirms mutating the sheet after
+// projecting does not change the previously returned view.
+func TestStatusViewReturnsDetachedValues(t *testing.T) {
+	fighter := newLevel3Fighter(t)
+
+	out, err := fighter.StatusView(&StatusViewInput{})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+
+	hpBefore := out.View.HitPoints.Current
+	// Mutate the live sheet.
+	fighter.hitPoints = fighter.hitPoints - 1
+	require.Equal(t, hpBefore, out.View.HitPoints.Current, "view is detached from the live sheet")
+}
+
+// --- helpers ---
+
+// newLevel3Fighter finalizes the existing Fighter draft fixture, then promotes
+// the sheet to level 3 by re-running class resource initialization and adding
+// the level-2 Action Surge feature through the features factory — never by
+// hand-authoring a runtime feature object.
+func newLevel3Fighter(t *testing.T) *Character {
+	t.Helper()
+	draft := newFighterDraft(t)
+	char, err := draft.ToCharacter(context.Background(), "fighter-3", events.NewEventBus())
+	require.NoError(t, err)
+	require.NotNil(t, char)
+
+	promoteToLevel(t, draft, char, 3)
+
+	// Action Surge is a level-2 fighter feature.
+	actionSurge, err := features.CreateFromRef(&features.CreateFromRefInput{
+		Ref:         refs.Features.ActionSurge().String(),
+		CharacterID: char.GetID(),
+	})
+	require.NoError(t, err)
+	char.features = append(char.features, actionSurge.Feature)
+	return char
+}
+
+// newLevel3Barbarian finalizes the Barbarian draft fixture and promotes to
+// level 3, adding the level-2 Reckless Attack feature.
+func newLevel3Barbarian(t *testing.T) *Character {
+	t.Helper()
+	draft := newBarbarianDraft(t)
+	char, err := draft.ToCharacter(context.Background(), "barbarian-3", events.NewEventBus())
+	require.NoError(t, err)
+	require.NotNil(t, char)
+
+	promoteToLevel(t, draft, char, 3)
+
+	reckless, err := features.CreateFromRef(&features.CreateFromRefInput{
+		Ref:         refs.Features.RecklessAttack().String(),
+		CharacterID: char.GetID(),
+	})
+	require.NoError(t, err)
+	char.features = append(char.features, reckless.Feature)
+	return char
+}
+
+// newLevel3Monk finalizes the Monk draft fixture and promotes to level 3,
+// adding the three level-2 Ki features and the level-3 Deflect Missiles
+// feature. initializeClassResources at level 3 creates the shared Ki pool.
+func newLevel3Monk(t *testing.T) *Character {
+	t.Helper()
+	draft := newMonkDraft(t)
+	char, err := draft.ToCharacter(context.Background(), "monk-3", events.NewEventBus())
+	require.NoError(t, err)
+	require.NotNil(t, char)
+
+	promoteToLevel(t, draft, char, 3)
+
+	for _, ref := range []*core.Ref{
+		refs.Features.FlurryOfBlows(),
+		refs.Features.PatientDefense(),
+		refs.Features.StepOfTheWind(),
+		refs.Features.DeflectMissiles(),
+	} {
+		out, err := features.CreateFromRef(&features.CreateFromRefInput{
+			Ref:         ref.String(),
+			CharacterID: char.GetID(),
+		})
+		require.NoError(t, err)
+		char.features = append(char.features, out.Feature)
+	}
+	return char
+}
+
+// newLevel3Rogue finalizes the Rogue draft fixture and promotes to level 3.
+// The rogue carries the Sneak Attack condition and no feature-private
+// resources through level 3.
+func newLevel3Rogue(t *testing.T) *Character {
+	t.Helper()
+	draft := newRogueDraft(t)
+	char, err := draft.ToCharacter(context.Background(), "rogue-3", events.NewEventBus())
+	require.NoError(t, err)
+	require.NotNil(t, char)
+
+	promoteToLevel(t, draft, char, 3)
+	return char
+}
+
+// promoteToLevel bumps a finalized level-1 sheet to the given level and
+// re-runs class resource initialization so owner-owned pools (Hit Dice, Ki,
+// RageCharges) match the new level.
+func promoteToLevel(t *testing.T, draft *Draft, char *Character, level int) {
+	t.Helper()
+	char.level = level
+	// Re-run resource initialization against the new level. The draft's class
+	// is what gates which pools are created.
+	draft.initializeClassResources(char)
+}
+
+// newFighterDraft mirrors the fighter_finalize_test fixture: a Human Fighter
+// with the Defense fighting style.
+func newFighterDraft(t *testing.T) *Draft {
+	t.Helper()
+	draft, err := NewDraft(&DraftConfig{ID: "fighter-draft", PlayerID: "player-1"})
+	require.NoError(t, err)
+
+	require.NoError(t, draft.SetName(&SetNameInput{Name: "Arthur"}))
+	require.NoError(t, draft.SetRace(&SetRaceInput{
+		RaceID:  races.Human,
+		Choices: RaceChoices{Languages: []languages.Language{languages.Common}},
+	}))
+	require.NoError(t, draft.SetClass(&SetClassInput{
+		ClassID: classes.Fighter,
+		Choices: ClassChoices{
+			Skills: []skills.Skill{skills.Athletics, skills.History},
+			Equipment: []EquipmentChoiceSelection{
+				{ChoiceID: choices.FighterArmor, OptionID: choices.FighterArmorChainMail},
+				{
+					ChoiceID:           choices.FighterWeaponsPrimary,
+					OptionID:           choices.FighterWeaponMartialShield,
+					CategorySelections: []shared.EquipmentID{weapons.Longsword},
+				},
+				{ChoiceID: choices.FighterWeaponsSecondary, OptionID: choices.FighterRangedCrossbow},
+				{ChoiceID: choices.FighterPack, OptionID: choices.FighterPackDungeoneer},
+			},
+			FightingStyle: fightingstyles.Defense,
+		},
+	}))
+	require.NoError(t, draft.SetBackground(&SetBackgroundInput{BackgroundID: backgrounds.Soldier}))
+	require.NoError(t, draft.SetAbilityScores(&SetAbilityScoresInput{
+		Scores: shared.AbilityScores{
+			abilities.STR: 15, abilities.DEX: 14, abilities.CON: 13,
+			abilities.INT: 12, abilities.WIS: 10, abilities.CHA: 8,
+		},
+		Method: "standard-array",
+	}))
+	return draft
+}
+
+// newBarbarianDraft mirrors the barbarian_finalize_test fixture.
+func newBarbarianDraft(t *testing.T) *Draft {
+	t.Helper()
+	draft, err := NewDraft(&DraftConfig{ID: "barbarian-draft", PlayerID: "player-1"})
+	require.NoError(t, err)
+
+	require.NoError(t, draft.SetName(&SetNameInput{Name: "Grog"}))
+	require.NoError(t, draft.SetRace(&SetRaceInput{
+		RaceID:  races.Human,
+		Choices: RaceChoices{Languages: []languages.Language{languages.Dwarvish}},
+	}))
+	require.NoError(t, draft.SetClass(&SetClassInput{
+		ClassID: classes.Barbarian,
+		Choices: ClassChoices{
+			Skills: []skills.Skill{skills.Athletics, skills.Intimidation},
+			Equipment: []EquipmentChoiceSelection{
+				{ChoiceID: choices.BarbarianWeaponsPrimary, OptionID: choices.BarbarianWeaponGreataxe},
+				{ChoiceID: choices.BarbarianWeaponsSecondary, OptionID: choices.BarbarianSecondaryHandaxes},
+				{ChoiceID: choices.BarbarianPack, OptionID: choices.BarbarianPackExplorer},
+			},
+		},
+	}))
+	require.NoError(t, draft.SetBackground(&SetBackgroundInput{BackgroundID: backgrounds.Soldier}))
+	require.NoError(t, draft.SetAbilityScores(&SetAbilityScoresInput{
+		Scores: shared.AbilityScores{
+			abilities.STR: 16, abilities.DEX: 14, abilities.CON: 15,
+			abilities.INT: 8, abilities.WIS: 12, abilities.CHA: 10,
+		},
+		Method: "standard-array",
+	}))
+	return draft
+}
+
+// newMonkDraft mirrors the monk draft fixture from draft_test.go.
+func newMonkDraft(t *testing.T) *Draft {
+	t.Helper()
+	draft, err := NewDraft(&DraftConfig{ID: "monk-draft", PlayerID: "player-1"})
+	require.NoError(t, err)
+
+	require.NoError(t, draft.SetName(&SetNameInput{Name: "Li"}))
+	require.NoError(t, draft.SetRace(&SetRaceInput{
+		RaceID:  races.Human,
+		Choices: RaceChoices{Languages: []languages.Language{languages.Common}},
+	}))
+	require.NoError(t, draft.SetBackground(&SetBackgroundInput{BackgroundID: backgrounds.Hermit}))
+	require.NoError(t, draft.SetClass(&SetClassInput{
+		ClassID: classes.Monk,
+		Choices: ClassChoices{
+			Skills: []skills.Skill{skills.Acrobatics, skills.Stealth},
+			Equipment: []EquipmentChoiceSelection{
+				{ChoiceID: choices.MonkWeaponsPrimary, OptionID: choices.MonkWeaponShortsword},
+				{ChoiceID: choices.MonkPack, OptionID: choices.MonkPackDungeoneer},
+			},
+			Tools: []shared.SelectionID{shared.SelectionID(proficiencies.ToolBrewer)},
+		},
+	}))
+	require.NoError(t, draft.SetAbilityScores(&SetAbilityScoresInput{
+		Scores: shared.AbilityScores{
+			abilities.STR: 8, abilities.DEX: 15, abilities.CON: 13,
+			abilities.INT: 10, abilities.WIS: 14, abilities.CHA: 12,
+		},
+		Method: "standard-array",
+	}))
+	return draft
+}
+
+// newRogueDraft mirrors the rogue draft fixture from draft_test.go.
+func newRogueDraft(t *testing.T) *Draft {
+	t.Helper()
+	draft, err := NewDraft(&DraftConfig{ID: "rogue-draft", PlayerID: "player-1"})
+	require.NoError(t, err)
+
+	require.NoError(t, draft.SetName(&SetNameInput{Name: "Vex"}))
+	require.NoError(t, draft.SetRace(&SetRaceInput{
+		RaceID:  races.Human,
+		Choices: RaceChoices{Languages: []languages.Language{languages.Common}},
+	}))
+	require.NoError(t, draft.SetBackground(&SetBackgroundInput{BackgroundID: backgrounds.Criminal}))
+	require.NoError(t, draft.SetClass(&SetClassInput{
+		ClassID: classes.Rogue,
+		Choices: ClassChoices{
+			Skills: []skills.Skill{
+				skills.Stealth, skills.Perception,
+				skills.Investigation, skills.Acrobatics,
+			},
+			Expertise: []skills.Skill{skills.Stealth, skills.Perception},
+			Equipment: []EquipmentChoiceSelection{
+				{ChoiceID: choices.RogueWeaponsPrimary, OptionID: choices.RogueWeaponRapier},
+				{ChoiceID: choices.RogueWeaponsSecondary, OptionID: choices.RogueSecondaryShortbow},
+				{ChoiceID: choices.RoguePack, OptionID: choices.RoguePackBurglar},
+			},
+		},
+	}))
+	require.NoError(t, draft.SetAbilityScores(&SetAbilityScoresInput{
+		Scores: shared.AbilityScores{
+			abilities.STR: 8, abilities.DEX: 16, abilities.CON: 14,
+			abilities.INT: 12, abilities.WIS: 14, abilities.CHA: 10,
+		},
+		Method: "standard-array",
+	}))
+	return draft
+}
+
+// resourceKeys collects the keys from a slice of ResourceView.
+func resourceKeys(rs []ResourceView) []coreResources.ResourceKey {
+	out := make([]coreResources.ResourceKey, 0, len(rs))
+	for _, r := range rs {
+		out = append(out, r.Key)
+	}
+	return out
+}
+
+func featuresToRefs(fs []FeatureView) []core.Ref {
+	out := make([]core.Ref, 0, len(fs))
+	for _, f := range fs {
+		out = append(out, f.Ref)
+	}
+	return out
+}
+
+func conditionsToRefs(cs []ConditionView) []core.Ref {
+	out := make([]core.Ref, 0, len(cs))
+	for _, c := range cs {
+		out = append(out, c.Ref)
+	}
+	return out
+}
+
+func refStrings(refs []core.Ref) []string {
+	out := make([]string, 0, len(refs))
+	for _, r := range refs {
+		out = append(out, r.String())
+	}
+	return out
+}
+
+func uniqueKeys(keys []coreResources.ResourceKey) []coreResources.ResourceKey {
+	seen := make(map[coreResources.ResourceKey]struct{}, len(keys))
+	out := make([]coreResources.ResourceKey, 0, len(keys))
+	for _, k := range keys {
+		if _, ok := seen[k]; ok {
+			continue
+		}
+		seen[k] = struct{}{}
+		out = append(out, k)
+	}
+	return out
+}
+
+func sortedCopy(in []string) []string {
+	out := append([]string(nil), in...)
+	// simple deterministic sort
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+func sortedKeysCopy(in []coreResources.ResourceKey) []coreResources.ResourceKey {
+	out := append([]coreResources.ResourceKey(nil), in...)
+	for i := 1; i < len(out); i++ {
+		for j := i; j > 0 && out[j-1] > out[j]; j-- {
+			out[j-1], out[j] = out[j], out[j-1]
+		}
+	}
+	return out
+}
+
+// mustNewDodgingCondition creates a Dodging condition for the projection tests.
+func mustNewDodgingCondition(characterID string) dnd5eEvents.ConditionBehavior {
+	return conditions.NewDodgingCondition(characterID)
+}
+
+// stubCondition is a ConditionBehavior that names itself by an arbitrary ref,
+// used to exercise the unknown-ref error path.
+type stubCondition struct {
+	ref *core.Ref
+}
+
+func (s *stubCondition) Ref() *core.Ref                                { return s.ref }
+func (s *stubCondition) IsApplied() bool                               { return true }
+func (s *stubCondition) Apply(context.Context, events.EventBus) error  { return nil }
+func (s *stubCondition) Remove(context.Context, events.EventBus) error { return nil }
+func (s *stubCondition) ToJSON() (json.RawMessage, error)              { return nil, nil }
+
+// malformedStatusFeature is a Feature whose Status always errors, used to
+// exercise the malformed-feature-status error path. It implements the full
+// features.Feature surface with no-op activations.
+type malformedStatusFeature struct{}
+
+func (m *malformedStatusFeature) GetID() string { return "malformed" }
+func (m *malformedStatusFeature) GetType() core.EntityType {
+	return core.EntityType("feature")
+}
+func (m *malformedStatusFeature) CanActivate(context.Context, core.Entity, features.FeatureInput) error {
+	return nil
+}
+func (m *malformedStatusFeature) Activate(context.Context, core.Entity, features.FeatureInput) error {
+	return nil
+}
+func (m *malformedStatusFeature) Ref() *core.Ref {
+	return &core.Ref{Module: refs.Module, Type: refs.TypeFeatures, ID: "malformed"}
+}
+func (m *malformedStatusFeature) Name() string                      { return "Malformed" }
+func (m *malformedStatusFeature) ToJSON() (json.RawMessage, error)  { return nil, nil }
+func (m *malformedStatusFeature) ActionType() coreCombat.ActionType { return "" }
+func (m *malformedStatusFeature) Status(*features.StatusInput) (*features.StatusOutput, error) {
+	return nil, errMalformedStatusForTest
+}
+
+// errMalformedStatusForTest is the sentinel a malformedStatusFeature returns.
+var errMalformedStatusForTest = newSentinelErr("malformed feature status for test")
+
+func newSentinelErr(msg string) error {
+	return &sentinelError{msg: msg}
+}
+
+type sentinelError struct{ msg string }
+
+func (e *sentinelError) Error() string { return e.msg }

--- a/rulebooks/dnd5e/character/status_view_test.go
+++ b/rulebooks/dnd5e/character/status_view_test.go
@@ -186,10 +186,10 @@ func TestStatusViewRejectsConflictingDuplicateResourceKey(t *testing.T) {
 	// Drive the merge directly: an owner Ki row that disagrees with a
 	// feature-reported Ki row must fail loudly with no partial output.
 	ownerRows := []resourceReport{
-		{Key: resources.Ki, Current: 3, Maximum: 3},
+		{Key: resources.Ki, Name: "Ki", Current: 3, Maximum: 3},
 	}
 	reports := []resourceReport{
-		{Key: resources.Ki, Current: 2, Maximum: 3},
+		{Key: resources.Ki, Name: "Ki", Current: 2, Maximum: 3},
 	}
 
 	views, err := mergeResources(ownerRows, reports)
@@ -201,7 +201,7 @@ func TestStatusViewRejectsConflictingDuplicateResourceKey(t *testing.T) {
 // on an owner row fails without partial output.
 func TestStatusViewRejectsNegativeResource(t *testing.T) {
 	_, err := mergeResources(
-		[]resourceReport{{Key: resources.Ki, Current: -1, Maximum: 3}},
+		[]resourceReport{{Key: resources.Ki, Name: "Ki", Current: -1, Maximum: 3}},
 		nil,
 	)
 	require.Error(t, err)
@@ -210,10 +210,85 @@ func TestStatusViewRejectsNegativeResource(t *testing.T) {
 // TestStatusViewRejectsCurrentAboveMaximum confirms current > maximum fails.
 func TestStatusViewRejectsCurrentAboveMaximum(t *testing.T) {
 	_, err := mergeResources(
-		[]resourceReport{{Key: resources.Ki, Current: 4, Maximum: 3}},
+		[]resourceReport{{Key: resources.Ki, Name: "Ki", Current: 4, Maximum: 3}},
 		nil,
 	)
 	require.Error(t, err)
+}
+
+func TestStatusViewRejectsUnknownSpellLikeOwnerResourceKey(t *testing.T) {
+	fighter := newLevel3Fighter(t)
+	fighter.resources[coreResources.ResourceKey("spell_slots")] = fighter.resources[resources.HitDice]
+
+	out, err := fighter.StatusView(&StatusViewInput{})
+	require.Error(t, err)
+	require.Nil(t, out)
+}
+
+func TestStatusViewRejectsCrossClassOwnerResourceKey(t *testing.T) {
+	fighter := newLevel3Fighter(t)
+	fighter.resources[resources.Ki] = fighter.resources[resources.HitDice]
+
+	out, err := fighter.StatusView(&StatusViewInput{})
+	require.Error(t, err)
+	require.Nil(t, out)
+}
+
+func TestStatusViewRejectsFeatureResourceKeyOrNameMismatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource features.ResourceStatus
+	}{
+		{
+			name: "wrong key",
+			resource: features.ResourceStatus{
+				Key: resources.ActionSurge, Name: "Action Surge", Current: 1, Maximum: 1,
+			},
+		},
+		{
+			name: "wrong name",
+			resource: features.ResourceStatus{
+				Key: resources.SecondWind, Name: "Wind Points", Current: 1, Maximum: 1,
+			},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			fighter := newLevel3Fighter(t)
+			resource := tc.resource
+			fighter.features = append(fighter.features, &reportedStatusFeature{status: features.Status{
+				Ref: *refs.Features.SecondWind(), Name: "Second Wind", Resource: &resource,
+			}})
+
+			out, err := fighter.StatusView(&StatusViewInput{})
+			require.Error(t, err)
+			require.Nil(t, out)
+		})
+	}
+}
+
+func TestStatusViewRejectsFeaturePrivateResourceOnWrongClass(t *testing.T) {
+	monk := newLevel3Monk(t)
+	monk.features = append(monk.features, &reportedStatusFeature{status: features.Status{
+		Ref:  *refs.Features.ActionSurge(),
+		Name: "Action Surge",
+		Resource: &features.ResourceStatus{
+			Key: resources.ActionSurge, Name: "Action Surge", Current: 1, Maximum: 1,
+		},
+	}})
+
+	out, err := monk.StatusView(&StatusViewInput{})
+	require.Error(t, err)
+	require.Nil(t, out)
+}
+
+func TestStatusViewRejectsSameKeyAndCountsWithConflictingName(t *testing.T) {
+	views, err := mergeResources(
+		[]resourceReport{{Key: resources.Ki, Name: "Ki", Current: 3, Maximum: 3}},
+		[]resourceReport{{Key: resources.Ki, Name: "Focus", Current: 3, Maximum: 3}},
+	)
+	require.Error(t, err)
+	require.Nil(t, views)
 }
 
 // TestStatusViewRejectsUnknownConditionRef confirms an unknown condition ref
@@ -654,6 +729,21 @@ func (m *malformedStatusFeature) ToJSON() (json.RawMessage, error)  { return nil
 func (m *malformedStatusFeature) ActionType() coreCombat.ActionType { return "" }
 func (m *malformedStatusFeature) Status(*features.StatusInput) (*features.StatusOutput, error) {
 	return nil, errMalformedStatusForTest
+}
+
+// reportedStatusFeature supplies one authored status report so catalog
+// rejection tests can exercise provider key/name/class mismatches end to end.
+type reportedStatusFeature struct {
+	malformedStatusFeature
+	status features.Status
+}
+
+func (f *reportedStatusFeature) GetID() string  { return f.status.Ref.ID }
+func (f *reportedStatusFeature) Ref() *core.Ref { return &f.status.Ref }
+func (f *reportedStatusFeature) Name() string   { return f.status.Name }
+func (f *reportedStatusFeature) Status(*features.StatusInput) (*features.StatusOutput, error) {
+	status := f.status
+	return &features.StatusOutput{Status: &status}, nil
 }
 
 // errMalformedStatusForTest is the sentinel a malformedStatusFeature returns.

--- a/rulebooks/dnd5e/conditions/brutal_critical.go
+++ b/rulebooks/dnd5e/conditions/brutal_critical.go
@@ -47,6 +47,10 @@ type BrutalCriticalCondition struct {
 // Ensure BrutalCriticalCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*BrutalCriticalCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (b *BrutalCriticalCondition) Ref() *core.Ref { return refs.Conditions.BrutalCritical() }
+
 // BrutalCriticalInput provides configuration for creating a brutal critical condition
 type BrutalCriticalInput struct {
 	CharacterID string      // ID of the barbarian

--- a/rulebooks/dnd5e/conditions/disengaging.go
+++ b/rulebooks/dnd5e/conditions/disengaging.go
@@ -38,6 +38,10 @@ type DisengagingCondition struct {
 // Ensure DisengagingCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*DisengagingCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (d *DisengagingCondition) Ref() *core.Ref { return refs.Conditions.Disengaging() }
+
 // NewDisengagingCondition creates a new Disengaging condition for the specified character.
 // The condition will prevent opportunity attacks when the character moves and will
 // automatically remove itself at the end of the character's turn.

--- a/rulebooks/dnd5e/conditions/display.go
+++ b/rulebooks/dnd5e/conditions/display.go
@@ -1,0 +1,78 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// Display is the rulebook-owned, display-ready projection of one condition
+// ref: a never-empty display name and optional server-authored detail. It is
+// the value a character StatusView (Task 4) looks up by ref so the projection
+// never has to serialize a condition back to JSON to recover a human-readable
+// label, and so the set of conditions a status view can name is bounded by
+// this catalog rather than by whatever a live condition happens to carry.
+type Display struct {
+	// Name is the condition's display name. Never empty for a known ref.
+	Name string
+
+	// Detail is optional, server/toolkit-composed display text. May be empty.
+	Detail string
+}
+
+// DisplayFor returns the display descriptor for the given condition ref, or
+// (Display{}, false) when the ref is not in the rulebook-owned catalog. The
+// character projection turns a false result into a hard error rather than
+// silently dropping the condition, so an unknown ref fails loudly.
+func DisplayFor(ref core.Ref) (Display, bool) {
+	d, ok := displayCatalog[ref.String()]
+	return d, ok
+}
+
+// displayCatalog maps the canonical ref string of every condition reachable by
+// the four builds (Fighter, Barbarian, Monk, Rogue) to its display descriptor.
+// It is keyed by ref.String() because at least one condition — Sneak Attack —
+// names itself by a feature ref (refs.Features.SneakAttack) rather than a
+// condition ref, so the type alone is not enough to disambiguate.
+//
+// The catalog deliberately excludes spell-oriented status (e.g. the Shield
+// spell condition): a status view is a no-magic projection of the sheet, and
+// the existing Shield condition is not promoted into this catalog.
+var displayCatalog = map[string]Display{
+	// Fighting styles (Fighter).
+	refs.Conditions.FightingStyleArchery().String():             {Name: "Archery"},
+	refs.Conditions.FightingStyleDefense().String():             {Name: "Defense"},
+	refs.Conditions.FightingStyleDueling().String():             {Name: "Dueling"},
+	refs.Conditions.FightingStyleGreatWeaponFighting().String(): {Name: "Great Weapon Fighting"},
+	refs.Conditions.FightingStyleProtection().String():          {Name: "Protection"},
+	refs.Conditions.FightingStyleTwoWeaponFighting().String():   {Name: "Two-Weapon Fighting"},
+
+	// Barbarian.
+	refs.Conditions.Raging().String():         {Name: "Raging"},
+	refs.Conditions.RecklessAttack().String(): {Name: "Reckless Attack"},
+	refs.Conditions.BrutalCritical().String(): {Name: "Brutal Critical"},
+
+	// Fighter (champion).
+	refs.Conditions.ImprovedCritical().String(): {Name: "Improved Critical"},
+
+	// Monk.
+	refs.Conditions.MartialArts().String():       {Name: "Martial Arts"},
+	refs.Conditions.UnarmoredDefense().String():  {Name: "Unarmored Defense"},
+	refs.Conditions.UnarmoredMovement().String(): {Name: "Unarmored Movement"},
+
+	// Rogue. Sneak Attack names itself by a feature ref, not a condition ref.
+	refs.Features.SneakAttack().String(): {Name: "Sneak Attack"},
+
+	// Turn-based / combat-ability conditions.
+	refs.Conditions.Dodging().String():           {Name: "Dodging"},
+	refs.Conditions.Disengaging().String():       {Name: "Disengaging"},
+	refs.Conditions.Hidden().String():            {Name: "Hidden"},
+	refs.Conditions.Helped().String():            {Name: "Helped"},
+	refs.Conditions.Prone().String():             {Name: "Prone"},
+	refs.Conditions.OpportunityAttack().String(): {Name: "Opportunity Attack"},
+
+	// Standard conditions reachable by the four builds.
+	refs.Conditions.Unconscious().String(): {Name: "Unconscious"},
+}

--- a/rulebooks/dnd5e/conditions/display_test.go
+++ b/rulebooks/dnd5e/conditions/display_test.go
@@ -1,0 +1,74 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+func TestDisplayForKnownConditions(t *testing.T) {
+	cases := []struct {
+		name string
+		ref  core.Ref
+		want Display
+	}{
+		{"fighting style defense", *refs.Conditions.FightingStyleDefense(), Display{Name: "Defense"}},
+		{"raging", *refs.Conditions.Raging(), Display{Name: "Raging"}},
+		{"martial arts", *refs.Conditions.MartialArts(), Display{Name: "Martial Arts"}},
+		{"unarmored defense", *refs.Conditions.UnarmoredDefense(), Display{Name: "Unarmored Defense"}},
+		{"unarmored movement", *refs.Conditions.UnarmoredMovement(), Display{Name: "Unarmored Movement"}},
+		{"sneak attack (feature ref)", *refs.Features.SneakAttack(), Display{Name: "Sneak Attack"}},
+		{"brutal critical", *refs.Conditions.BrutalCritical(), Display{Name: "Brutal Critical"}},
+		{"improved critical", *refs.Conditions.ImprovedCritical(), Display{Name: "Improved Critical"}},
+		{"reckless attack", *refs.Conditions.RecklessAttack(), Display{Name: "Reckless Attack"}},
+		{"dodging", *refs.Conditions.Dodging(), Display{Name: "Dodging"}},
+		{"disengaging", *refs.Conditions.Disengaging(), Display{Name: "Disengaging"}},
+		{"hidden", *refs.Conditions.Hidden(), Display{Name: "Hidden"}},
+		{"helped", *refs.Conditions.Helped(), Display{Name: "Helped"}},
+		{"prone", *refs.Conditions.Prone(), Display{Name: "Prone"}},
+		{"opportunity attack", *refs.Conditions.OpportunityAttack(), Display{Name: "Opportunity Attack"}},
+		{"unconscious", *refs.Conditions.Unconscious(), Display{Name: "Unconscious"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := DisplayFor(tc.ref)
+			assert.True(t, ok, "known ref must be in the catalog")
+			assert.Equal(t, tc.want, got)
+			assert.NotEmpty(t, got.Name, "name is never empty for a known ref")
+		})
+	}
+}
+
+func TestDisplayForAllFightingStyles(t *testing.T) {
+	for _, ref := range []*core.Ref{
+		refs.Conditions.FightingStyleArchery(),
+		refs.Conditions.FightingStyleDefense(),
+		refs.Conditions.FightingStyleDueling(),
+		refs.Conditions.FightingStyleGreatWeaponFighting(),
+		refs.Conditions.FightingStyleProtection(),
+		refs.Conditions.FightingStyleTwoWeaponFighting(),
+	} {
+		_, ok := DisplayFor(*ref)
+		assert.True(t, ok, "fighting style %s must be in the catalog", ref.String())
+	}
+}
+
+func TestDisplayForUnknownRefReturnsFalse(t *testing.T) {
+	unknown := core.Ref{Module: refs.Module, Type: refs.TypeConditions, ID: "totally_unknown"}
+	_, ok := DisplayFor(unknown)
+	assert.False(t, ok, "unknown ref must not be in the catalog")
+}
+
+// TestDisplayCatalogExcludesShieldSpell confirms the no-magic boundary: the
+// existing Shield spell condition is deliberately not promoted into the
+// status-view catalog.
+func TestDisplayCatalogExcludesShieldSpell(t *testing.T) {
+	_, ok := DisplayFor(*refs.Spells.Shield())
+	assert.False(t, ok, "Shield spell is not a status-view condition")
+}

--- a/rulebooks/dnd5e/conditions/dodging.go
+++ b/rulebooks/dnd5e/conditions/dodging.go
@@ -39,6 +39,10 @@ type DodgingCondition struct {
 // Ensure DodgingCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*DodgingCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (d *DodgingCondition) Ref() *core.Ref { return refs.Conditions.Dodging() }
+
 // NewDodgingCondition creates a new Dodging condition for the specified character.
 // The condition grants disadvantage on attacks targeting this character and
 // advantage on DEX saves, and removes itself at the start of the character's next turn.

--- a/rulebooks/dnd5e/conditions/fighting_style_archery.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_archery.go
@@ -34,6 +34,12 @@ type FightingStyleArcheryCondition struct {
 // Ensure FightingStyleArcheryCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*FightingStyleArcheryCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (f *FightingStyleArcheryCondition) Ref() *core.Ref {
+	return refs.Conditions.FightingStyleArchery()
+}
+
 // NewFightingStyleArcheryCondition creates a new Archery fighting style condition.
 func NewFightingStyleArcheryCondition(characterID string) *FightingStyleArcheryCondition {
 	return &FightingStyleArcheryCondition{

--- a/rulebooks/dnd5e/conditions/fighting_style_defense.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_defense.go
@@ -34,6 +34,12 @@ type FightingStyleDefenseCondition struct {
 // Ensure FightingStyleDefenseCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*FightingStyleDefenseCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (f *FightingStyleDefenseCondition) Ref() *core.Ref {
+	return refs.Conditions.FightingStyleDefense()
+}
+
 // NewFightingStyleDefenseCondition creates a new Defense fighting style condition.
 func NewFightingStyleDefenseCondition(characterID string) *FightingStyleDefenseCondition {
 	return &FightingStyleDefenseCondition{

--- a/rulebooks/dnd5e/conditions/fighting_style_dueling.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_dueling.go
@@ -34,6 +34,12 @@ type FightingStyleDuelingCondition struct {
 // Ensure FightingStyleDuelingCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*FightingStyleDuelingCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (f *FightingStyleDuelingCondition) Ref() *core.Ref {
+	return refs.Conditions.FightingStyleDueling()
+}
+
 // NewFightingStyleDuelingCondition creates a new Dueling fighting style condition.
 func NewFightingStyleDuelingCondition(characterID string) *FightingStyleDuelingCondition {
 	return &FightingStyleDuelingCondition{

--- a/rulebooks/dnd5e/conditions/fighting_style_great_weapon_fighting.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_great_weapon_fighting.go
@@ -42,6 +42,12 @@ type FightingStyleGreatWeaponFightingCondition struct {
 // Ensure FightingStyleGreatWeaponFightingCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*FightingStyleGreatWeaponFightingCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (f *FightingStyleGreatWeaponFightingCondition) Ref() *core.Ref {
+	return refs.Conditions.FightingStyleGreatWeaponFighting()
+}
+
 // NewFightingStyleGreatWeaponFightingCondition creates a new Great Weapon Fighting condition.
 func NewFightingStyleGreatWeaponFightingCondition(
 	characterID string, roller dice.Roller,

--- a/rulebooks/dnd5e/conditions/fighting_style_protection.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_protection.go
@@ -51,6 +51,12 @@ type FightingStyleProtectionCondition struct {
 // Ensure FightingStyleProtectionCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*FightingStyleProtectionCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (f *FightingStyleProtectionCondition) Ref() *core.Ref {
+	return refs.Conditions.FightingStyleProtection()
+}
+
 // Ensure FightingStyleProtectionCondition implements dnd5eEvents.OwnerAware
 var _ dnd5eEvents.OwnerAware = (*FightingStyleProtectionCondition)(nil)
 

--- a/rulebooks/dnd5e/conditions/fighting_style_two_weapon_fighting.go
+++ b/rulebooks/dnd5e/conditions/fighting_style_two_weapon_fighting.go
@@ -36,6 +36,12 @@ type FightingStyleTwoWeaponFightingCondition struct {
 // Ensure FightingStyleTwoWeaponFightingCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*FightingStyleTwoWeaponFightingCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (f *FightingStyleTwoWeaponFightingCondition) Ref() *core.Ref {
+	return refs.Conditions.FightingStyleTwoWeaponFighting()
+}
+
 // NewFightingStyleTwoWeaponFightingCondition creates a new Two-Weapon Fighting condition.
 func NewFightingStyleTwoWeaponFightingCondition(characterID string) *FightingStyleTwoWeaponFightingCondition {
 	return &FightingStyleTwoWeaponFightingCondition{

--- a/rulebooks/dnd5e/conditions/helped.go
+++ b/rulebooks/dnd5e/conditions/helped.go
@@ -49,6 +49,10 @@ type HelpedCondition struct {
 // Ensure HelpedCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*HelpedCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (h *HelpedCondition) Ref() *core.Ref { return refs.Conditions.Helped() }
+
 // NewHelpedCondition creates a new Helped condition granting the given ally
 // advantage, with removal tied to the helper's next turn as a safety net.
 func NewHelpedCondition(characterID, helperID string) *HelpedCondition {

--- a/rulebooks/dnd5e/conditions/hidden.go
+++ b/rulebooks/dnd5e/conditions/hidden.go
@@ -41,6 +41,10 @@ type HiddenCondition struct {
 // Ensure HiddenCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*HiddenCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (h *HiddenCondition) Ref() *core.Ref { return refs.Conditions.Hidden() }
+
 // NewHiddenCondition creates a new Hidden condition for the specified character.
 func NewHiddenCondition(characterID string) *HiddenCondition {
 	return &HiddenCondition{

--- a/rulebooks/dnd5e/conditions/improved_critical.go
+++ b/rulebooks/dnd5e/conditions/improved_critical.go
@@ -37,6 +37,10 @@ type ImprovedCriticalCondition struct {
 // Ensure ImprovedCriticalCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*ImprovedCriticalCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (ic *ImprovedCriticalCondition) Ref() *core.Ref { return refs.Conditions.ImprovedCritical() }
+
 // IsApplied returns true if this condition is currently applied
 func (ic *ImprovedCriticalCondition) IsApplied() bool {
 	return ic.bus != nil

--- a/rulebooks/dnd5e/conditions/loader_test.go
+++ b/rulebooks/dnd5e/conditions/loader_test.go
@@ -7,13 +7,17 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
 // LoaderTestSuite tests the condition loader functionality
@@ -285,4 +289,107 @@ func (s *LoaderTestSuite) TestRagingConditionRoundTripCleanup() {
 
 	// Should only have 2 components: weapon and ability (no rage)
 	s.Require().Len(finalEvent.Components, 2, "Should only have weapon and ability after Remove()")
+}
+
+// TestEveryLoadedConditionNamesItsCanonicalRef pins the rpg-toolkit#971
+// contract: every condition the loader can route names itself through Ref(),
+// and the name it reports is exactly the ref its own ToJSON embeds (and that
+// LoadJSON routed on). A condition that returns a different ref — or nil —
+// breaks per-effect attribution downstream, so this fails the whole table on
+// the first divergence rather than silently dropping one.
+func TestEveryLoadedConditionNamesItsCanonicalRef(t *testing.T) {
+	cases := []struct {
+		name     string
+		ref      *core.Ref
+		behavior func() dnd5eEvents.ConditionBehavior
+	}{
+		{"raging", refs.Conditions.Raging(), func() dnd5eEvents.ConditionBehavior {
+			return &RagingCondition{CharacterID: "barbarian-1", DamageBonus: 2, Level: 5}
+		}},
+		{"brutal_critical", refs.Conditions.BrutalCritical(), func() dnd5eEvents.ConditionBehavior {
+			return NewBrutalCriticalCondition(BrutalCriticalInput{CharacterID: "barbarian-1", Level: 13})
+		}},
+		{"unarmored_defense", refs.Conditions.UnarmoredDefense(), func() dnd5eEvents.ConditionBehavior {
+			return NewUnarmoredDefenseCondition(UnarmoredDefenseInput{
+				CharacterID: "barbarian-1", Type: UnarmoredDefenseBarbarian, Source: "dnd5e:classes:barbarian",
+			})
+		}},
+		{"fighting_style_archery", refs.Conditions.FightingStyleArchery(), func() dnd5eEvents.ConditionBehavior {
+			return NewFightingStyleArcheryCondition("fighter-1")
+		}},
+		{"fighting_style_defense", refs.Conditions.FightingStyleDefense(), func() dnd5eEvents.ConditionBehavior {
+			return NewFightingStyleDefenseCondition("fighter-1")
+		}},
+		{"fighting_style_dueling", refs.Conditions.FightingStyleDueling(), func() dnd5eEvents.ConditionBehavior {
+			return NewFightingStyleDuelingCondition("fighter-1")
+		}},
+		{"fighting_style_great_weapon_fighting", refs.Conditions.FightingStyleGreatWeaponFighting(), func() dnd5eEvents.ConditionBehavior {
+			return NewFightingStyleGreatWeaponFightingCondition("fighter-1", nil)
+		}},
+		{"fighting_style_protection", refs.Conditions.FightingStyleProtection(), func() dnd5eEvents.ConditionBehavior {
+			return NewFightingStyleProtectionCondition("fighter-1")
+		}},
+		{"fighting_style_two_weapon_fighting", refs.Conditions.FightingStyleTwoWeaponFighting(), func() dnd5eEvents.ConditionBehavior {
+			return NewFightingStyleTwoWeaponFightingCondition("fighter-1")
+		}},
+		{"improved_critical", refs.Conditions.ImprovedCritical(), func() dnd5eEvents.ConditionBehavior {
+			return NewImprovedCriticalCondition(ImprovedCriticalInput{CharacterID: "fighter-1", Threshold: 19})
+		}},
+		{"reckless_attack", refs.Conditions.RecklessAttack(), func() dnd5eEvents.ConditionBehavior {
+			return NewRecklessAttackCondition("barbarian-1")
+		}},
+		{"martial_arts", refs.Conditions.MartialArts(), func() dnd5eEvents.ConditionBehavior {
+			return NewMartialArtsCondition(MartialArtsInput{CharacterID: "monk-1", MonkLevel: 3})
+		}},
+		{"unarmored_movement", refs.Conditions.UnarmoredMovement(), func() dnd5eEvents.ConditionBehavior {
+			return NewUnarmoredMovementCondition(UnarmoredMovementInput{CharacterID: "monk-1", MonkLevel: 3})
+		}},
+		{"sneak_attack", refs.Features.SneakAttack(), func() dnd5eEvents.ConditionBehavior {
+			return NewSneakAttackCondition(SneakAttackInput{CharacterID: "rogue-1", Level: 3})
+		}},
+		{"disengaging", refs.Conditions.Disengaging(), func() dnd5eEvents.ConditionBehavior {
+			return NewDisengagingCondition("rogue-1")
+		}},
+		{"dodging", refs.Conditions.Dodging(), func() dnd5eEvents.ConditionBehavior {
+			return NewDodgingCondition("fighter-1")
+		}},
+		{"prone", refs.Conditions.Prone(), func() dnd5eEvents.ConditionBehavior {
+			return NewProneCondition("fighter-1")
+		}},
+		{"hidden", refs.Conditions.Hidden(), func() dnd5eEvents.ConditionBehavior {
+			return NewHiddenCondition("rogue-1")
+		}},
+		{"helped", refs.Conditions.Helped(), func() dnd5eEvents.ConditionBehavior {
+			return NewHelpedCondition("rogue-1", "cleric-1")
+		}},
+		{"unconscious", refs.Conditions.Unconscious(), func() dnd5eEvents.ConditionBehavior {
+			return NewUnconsciousCondition("fighter-1", nil)
+		}},
+		{"opportunity_attack", refs.Conditions.OpportunityAttack(), func() dnd5eEvents.ConditionBehavior {
+			return NewOpportunityAttackCondition("fighter-1")
+		}},
+		{"shield_spell", refs.Spells.Shield(), func() dnd5eEvents.ConditionBehavior {
+			return NewShieldSpellCondition("wizard-1")
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			original := tc.behavior()
+			require.NotNil(t, original)
+			require.NotNil(t, original.Ref(), "original Ref() must never return nil")
+
+			blob, err := original.ToJSON()
+			require.NoError(t, err)
+
+			loaded, err := LoadJSON(blob)
+			require.NoError(t, err)
+			require.NotNil(t, loaded.Ref(), "loaded Ref() must never return nil")
+
+			assert.Equal(t, tc.ref.String(), original.Ref().String(),
+				"original condition must name its own canonical ref")
+			assert.Equal(t, tc.ref.String(), loaded.Ref().String(),
+				"loaded condition must name the same ref its ToJSON embeds")
+		})
+	}
 }

--- a/rulebooks/dnd5e/conditions/martial_arts.go
+++ b/rulebooks/dnd5e/conditions/martial_arts.go
@@ -43,6 +43,10 @@ type MartialArtsCondition struct {
 // Ensure MartialArtsCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*MartialArtsCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (ma *MartialArtsCondition) Ref() *core.Ref { return refs.Conditions.MartialArts() }
+
 // IsApplied returns true if this condition is currently applied
 func (ma *MartialArtsCondition) IsApplied() bool {
 	return ma.bus != nil

--- a/rulebooks/dnd5e/conditions/opportunity_attack.go
+++ b/rulebooks/dnd5e/conditions/opportunity_attack.go
@@ -66,6 +66,10 @@ type OpportunityAttackCondition struct {
 // Ensure OpportunityAttackCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*OpportunityAttackCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (o *OpportunityAttackCondition) Ref() *core.Ref { return refs.Conditions.OpportunityAttack() }
+
 // NewOpportunityAttackCondition creates a new OA condition for the given character.
 // The condition is universal for melee combatants and applied programmatically
 // at encounter setup; it does not require player choice or persistence in

--- a/rulebooks/dnd5e/conditions/prone.go
+++ b/rulebooks/dnd5e/conditions/prone.go
@@ -77,6 +77,10 @@ type ProneCondition struct {
 // Ensure ProneCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*ProneCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (p *ProneCondition) Ref() *core.Ref { return refs.Conditions.Prone() }
+
 // NewProneCondition creates a prone condition for the specified creature.
 //
 // It does not remove itself: prone lasts until something stands the creature up,

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -50,6 +50,10 @@ type RagingCondition struct {
 // Ensure RagingCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*RagingCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (r *RagingCondition) Ref() *core.Ref { return refs.Conditions.Raging() }
+
 // IsApplied returns true if this condition is currently applied
 func (r *RagingCondition) IsApplied() bool {
 	return r.bus != nil

--- a/rulebooks/dnd5e/conditions/reckless_attack.go
+++ b/rulebooks/dnd5e/conditions/reckless_attack.go
@@ -39,6 +39,10 @@ type RecklessAttackCondition struct {
 // Ensure RecklessAttackCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*RecklessAttackCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (r *RecklessAttackCondition) Ref() *core.Ref { return refs.Conditions.RecklessAttack() }
+
 // NewRecklessAttackCondition creates a new reckless attack condition
 func NewRecklessAttackCondition(characterID string) *RecklessAttackCondition {
 	return &RecklessAttackCondition{

--- a/rulebooks/dnd5e/conditions/shield_spell.go
+++ b/rulebooks/dnd5e/conditions/shield_spell.go
@@ -71,6 +71,13 @@ type ShieldSpellCondition struct {
 // Ensure ShieldSpellCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*ShieldSpellCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on. Shield is a spell-named
+// condition; its canonical ref lives under refs.Spells, and it receives Ref()
+// only because the shared interface must stay complete — no magic status,
+// descriptor, resource, or executable offer is added here.
+func (s *ShieldSpellCondition) Ref() *core.Ref { return refs.Spells.Shield() }
+
 // NewShieldSpellCondition creates a Shield condition for the given character.
 // rpg-api Apply()'s this on a character at encounter setup IF the character
 // has Shield prepared. Default readiness is OFF (spell-cost reactions are

--- a/rulebooks/dnd5e/conditions/sneak_attack.go
+++ b/rulebooks/dnd5e/conditions/sneak_attack.go
@@ -51,6 +51,12 @@ type SneakAttackCondition struct {
 // Ensure SneakAttackCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*SneakAttackCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on. Sneak Attack's canonical ref
+// lives under refs.Features (it is a rogue feature turned active condition),
+// so that is what Ref reports.
+func (s *SneakAttackCondition) Ref() *core.Ref { return refs.Features.SneakAttack() }
+
 // SneakAttackInput provides configuration for creating a sneak attack condition
 type SneakAttackInput struct {
 	CharacterID string      // ID of the rogue

--- a/rulebooks/dnd5e/conditions/unarmored_defense.go
+++ b/rulebooks/dnd5e/conditions/unarmored_defense.go
@@ -55,6 +55,10 @@ type UnarmoredDefenseCondition struct {
 // Ensure UnarmoredDefenseCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*UnarmoredDefenseCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (u *UnarmoredDefenseCondition) Ref() *core.Ref { return refs.Conditions.UnarmoredDefense() }
+
 // UnarmoredDefenseInput provides configuration for creating an unarmored defense condition
 type UnarmoredDefenseInput struct {
 	CharacterID string               // ID of the character

--- a/rulebooks/dnd5e/conditions/unarmored_movement.go
+++ b/rulebooks/dnd5e/conditions/unarmored_movement.go
@@ -39,6 +39,10 @@ type UnarmoredMovementCondition struct {
 // Ensure UnarmoredMovementCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*UnarmoredMovementCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (u *UnarmoredMovementCondition) Ref() *core.Ref { return refs.Conditions.UnarmoredMovement() }
+
 // UnarmoredMovementInput provides configuration for creating an unarmored movement condition
 type UnarmoredMovementInput struct {
 	CharacterID string // ID of the character

--- a/rulebooks/dnd5e/conditions/unconscious.go
+++ b/rulebooks/dnd5e/conditions/unconscious.go
@@ -40,6 +40,10 @@ type UnconsciousCondition struct {
 // Ensure UnconsciousCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*UnconsciousCondition)(nil)
 
+// Ref returns the canonical ref this condition names itself by — the same ref
+// its ToJSON embeds and its loader routes on.
+func (c *UnconsciousCondition) Ref() *core.Ref { return refs.Conditions.Unconscious() }
+
 // NewUnconsciousCondition creates a new Unconscious condition for the
 // specified character, using roller for its auto-rolled death saves.
 // Mirrors NewDodgingCondition's constructor pattern; Unconscious additionally

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -105,6 +105,12 @@ const (
 // ConditionBehavior represents the behavior of an active condition.
 // Conditions subscribe to events to modify game mechanics.
 type ConditionBehavior interface {
+	// Ref returns the canonical ref this condition names itself by — the same
+	// ref its ToJSON embeds and its loader routes on (rpg-toolkit#971). A live
+	// condition can now name itself honestly, so a composition never has to
+	// serialize it back to JSON to recover the pairing. Must never return nil.
+	Ref() *core.Ref
+
 	// IsApplied returns true if this condition is currently applied.
 	// Note: Some conditions may allow stacking (multiple applies), others may not.
 	IsApplied() bool

--- a/rulebooks/dnd5e/features/action_surge.go
+++ b/rulebooks/dnd5e/features/action_surge.go
@@ -13,6 +13,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	dnd5eCombat "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
 )
 
 // ActionSurge represents the fighter's Action Surge feature.
@@ -36,6 +37,29 @@ type ActionSurgeData struct {
 
 // Ref returns the unique ref for the Action Surge feature.
 func (a *ActionSurge) Ref() *core.Ref { return refs.Features.ActionSurge() }
+
+// Status reports the feature's privately-owned Action Surge resource through
+// the non-mutating status surface, without serializing ToJSON. The owner is
+// not required: Action Surge owns its own [RecoverableResource].
+func (a *ActionSurge) Status(*StatusInput) (*StatusOutput, error) {
+	if a.resource == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "action surge feature has no resource")
+	}
+	name := a.name
+	if name == "" {
+		name = "Action Surge"
+	}
+	return &StatusOutput{Status: &Status{
+		Ref:  *refs.Features.ActionSurge(),
+		Name: name,
+		Resource: &ResourceStatus{
+			Key:     resources.ActionSurge,
+			Name:    "Action Surge",
+			Current: a.resource.Current(),
+			Maximum: a.resource.Maximum(),
+		},
+	}}, nil
+}
 
 // Name returns the display name for the Action Surge feature.
 func (a *ActionSurge) Name() string { return a.name }

--- a/rulebooks/dnd5e/features/action_surge.go
+++ b/rulebooks/dnd5e/features/action_surge.go
@@ -119,11 +119,16 @@ func (a *ActionSurge) Activate(ctx context.Context, owner core.Entity, input Fea
 	return nil
 }
 
-// loadJSON loads Action Surge state from JSON
+// loadJSON loads Action Surge state from JSON, rejecting negative or
+// over-maximum persisted uses before constructing its private resource.
 func (a *ActionSurge) loadJSON(data json.RawMessage) error {
 	var actionSurgeData ActionSurgeData
 	if err := json.Unmarshal(data, &actionSurgeData); err != nil {
 		return fmt.Errorf("failed to unmarshal action surge data: %w", err)
+	}
+
+	if err := validateResourceBounds("action surge", actionSurgeData.Uses, actionSurgeData.MaxUses); err != nil {
+		return err
 	}
 
 	a.id = actionSurgeData.ID

--- a/rulebooks/dnd5e/features/deflect_missiles.go
+++ b/rulebooks/dnd5e/features/deflect_missiles.go
@@ -42,6 +42,21 @@ type DeflectMissilesData struct {
 // Ref returns the unique ref for the Deflect Missiles feature.
 func (d *DeflectMissiles) Ref() *core.Ref { return refs.Features.DeflectMissiles() }
 
+// Status reports the feature's non-mutating status surface, without
+// serializing ToJSON. Deflect Missiles owns no resource pool — the optional
+// 1-Ki catch-and-throw is paid by the owner at activation, not tracked here —
+// so Resource is nil.
+func (d *DeflectMissiles) Status(*StatusInput) (*StatusOutput, error) {
+	name := d.name
+	if name == "" {
+		name = "Deflect Missiles"
+	}
+	return &StatusOutput{Status: &Status{
+		Ref:  *refs.Features.DeflectMissiles(),
+		Name: name,
+	}}, nil
+}
+
 // Name returns the display name for the Deflect Missiles feature.
 func (d *DeflectMissiles) Name() string { return d.name }
 

--- a/rulebooks/dnd5e/features/flurry_of_blows.go
+++ b/rulebooks/dnd5e/features/flurry_of_blows.go
@@ -35,6 +35,14 @@ type FlurryOfBlowsData struct {
 // Ref returns the unique ref for the Flurry of Blows feature.
 func (f *FlurryOfBlows) Ref() *core.Ref { return refs.Features.FlurryOfBlows() }
 
+// Status reports the monk's character-owned Ki pool through the non-mutating
+// status surface, without serializing ToJSON. Flurry of Blows shares the Ki
+// pool with every other monk Ki feature, so a non-nil [StatusInput.Owner] that
+// carries Ki is required; the key reported is the single shared resources.Ki.
+func (f *FlurryOfBlows) Status(in *StatusInput) (*StatusOutput, error) {
+	return reportKiStatus(in, refs.Features.FlurryOfBlows(), f.name, "Flurry of Blows")
+}
+
 // Name returns the display name for the Flurry of Blows feature.
 func (f *FlurryOfBlows) Name() string { return f.name }
 

--- a/rulebooks/dnd5e/features/loader.go
+++ b/rulebooks/dnd5e/features/loader.go
@@ -16,6 +16,12 @@ type Feature interface {
 	Name() string             // Returns the feature's display name
 	ToJSON() (json.RawMessage, error)
 	ActionType() combat.ActionType // Returns action economy cost to activate
+
+	// StatusProvider reports the feature's non-mutating status surface
+	// (ref, name, optional detail, optional owned resource) without
+	// serializing ToJSON. Embedded so every loadable feature must name itself
+	// honestly for the character StatusView projection (rpg-toolkit#971).
+	StatusProvider
 }
 
 // LoadJSON loads a feature from JSON based on its ref

--- a/rulebooks/dnd5e/features/loader_test.go
+++ b/rulebooks/dnd5e/features/loader_test.go
@@ -53,6 +53,47 @@ func (s *LoaderTestSuite) TestLoadUnknownFeature() {
 	s.T().Skip("Skipping until we have multiple feature types")
 }
 
+func (s *LoaderTestSuite) TestPrivateResourceLoadsRejectInvalidBounds() {
+	tests := []struct {
+		name string
+		data any
+	}{
+		{
+			name: "second wind negative current",
+			data: SecondWindData{Ref: refs.Features.SecondWind(), Uses: -1, MaxUses: 1},
+		},
+		{
+			name: "second wind negative maximum",
+			data: SecondWindData{Ref: refs.Features.SecondWind(), Uses: 0, MaxUses: -1},
+		},
+		{
+			name: "second wind current above maximum",
+			data: SecondWindData{Ref: refs.Features.SecondWind(), Uses: 2, MaxUses: 1},
+		},
+		{
+			name: "action surge negative current",
+			data: ActionSurgeData{Ref: refs.Features.ActionSurge(), Uses: -1, MaxUses: 1},
+		},
+		{
+			name: "action surge negative maximum",
+			data: ActionSurgeData{Ref: refs.Features.ActionSurge(), Uses: 0, MaxUses: -1},
+		},
+		{
+			name: "action surge current above maximum",
+			data: ActionSurgeData{Ref: refs.Features.ActionSurge(), Uses: 2, MaxUses: 1},
+		},
+	}
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			raw, err := json.Marshal(tc.data)
+			s.Require().NoError(err)
+			feature, err := LoadJSON(raw)
+			s.Require().Error(err)
+			s.Nil(feature)
+		})
+	}
+}
+
 func (s *LoaderTestSuite) TestRoundTripThroughJSON() {
 	// Create a rage feature
 	originalRage := newRageForTest("rage-roundtrip", 7)

--- a/rulebooks/dnd5e/features/patient_defense.go
+++ b/rulebooks/dnd5e/features/patient_defense.go
@@ -35,6 +35,14 @@ type PatientDefenseData struct {
 // Ref returns the unique ref for the Patient Defense feature.
 func (p *PatientDefense) Ref() *core.Ref { return refs.Features.PatientDefense() }
 
+// Status reports the monk's character-owned Ki pool through the non-mutating
+// status surface, without serializing ToJSON. Patient Defense shares the Ki
+// pool with every other monk Ki feature; the key reported is the single shared
+// resources.Ki.
+func (p *PatientDefense) Status(in *StatusInput) (*StatusOutput, error) {
+	return reportKiStatus(in, refs.Features.PatientDefense(), p.name, "Patient Defense")
+}
+
 // Name returns the display name for the Patient Defense feature.
 func (p *PatientDefense) Name() string { return p.name }
 

--- a/rulebooks/dnd5e/features/rage.go
+++ b/rulebooks/dnd5e/features/rage.go
@@ -68,6 +68,34 @@ func calculateRageDamage(level int) int {
 // Ref returns the unique ref for the Rage feature.
 func (r *Rage) Ref() *core.Ref { return refs.Features.Rage() }
 
+// Status reports the barbarian's character-owned RageCharges pool through the
+// non-mutating status surface, without serializing ToJSON. Rage does not own
+// its resource — the Character does — so a non-nil [StatusInput.Owner] that
+// carries RageCharges is required.
+func (r *Rage) Status(in *StatusInput) (*StatusOutput, error) {
+	if in == nil || in.Owner == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "rage status requires an owner resource reader")
+	}
+	current, maximum, ok := in.Owner.ResourceStatus(resources.RageCharges)
+	if !ok {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "owner does not carry rage_charges")
+	}
+	name := r.name
+	if name == "" {
+		name = "Rage"
+	}
+	return &StatusOutput{Status: &Status{
+		Ref:  *refs.Features.Rage(),
+		Name: name,
+		Resource: &ResourceStatus{
+			Key:     resources.RageCharges,
+			Name:    "Rage",
+			Current: current,
+			Maximum: maximum,
+		},
+	}}, nil
+}
+
 // Name returns the display name for the Rage feature.
 func (r *Rage) Name() string { return r.name }
 

--- a/rulebooks/dnd5e/features/reckless_attack.go
+++ b/rulebooks/dnd5e/features/reckless_attack.go
@@ -34,6 +34,19 @@ type RecklessAttackData struct {
 // Ref returns the unique ref for the Reckless Attack feature.
 func (r *RecklessAttack) Ref() *core.Ref { return refs.Features.RecklessAttack() }
 
+// Status reports the feature's non-mutating status surface, without
+// serializing ToJSON. Reckless Attack owns no resource, so Resource is nil.
+func (r *RecklessAttack) Status(*StatusInput) (*StatusOutput, error) {
+	name := r.name
+	if name == "" {
+		name = "Reckless Attack"
+	}
+	return &StatusOutput{Status: &Status{
+		Ref:  *refs.Features.RecklessAttack(),
+		Name: name,
+	}}, nil
+}
+
 // Name returns the display name for the Reckless Attack feature.
 func (r *RecklessAttack) Name() string { return r.name }
 

--- a/rulebooks/dnd5e/features/second_wind.go
+++ b/rulebooks/dnd5e/features/second_wind.go
@@ -145,11 +145,16 @@ func (s *SecondWind) Activate(ctx context.Context, owner core.Entity, input Feat
 	return nil
 }
 
-// loadJSON loads Second Wind state from JSON
+// loadJSON loads Second Wind state from JSON, rejecting negative or
+// over-maximum persisted uses before constructing its private resource.
 func (s *SecondWind) loadJSON(data json.RawMessage) error {
 	var secondWindData SecondWindData
 	if err := json.Unmarshal(data, &secondWindData); err != nil {
 		return fmt.Errorf("failed to unmarshal second wind data: %w", err)
+	}
+
+	if err := validateResourceBounds("second wind", secondWindData.Uses, secondWindData.MaxUses); err != nil {
+		return err
 	}
 
 	s.id = secondWindData.ID

--- a/rulebooks/dnd5e/features/second_wind.go
+++ b/rulebooks/dnd5e/features/second_wind.go
@@ -15,6 +15,7 @@ import (
 	dnd5eCombat "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
 )
 
 // SecondWind represents the fighter's Second Wind feature.
@@ -40,6 +41,29 @@ type SecondWindData struct {
 
 // Ref returns the unique ref for the Second Wind feature.
 func (s *SecondWind) Ref() *core.Ref { return refs.Features.SecondWind() }
+
+// Status reports the feature's privately-owned Second Wind resource through
+// the non-mutating status surface, without serializing ToJSON. The owner is
+// not required: Second Wind owns its own [RecoverableResource].
+func (s *SecondWind) Status(*StatusInput) (*StatusOutput, error) {
+	if s.resource == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "second wind feature has no resource")
+	}
+	name := s.name
+	if name == "" {
+		name = "Second Wind"
+	}
+	return &StatusOutput{Status: &Status{
+		Ref:  *refs.Features.SecondWind(),
+		Name: name,
+		Resource: &ResourceStatus{
+			Key:     resources.SecondWind,
+			Name:    "Second Wind",
+			Current: s.resource.Current(),
+			Maximum: s.resource.Maximum(),
+		},
+	}}, nil
+}
 
 // Name returns the display name for the Second Wind feature.
 func (s *SecondWind) Name() string { return s.name }

--- a/rulebooks/dnd5e/features/status.go
+++ b/rulebooks/dnd5e/features/status.go
@@ -98,6 +98,18 @@ type StatusProvider interface {
 // feature's own ref and name. A Ki feature without an owner, or whose owner
 // does not carry Ki, is a malformed sheet — the projection fails loudly
 // rather than dropping the feature.
+func validateResourceBounds(feature string, current, maximum int) error {
+	if current < 0 || maximum < 0 {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"%s resource has negative bounds: current=%d maximum=%d", feature, current, maximum)
+	}
+	if current > maximum {
+		return rpgerr.Newf(rpgerr.CodeInvalidArgument,
+			"%s resource current %d exceeds maximum %d", feature, current, maximum)
+	}
+	return nil
+}
+
 func reportKiStatus(in *StatusInput, ref *core.Ref, name, defaultName string) (*StatusOutput, error) {
 	if in == nil || in.Owner == nil {
 		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "ki feature status requires an owner resource reader")

--- a/rulebooks/dnd5e/features/status.go
+++ b/rulebooks/dnd5e/features/status.go
@@ -1,0 +1,122 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package features
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+)
+
+// ResourceReader reads a single owned resource's current and maximum through
+// the owner (a Character) — the narrow, non-mutating surface a feature uses to
+// report a pool it shares with its owner, such as a monk's Ki or a barbarian's
+// RageCharges. It never exposes the resource store or its persistence, so a
+// projection built on [Status] never has to serialize a feature's ToJSON to
+// discover uses.
+type ResourceReader interface {
+	// ResourceStatus returns the current and maximum for one resource key.
+	// ok is false when the owner does not carry that resource.
+	ResourceStatus(key coreResources.ResourceKey) (current, maximum int, ok bool)
+}
+
+// StatusInput carries the owner a feature asks about a shared resource. The
+// owner is optional for features that own their resource privately
+// ([SecondWind], [ActionSurge]) and required for features that share a
+// character-owned pool (Rage, Flurry of Blows, Patient Defense, Step of the
+// Wind).
+type StatusInput struct {
+	// Owner reads the shared resource pools the feature consumes from but
+	// does not store. Nil is valid only for features with no shared resource.
+	Owner ResourceReader
+}
+
+// ResourceStatus is the immutable projection of one owned resource: its stable
+// key, display name, and current/maximum counts. It is a value, not a live
+// handle — mutating the owner after reading does not change a previously
+// returned ResourceStatus.
+type ResourceStatus struct {
+	// Key is the stable, opaque core/resources.ResourceKey the web joins to
+	// display the resource. It is never derived from a name.
+	Key coreResources.ResourceKey
+
+	// Name is the resource's display name. Never empty.
+	Name string
+
+	// Current is the currently available amount.
+	Current int
+
+	// Maximum is the resource's capacity.
+	Maximum int
+}
+
+// Status is the immutable, non-mutating status surface one feature exposes:
+// its canonical ref, a display name that is never empty, optional
+// server-authored detail, and an optional owned resource. It is the value a
+// character StatusView (Task 4) deduplicates by resource key and refuses to
+// conflict on. No feature serializes ToJSON to produce one.
+type Status struct {
+	// Ref is the feature's canonical ref — the same ref its ToJSON embeds and
+	// its loader routes on.
+	Ref core.Ref
+
+	// Name is the feature's display name. Never empty.
+	Name string
+
+	// Detail is server/toolkit-composed display text. May be empty; a name is
+	// the minimum a status ever reports.
+	Detail string
+
+	// Resource is the optional owned resource the feature reports. Nil for
+	// features that own no resource (Reckless Attack, Deflect Missiles).
+	Resource *ResourceStatus
+}
+
+// StatusOutput wraps [Status] for the [StatusProvider] contract. A pointer so
+// the projection can tell "the feature reported nothing" (nil) from "the
+// feature reported a status with no resource" (non-nil, Resource nil).
+type StatusOutput struct {
+	Status *Status
+}
+
+// StatusProvider reports a feature's non-mutating status surface: its
+// canonical ref, display name, optional server-authored detail, and an
+// optional owned resource. It is the composition point a character StatusView
+// (Task 4) builds from — and it never serializes ToJSON to read status.
+// [Feature] embeds it so every loadable feature must name itself honestly.
+type StatusProvider interface {
+	// Status returns the feature's immutable status. A feature that shares a
+	// character-owned resource requires a non-nil [StatusInput.Owner]; a
+	// feature with no shared resource ignores the owner.
+	Status(*StatusInput) (*StatusOutput, error)
+}
+
+// reportKiStatus is the shared body of every monk Ki feature's Status: it
+// reads the single shared Ki pool from the owner and reports it under the
+// feature's own ref and name. A Ki feature without an owner, or whose owner
+// does not carry Ki, is a malformed sheet — the projection fails loudly
+// rather than dropping the feature.
+func reportKiStatus(in *StatusInput, ref *core.Ref, name, defaultName string) (*StatusOutput, error) {
+	if in == nil || in.Owner == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "ki feature status requires an owner resource reader")
+	}
+	current, maximum, ok := in.Owner.ResourceStatus(resources.Ki)
+	if !ok {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "owner does not carry ki")
+	}
+	if name == "" {
+		name = defaultName
+	}
+	return &StatusOutput{Status: &Status{
+		Ref:  *ref,
+		Name: name,
+		Resource: &ResourceStatus{
+			Key:     resources.Ki,
+			Name:    "Ki",
+			Current: current,
+			Maximum: maximum,
+		},
+	}}, nil
+}

--- a/rulebooks/dnd5e/features/status_test.go
+++ b/rulebooks/dnd5e/features/status_test.go
@@ -1,0 +1,168 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package features
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+)
+
+// stubResourceReader is a minimal ResourceReader for tests: it hands back
+// fixed current/maximum values for the keys it knows, and reports not-found
+// (ok=false) for anything else. It never touches persistence JSON.
+type stubResourceReader struct {
+	values map[coreResources.ResourceKey][2]int // current, maximum
+}
+
+func (r stubResourceReader) ResourceStatus(key coreResources.ResourceKey) (int, int, bool) {
+	v, ok := r.values[key]
+	if !ok {
+		return 0, 0, false
+	}
+	return v[0], v[1], true
+}
+
+func TestSecondWindStatusReportsPrivateResourceWithoutJSON(t *testing.T) {
+	sw := newSecondWindForTest("second-wind-feature", 3, "fighter-1")
+
+	out, err := sw.Status(&StatusInput{})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.Status)
+
+	assert.Equal(t, *refs.Features.SecondWind(), out.Status.Ref, "ref must be the canonical SecondWind ref")
+	assert.NotEmpty(t, out.Status.Name, "name must never be empty")
+	assert.Empty(t, out.Status.Detail, "detail is server-authored and may be empty")
+
+	require.NotNil(t, out.Status.Resource, "Second Wind owns a private resource")
+	assert.Equal(t, resources.SecondWind, out.Status.Resource.Key)
+	assert.Equal(t, "Second Wind", out.Status.Resource.Name)
+	assert.Equal(t, 1, out.Status.Resource.Current)
+	assert.Equal(t, 1, out.Status.Resource.Maximum)
+}
+
+func TestActionSurgeStatusReportsPrivateResourceWithoutJSON(t *testing.T) {
+	as := &ActionSurge{
+		id:          refs.Features.ActionSurge().ID,
+		name:        "Action Surge",
+		characterID: "fighter-1",
+		resource: combat.NewRecoverableResource(combat.RecoverableResourceConfig{
+			ID:          refs.Features.ActionSurge().ID,
+			Maximum:     1,
+			CharacterID: "fighter-1",
+			ResetType:   coreResources.ResetShortRest,
+		}),
+	}
+
+	out, err := as.Status(&StatusInput{})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.Status)
+
+	assert.Equal(t, *refs.Features.ActionSurge(), out.Status.Ref)
+	assert.NotEmpty(t, out.Status.Name)
+
+	require.NotNil(t, out.Status.Resource)
+	assert.Equal(t, resources.ActionSurge, out.Status.Resource.Key)
+	assert.Equal(t, "Action Surge", out.Status.Resource.Name)
+	assert.Equal(t, 1, out.Status.Resource.Current)
+	assert.Equal(t, 1, out.Status.Resource.Maximum)
+}
+
+func TestKiFeaturesReportOneSharedResourceKey(t *testing.T) {
+	owner := stubResourceReader{values: map[coreResources.ResourceKey][2]int{
+		resources.Ki: {3, 5},
+	}}
+
+	flurry := &FlurryOfBlows{id: "flurry", name: "Flurry of Blows", characterID: "monk-1"}
+	patient := &PatientDefense{id: "patient", name: "Patient Defense", characterID: "monk-1"}
+	step := &StepOfTheWind{id: "step", name: "Step of the Wind", characterID: "monk-1"}
+
+	for _, tc := range []struct {
+		name    string
+		feature StatusProvider
+		ref     core.Ref
+	}{
+		{"flurry_of_blows", flurry, *refs.Features.FlurryOfBlows()},
+		{"patient_defense", patient, *refs.Features.PatientDefense()},
+		{"step_of_the_wind", step, *refs.Features.StepOfTheWind()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.feature.Status(&StatusInput{Owner: owner})
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			require.NotNil(t, out.Status)
+
+			assert.Equal(t, tc.ref, out.Status.Ref)
+			assert.NotEmpty(t, out.Status.Name)
+
+			require.NotNil(t, out.Status.Resource, "Ki features report the shared Ki pool")
+			assert.Equal(t, resources.Ki, out.Status.Resource.Key)
+			assert.Equal(t, "Ki", out.Status.Resource.Name)
+			assert.Equal(t, 3, out.Status.Resource.Current)
+			assert.Equal(t, 5, out.Status.Resource.Maximum)
+		})
+	}
+}
+
+func TestKiFeatureStatusErrorsWithoutOwner(t *testing.T) {
+	flurry := &FlurryOfBlows{id: "flurry", name: "Flurry of Blows", characterID: "monk-1"}
+
+	_, err := flurry.Status(&StatusInput{})
+	require.Error(t, err)
+}
+
+func TestRageStatusReportsOwnerOwnedRageCharges(t *testing.T) {
+	owner := stubResourceReader{values: map[coreResources.ResourceKey][2]int{
+		resources.RageCharges: {2, 4},
+	}}
+
+	rage := &Rage{id: "rage", name: "Rage", level: 5}
+
+	out, err := rage.Status(&StatusInput{Owner: owner})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+	require.NotNil(t, out.Status)
+
+	assert.Equal(t, *refs.Features.Rage(), out.Status.Ref)
+	assert.NotEmpty(t, out.Status.Name)
+
+	require.NotNil(t, out.Status.Resource)
+	assert.Equal(t, resources.RageCharges, out.Status.Resource.Key)
+	assert.Equal(t, 2, out.Status.Resource.Current)
+	assert.Equal(t, 4, out.Status.Resource.Maximum)
+}
+
+func TestResourcelessFeaturesReportNoResource(t *testing.T) {
+	reckless := &RecklessAttack{id: "reckless", name: "Reckless Attack", characterID: "barbarian-1"}
+	deflect := &DeflectMissiles{id: "deflect", name: "Deflect Missiles", characterID: "monk-1"}
+
+	for _, tc := range []struct {
+		name    string
+		feature StatusProvider
+		ref     core.Ref
+	}{
+		{"reckless_attack", reckless, *refs.Features.RecklessAttack()},
+		{"deflect_missiles", deflect, *refs.Features.DeflectMissiles()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := tc.feature.Status(&StatusInput{})
+			require.NoError(t, err)
+			require.NotNil(t, out)
+			require.NotNil(t, out.Status)
+
+			assert.Equal(t, tc.ref, out.Status.Ref)
+			assert.NotEmpty(t, out.Status.Name)
+			assert.Nil(t, out.Status.Resource, "this feature owns no resource")
+		})
+	}
+}

--- a/rulebooks/dnd5e/features/step_of_the_wind.go
+++ b/rulebooks/dnd5e/features/step_of_the_wind.go
@@ -36,6 +36,14 @@ type StepOfTheWindData struct {
 // Ref returns the unique ref for the Step of the Wind feature.
 func (s *StepOfTheWind) Ref() *core.Ref { return refs.Features.StepOfTheWind() }
 
+// Status reports the monk's character-owned Ki pool through the non-mutating
+// status surface, without serializing ToJSON. Step of the Wind shares the Ki
+// pool with every other monk Ki feature; the key reported is the single shared
+// resources.Ki.
+func (s *StepOfTheWind) Status(in *StatusInput) (*StatusOutput, error) {
+	return reportKiStatus(in, refs.Features.StepOfTheWind(), s.name, "Step of the Wind")
+}
+
 // Name returns the display name for the Step of the Wind feature.
 func (s *StepOfTheWind) Name() string { return s.name }
 

--- a/rulebooks/dnd5e/monster/load_test.go
+++ b/rulebooks/dnd5e/monster/load_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
@@ -226,6 +227,7 @@ type liveMonsterCondition struct {
 	applied bool
 }
 
+func (c *liveMonsterCondition) Ref() *core.Ref  { return refs.Conditions.Prone() }
 func (c *liveMonsterCondition) IsApplied() bool { return c.applied }
 func (c *liveMonsterCondition) Apply(_ context.Context, _ events.EventBus) error {
 	c.applied = true

--- a/rulebooks/dnd5e/monstertraits/immunity.go
+++ b/rulebooks/dnd5e/monstertraits/immunity.go
@@ -37,6 +37,10 @@ type immunityCondition struct {
 // Ensure immunityCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*immunityCondition)(nil)
 
+// Ref returns the canonical ref this trait names itself by — the same ref its
+// ToJSON embeds and its loader routes on.
+func (i *immunityCondition) Ref() *core.Ref { return refs.MonsterTraits.Immunity() }
+
 // Immunity creates a new immunity trait that reduces damage of the specified type to 0
 func Immunity(ownerID string, damageType damage.Type) dnd5eEvents.ConditionBehavior {
 	return &immunityCondition{

--- a/rulebooks/dnd5e/monstertraits/pack_tactics.go
+++ b/rulebooks/dnd5e/monstertraits/pack_tactics.go
@@ -37,6 +37,10 @@ type packTacticsCondition struct {
 // Ensure packTacticsCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*packTacticsCondition)(nil)
 
+// Ref returns the canonical ref this trait names itself by — the same ref its
+// ToJSON embeds and its loader routes on.
+func (p *packTacticsCondition) Ref() *core.Ref { return refs.MonsterTraits.PackTactics() }
+
 // PackTactics creates a new pack tactics trait
 func PackTactics(ownerID string) dnd5eEvents.ConditionBehavior {
 	return &packTacticsCondition{

--- a/rulebooks/dnd5e/monstertraits/undead_fortitude.go
+++ b/rulebooks/dnd5e/monstertraits/undead_fortitude.go
@@ -36,6 +36,10 @@ type undeadFortitudeCondition struct {
 // Ensure undeadFortitudeCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*undeadFortitudeCondition)(nil)
 
+// Ref returns the canonical ref this trait names itself by — the same ref its
+// ToJSON embeds and its loader routes on.
+func (u *undeadFortitudeCondition) Ref() *core.Ref { return refs.MonsterTraits.UndeadFortitude() }
+
 // UndeadFortitude creates a new undead fortitude trait.
 // When damage would reduce the creature to 0 HP, it makes a CON save (DC = 5 + damage taken).
 // On success, the creature drops to 1 HP instead.

--- a/rulebooks/dnd5e/monstertraits/vulnerability.go
+++ b/rulebooks/dnd5e/monstertraits/vulnerability.go
@@ -37,6 +37,10 @@ type vulnerabilityCondition struct {
 // Ensure vulnerabilityCondition implements dnd5eEvents.ConditionBehavior
 var _ dnd5eEvents.ConditionBehavior = (*vulnerabilityCondition)(nil)
 
+// Ref returns the canonical ref this trait names itself by — the same ref its
+// ToJSON embeds and its loader routes on.
+func (v *vulnerabilityCondition) Ref() *core.Ref { return refs.MonsterTraits.Vulnerability() }
+
 // Vulnerability creates a new vulnerability trait that doubles damage of the specified type
 func Vulnerability(ownerID string, damageType damage.Type) dnd5eEvents.ConditionBehavior {
 	return &vulnerabilityCondition{

--- a/rulebooks/dnd5e/resolution/surface_test.go
+++ b/rulebooks/dnd5e/resolution/surface_test.go
@@ -23,6 +23,9 @@ import (
 // behaviour it will rely on.
 type quietEffect struct{}
 
+func (quietEffect) Ref() *core.Ref {
+	return &core.Ref{Module: "dnd5e", Type: "conditions", ID: "quiet"}
+}
 func (quietEffect) IsApplied() bool                                   { return true }
 func (quietEffect) Apply(_ context.Context, _ events.EventBus) error  { return nil }
 func (quietEffect) Remove(_ context.Context, _ events.EventBus) error { return nil }

--- a/rulebooks/dnd5e/resources/keys.go
+++ b/rulebooks/dnd5e/resources/keys.go
@@ -44,24 +44,23 @@ const (
 	ActionSurge coreResources.ResourceKey = "action_surge"
 )
 
-// DisplayName returns the rulebook-owned display name for a resource key.
-// It is the single source of truth for how a resource surfaces in a status
-// view: the character projection never trusts a feature's reported name over
-// this mapping. Unknown keys fall back to their raw string so a future key is
-// still readable, but the four builds only ever carry the named keys below.
-func DisplayName(key coreResources.ResourceKey) string {
+// DisplayName returns the rulebook-owned display name for a resource key and
+// whether that key belongs to the closed owner-private status catalog. Unknown
+// keys return ("", false); they never fall back to raw persistence bytes and
+// therefore cannot become valid-looking status rows by accident.
+func DisplayName(key coreResources.ResourceKey) (string, bool) {
 	switch key {
 	case RageCharges:
-		return "Rage"
+		return "Rage", true
 	case Ki:
-		return "Ki"
+		return "Ki", true
 	case HitDice:
-		return "Hit Dice"
+		return "Hit Dice", true
 	case SecondWind:
-		return "Second Wind"
+		return "Second Wind", true
 	case ActionSurge:
-		return "Action Surge"
+		return "Action Surge", true
 	default:
-		return string(key)
+		return "", false
 	}
 }

--- a/rulebooks/dnd5e/resources/keys.go
+++ b/rulebooks/dnd5e/resources/keys.go
@@ -43,3 +43,25 @@ const (
 	// Recovered on short rest. Used by: Action Surge.
 	ActionSurge coreResources.ResourceKey = "action_surge"
 )
+
+// DisplayName returns the rulebook-owned display name for a resource key.
+// It is the single source of truth for how a resource surfaces in a status
+// view: the character projection never trusts a feature's reported name over
+// this mapping. Unknown keys fall back to their raw string so a future key is
+// still readable, but the four builds only ever carry the named keys below.
+func DisplayName(key coreResources.ResourceKey) string {
+	switch key {
+	case RageCharges:
+		return "Rage"
+	case Ki:
+		return "Ki"
+	case HitDice:
+		return "Hit Dice"
+	case SecondWind:
+		return "Second Wind"
+	case ActionSurge:
+		return "Action Surge"
+	default:
+		return string(key)
+	}
+}

--- a/rulebooks/dnd5e/resources/keys.go
+++ b/rulebooks/dnd5e/resources/keys.go
@@ -28,4 +28,18 @@ const (
 	// Recovered on long rest: regain half of maximum (minimum 1).
 	// Used by: Short rest healing
 	HitDice coreResources.ResourceKey = "hit_dice"
+
+	// SecondWind is the fighter's Second Wind feature pool, owned privately by
+	// the SecondWind feature object rather than by Character.resources. The
+	// feature reports it through its non-mutating Status surface so a projection
+	// never has to serialize the feature's persistence JSON to read uses.
+	// Recovered on short rest. Used by: Second Wind.
+	SecondWind coreResources.ResourceKey = "second_wind"
+
+	// ActionSurge is the fighter's Action Surge feature pool, owned privately by
+	// the ActionSurge feature object rather than by Character.resources. The
+	// feature reports it through its non-mutating Status surface so a projection
+	// never has to serialize the feature's persistence JSON to read uses.
+	// Recovered on short rest. Used by: Action Surge.
+	ActionSurge coreResources.ResourceKey = "action_surge"
 )

--- a/rulebooks/dnd5e/resources/keys_test.go
+++ b/rulebooks/dnd5e/resources/keys_test.go
@@ -1,0 +1,35 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resources
+
+import (
+	"testing"
+
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDisplayNameIsClosedToTheStatusCatalog(t *testing.T) {
+	tests := []struct {
+		key  coreResources.ResourceKey
+		name string
+	}{
+		{RageCharges, "Rage"},
+		{Ki, "Ki"},
+		{HitDice, "Hit Dice"},
+		{SecondWind, "Second Wind"},
+		{ActionSurge, "Action Surge"},
+	}
+	for _, tc := range tests {
+		t.Run(string(tc.key), func(t *testing.T) {
+			name, ok := DisplayName(tc.key)
+			require.True(t, ok)
+			require.Equal(t, tc.name, name)
+		})
+	}
+
+	name, ok := DisplayName(coreResources.ResourceKey("spell_slots"))
+	require.False(t, ok)
+	require.Empty(t, name, "unknown keys must not become valid-looking display names")
+}

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -207,18 +207,22 @@ type AffordOutput struct {
 // [compileOffers] assembles and prices one Attack definition, clones the
 // actual SpendProfile into Definition.Cost before hashing it, and asks
 // [combat.CanPay] against the same readied sheet execution will regenerate.
-// Attack then selects and reuses that compiled definition, price, sheet, and
-// shared target preflight. Move likewise reuses its compiled readied sheet;
-// EndTurn compiles from the clock alone.
+// It also gathers and strictly preflights one raw resolution cast. Attack then
+// selects and reuses that compiled definition, price, sheet, shared target
+// preflight, and exact raw cast without refetching participants. Move likewise
+// reuses its compiled readied sheet; EndTurn compiles from the clock alone.
 //
 // # The full current gate
 //
 // The clock-active comparison precedes every sheet load and blocks all three
 // verbs. Downed and unreadable dependencies are then applied per verb: Attack
-// and Move need a standing, readable actor; EndTurn needs only its real clock
-// gate. Candidate and budget failures keep a compiled Attack with a selector
-// and exact reasons, but mark it unavailable; execution treats an echoed
-// now-unavailable selector as [ErrStaleDeclaration].
+// and Move need a standing, readable actor; Attack additionally needs every
+// resolution participant to load and attach strictly; EndTurn needs only its
+// real clock gate. An unreadable candidate keeps its row with Unreadable, while
+// an unreadable cast dependency disables Attack globally without erasing other
+// candidate reach facts. Candidate and budget failures keep a compiled Attack
+// with a selector and exact reasons, but mark it unavailable; execution treats
+// an echoed now-unavailable selector as [ErrStaleDeclaration].
 //
 // # Reads, and reads only
 //
@@ -233,7 +237,10 @@ type AffordOutput struct {
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
 // ErrNoEncounter, or ErrNoMember if the member is not in this encounter.
 // Missing/unreadable actor sheets and attacks are projected as per-verb
-// Unreadable blockers rather than failing the whole read. Returns ErrBadCost if
+// Unreadable blockers rather than failing the whole read. Missing/unreadable
+// resolution participants make the compiled Attack unavailable; target
+// candidates carry their own Unreadable reason and non-target dependencies
+// produce the declaration-level one. Returns ErrBadCost if
 // the rulebook cannot compile this member's own price. Returns a wrapped error
 // when a live candidate holds no position in the roster: a live-sight holding
 // whose subject the encounter no longer places is an internal inconsistency
@@ -290,7 +297,7 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 	// repository reads. EndTurn remains clock-only when that actor is downed or
 	// unreadable.
 	actor := m.loadActorSheet(ctx, in.Member)
-	offers, err := m.compileOffers(ctx, enc, data, in.Member, clock, actor)
+	offers, err := m.compileOffers(ctx, enc, data, in.Session, in.Member, clock, actor)
 	if err != nil {
 		return nil, fmt.Errorf("afford: %w", err)
 	}

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -8,11 +8,9 @@ import (
 	"fmt"
 
 	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
-	"github.com/KirkDiggler/rpg-toolkit/play/intel"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
-	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 // AffordInput asks what one member can still declare this turn.
@@ -78,8 +76,9 @@ const (
 	SlotReaction Slot = "reaction"
 )
 
-// Declaration is one verb this member could still declare this turn, and
-// whether they can pay for it.
+// Declaration is one server-compiled action/cost variant a member could
+// still declare this turn, and whether every gate applicable to it currently
+// passes. Mirrors the merged proto's Declaration (rpg-project#272/273).
 //
 // DECLARATIONS, NOT REMAINING CURRENCIES — Kirk's ruling on rpg-toolkit#1138:
 // "backend tells dumb client what it can do." A read that answered
@@ -90,6 +89,13 @@ const (
 // has, CAN I DO THIS, and keeps the arithmetic where it has always lived:
 // server-side, behind [combat.SpendProfile]. See
 // docs/adr/0042-afford-answers-in-declarations-not-currencies.md.
+//
+// ONE COMPILED OFFER PER VERB, not one declaration per target: the candidate
+// universe lives on the single Attack declaration's Candidates, each carrying
+// its own target-specific availability. The client renders availability,
+// identity, target kind, and candidates verbatim and never derives game rules;
+// Attack, Move, and End Turn regenerate the selected offer before execution
+// (Task 7).
 type Declaration struct {
 	// Verb is which seam action this prices.
 	Verb Verb `json:"verb"`
@@ -100,74 +106,62 @@ type Declaration struct {
 	// what an action buys changes this automatically.
 	Slot Slot `json:"slot"`
 
-	// Affordable is whether the member could pay for this verb right now.
-	//
-	// NO OMITEMPTY. False is an ANSWER, not an absence — the same
+	// Available is whether every gate applicable to this verb currently
+	// passes. NO OMITEMPTY: false is an ANSWER, not an absence — the same
 	// false-vs-absent law every other bool at this seam keeps (types.go).
-	// Absence of information is instead Declarations being empty, on the
-	// world clock, where the question does not apply at all.
-	Affordable bool `json:"affordable"`
-
-	// Shortfall names what ran out, in the SAME words a refused Attack would
-	// use — "action: 1 needed, 0 left" — because a client that cannot repeat
-	// a refusal in the player's own words has been handed a boolean and
-	// nothing else. Empty when Affordable.
+	// Absence of the question is instead Declarations being empty, on the
+	// world clock, where the economy does not apply at all.
 	//
-	// NO OMITEMPTY, for the same reason Affordable has none: an empty string
-	// beside affordable:true is itself the answer ("nothing ran out"), not
-	// the absence of one, and a non-Go client reading a missing key cannot
-	// tell that from "the server didn't say".
-	//
-	// KEPT FOR OLDER READERS; SUPERSEDED BY Why. This is the same text as
-	// Why.Text — a producer that sets one sets both (rpg-toolkit#1010). A
-	// new reader takes Why, the structured form it can branch on, and never
-	// this.
-	Shortfall string `json:"shortfall"`
-
-	// Target is the candidate this declaration prices, for VerbAttack. ONE
-	// DECLARATION PER TARGET IN REACH (rpg-project#249 §6, Kirk): Afford
-	// gates each candidate through the same reach check Attack refuses
-	// with (melee one cell, the reach property two; ranged stays refused
-	// as today, rpg-toolkit#1010) and emits one declaration for each
-	// target that passes. That list IS the client's "enemies in reach"
-	// highlight — reach is never computed client-side, it is read off
-	// these. When NO candidate is in reach the seam still answers, once: a
-	// single ATTACK declaration with Affordable false, Why.Reason
-	// ShortfallNoTargetInReach, and this field unset.
-	//
-	// A POINTER, not an omitted empty string: a MOVE declaration has no
-	// target at all, and the no-target-in-reach ATTACK declaration has
-	// none either — neither is a target whose id happens to be empty.
-	//
-	// Further strikes are FURTHER DECLARATIONS of this same shape, not new
-	// fields: a monk's Martial Arts bonus strike is
-	// {VerbAttack, SlotBonus, target}; an off-hand swing and a flurry
-	// likewise. Nil for VerbMove.
-	Target *string `json:"target,omitempty"`
-
-	// Why is the structured reason this is unaffordable, present exactly
-	// when Affordable is false — the same presence law Remaining keeps for
-	// "this verb carries no such number": absence beside Affordable true is
-	// itself the answer ("nothing ran out"). Carries the same text
-	// Shortfall does, plus the reason and the figures a UI acts on.
-	// Lands with rpg-toolkit#1010.
-	Why *Shortfall `json:"why,omitempty"`
+	// For Attack, Available requires the global budget gate AND at least one
+	// candidate in reach; the global budget reason takes precedence over the
+	// no-target-in-reach reason at the declaration level. For Move, Available
+	// is whether any step at all is still possible. For EndTurn, Available is
+	// the clock/turn gate alone.
+	Available bool `json:"available"`
 
 	// Remaining is how much of this verb's own currency is left, in the
 	// currency's natural unit — feet, for Move (rpg-toolkit#1169).
 	//
-	// PRESENT ONLY WHERE THE NUMBER MEANS SOMETHING BEYOND CAN-OR-CANNOT.
-	// Attack's declaration has never needed one — a swing either happens or
-	// it does not — but a client walking Move wants to bound its own path
-	// preview to the server's real number rather than re-deriving a
-	// character's speed itself, which is exactly the calculation the
-	// Boundary Rule keeps off the client. Nil for VerbAttack.
-	//
-	// A POINTER, not an omitted zero: false-vs-absent for an int rather than
-	// a bool (types.go's law, generalised) — Remaining:0 is a real answer
-	// (nothing left this turn) and must not collide with "this verb carries
-	// no such number at all".
+	// PRESENT ONLY FOR VERB_MOVE. Attack and EndTurn carry no such number — a
+	// swing either happens or it does not, and EndTurn has no currency — so
+	// the field is nil for them. A POINTER, not an omitted zero: false-vs-absent
+	// for an int (types.go's law, generalised) — Remaining:0 is a real answer
+	// (nothing left this turn) and must not collide with "this verb carries no
+	// such number at all".
 	Remaining *int `json:"remaining,omitempty"`
+
+	// Why is the structured reason this declaration is unavailable, present
+	// if and only if Available is false — the same presence law Remaining
+	// keeps for "this verb carries no such number": absence beside Available
+	// true is itself the answer ("nothing ran out"). Carries the reason and
+	// the figures a UI acts on; the server owns refusal precedence. For
+	// Attack, NoBudget takes precedence over NoTargetInReach at the
+	// declaration level, and NoTargetInReach does not remove candidate rows.
+	Why *Shortfall `json:"why,omitempty"`
+
+	// ID is the opaque deterministic selector for this current compiled
+	// offer. Non-empty on every compiled Attack, turn-clock Move, and EndTurn
+	// declaration; empty on an early per-verb blocker. The client echoes it
+	// and never parses it.
+	ID string `json:"id"`
+
+	// Attack is the sole public Attack identity. Present on every compiled
+	// Attack declaration — including one disabled by budget or target gates,
+	// which still carries its compiled ref — and absent for Move, EndTurn,
+	// and early per-verb blockers.
+	Attack *AttackRef `json:"attack,omitempty"`
+
+	// TargetKind is fixed for every compiled or blocked declaration: Attack
+	// -> TargetMember, Move -> TargetPath, EndTurn -> TargetNone. A blocker
+	// keeps the fixed kind even with empty candidates, so a client always
+	// knows which selector shape the verb carries.
+	TargetKind TargetKind `json:"target_kind"`
+
+	// Candidates is every member in the ruled candidate universe exactly
+	// once, including unavailable targets and their server-authored
+	// reasons. ShortfallNoTargetInReach does not remove these rows. Empty
+	// (non-nil) for Move, EndTurn, and early per-verb blockers.
+	Candidates []TargetCandidate `json:"candidates"`
 }
 
 // AffordOutput is what one member can still declare this turn.
@@ -177,9 +171,9 @@ type AffordOutput struct {
 	// and that IS the answer rather than a shorter way of asking again.
 	Clock ClockKind `json:"clock"`
 
-	// Declarations is one entry per verb the seam prices, empty on the world
-	// clock — where empty IS the answer rather than a shorter way of asking
-	// again, so it is never omitted from the wire either: the same
+	// Declarations is one entry per compiled verb the seam prices, empty on
+	// the world clock — where empty IS the answer rather than a shorter way
+	// of asking again, so it is never omitted from the wire either: the same
 	// false-vs-absent law types.go keeps for every bool at this seam applies
 	// here to the list itself. A non-Go client must read "declarations": [],
 	// not a missing key that reads as "the server didn't say".
@@ -251,7 +245,10 @@ type AffordOutput struct {
 // and has no loadable sheet — reachable for a monster or a malformed record,
 // since a character already in a fight has one by construction. Returns
 // ErrBadCost if the rulebook cannot compile this member's own price, which
-// [Manager.Attack] would also refuse the same way.
+// [Manager.Attack] would also refuse the same way. Returns a wrapped error
+// when a live candidate holds no position in the roster: a live-sight holding
+// whose subject the encounter no longer places is an internal inconsistency
+// this read fails closed on rather than silently omitting the candidate.
 func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("afford: %w", ErrNilInput)
@@ -286,11 +283,16 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 	// loaded, so a refusal this early never reads a sheet at all). The
 	// same clock-active comparison Attack's own gate makes
 	// (rpg-toolkit#1010/#249) — announced here BEFORE a caller ever tries
-	// the verb, which is Afford's whole point.
+	// the verb, which is Afford's whole point. NotYourTurn blocks ALL THREE
+	// verbs the same way, so the sheet is never loaded for a member whose
+	// turn it is not.
 	if string(clock.Active) != in.Member {
-		return &AffordOutput{Clock: ClockTurn, Declarations: blockedDeclarations(Shortfall{
-			Reason: ShortfallNotYourTurn, Text: "not your turn",
-		})}, nil
+		notYourTurn := Shortfall{Reason: ShortfallNotYourTurn, Text: "not your turn"}
+		return &AffordOutput{Clock: ClockTurn, Declarations: []Declaration{
+			blockedDeclaration(VerbAttack, TargetMember, notYourTurn),
+			blockedDeclaration(VerbMove, TargetPath, notYourTurn),
+			blockedDeclaration(VerbEndTurn, TargetNone, notYourTurn),
+		}}, nil
 	}
 
 	// DOWNED, asked only once we know this member is even the one the
@@ -298,190 +300,44 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 	// order and can never be active, so NotYourTurn already covers a
 	// downed BYSTANDER — this is the specific fact a client renders
 	// differently ("you are down" versus "wait your turn") for the member
-	// who somehow is still active despite being down.
+	// who somehow is still active despite being down. Downed blocks
+	// Attack/Move but EndTurn follows the clock alone, so EndTurn is still
+	// compiled below even when the member is downed.
 	standing := m.standingFor(ctx, data)
 	down, err := standing.Standing([]encounter.MemberID{encounter.MemberID(in.Member)})
 	if err != nil {
 		return nil, fmt.Errorf("afford: %w", err)
 	}
-	if len(down) > 0 {
-		return &AffordOutput{Clock: ClockTurn, Declarations: blockedDeclarations(Shortfall{
-			Reason: ShortfallDowned, Text: "member is downed",
-		})}, nil
-	}
+	downed := len(down) > 0
 
-	// UNREADABLE: the same compile Attack's own door runs, so the two
-	// cannot disagree about whether a swing exists to price at all
-	// (rpg-toolkit#1168's other half — ADR-0042 scoped this out, amended
-	// here). ErrBadCharacter (no sheet, or bytes that will not
-	// reconstitute) stays a hard failure, exactly as before: there is no
-	// sheet to answer ANYTHING about, attack or movement. ErrBadAttack —
-	// a sheet that loads fine but names a weapon this build cannot
-	// compile — becomes a declaration instead of a failed read, so the
-	// rest of a UI's turn panel still renders.
-	sheet, err := m.loadAttackSheet(ctx, in.Member)
-	if err != nil {
-		return nil, fmt.Errorf("afford: %w", err)
-	}
-	definition, err := character.AssembleAttack(sheet, &character.AssembleAttackInput{Slot: character.SlotMainHand})
-	if err != nil {
-		badAttack := fmt.Errorf("member %q: %w: %v", in.Member, ErrBadAttack, err)
-		return &AffordOutput{Clock: ClockTurn, Declarations: blockedDeclarations(Shortfall{
-			Reason: ShortfallUnreadable, Text: badAttack.Error(),
-		})}, nil
-	}
-
-	price, err := m.priceSwing(ctx, enc, in.Member, sheet)
+	offers, err := m.compileOffers(ctx, enc, data, in.Member, clock, downed)
 	if err != nil {
 		return nil, fmt.Errorf("afford: %w", err)
 	}
 
-	// price.cost is never nil here: priceSwing returns a nil cost only when
-	// the member is on the world clock, already ruled out above.
-	slot := slotOf(price.cost.Profile)
-
-	// Charged ONCE against the sheet THIS CALL loaded, which is handed to
-	// nobody else and never saved (see the doc comment above). combat.Pay is
-	// the SAME gate Attack's door pays through, so a payment that succeeds
-	// or fails here answers exactly as Attack's would — and it answers the
-	// SAME way for every target below: affordability is an economy
-	// question, not a geometry one, so it is asked once and shared rather
-	// than re-paid per candidate (which would also double-spend the sheet
-	// this call loaded).
-	affordable := true
-	var why *Shortfall
-	if payErr := combat.Pay(sheet, price.cost.Profile); payErr != nil {
-		affordable = false
-		sf := shortfallForPay(sheet, price.cost.Profile, slot)
-		why = &sf
+	declarations := make([]Declaration, 0, len(offers))
+	for _, o := range offers {
+		declarations = append(declarations, o.declaration)
 	}
-
-	roster, err := enc.Members()
-	if err != nil {
-		return nil, fmt.Errorf("afford: %w", translate(err))
-	}
-	positions := rosterPositions(roster)
-
-	holdings, err := enc.View(&encounter.ViewInput{Member: encounter.MemberID(in.Member)})
-	if err != nil {
-		return nil, fmt.Errorf("afford: %w", translate(err))
-	}
-
-	attackDecls := attackDeclarationsFor(enc, positions, holdings, in.Member, slot, definition.Attack.Delivery.MaxRangeFeet(), affordable, why)
-
-	// affordMove reads the SAME sheet, already readied for this turn by
-	// priceSwing's own call above — never a second ready, which would
-	// re-seed a bank the attack declarations just read. Safe to share: an
-	// attack's profile never names CapacityMovement, so paying it above
-	// cannot have moved what affordMove is about to read.
-	return &AffordOutput{
-		Clock:        ClockTurn,
-		Declarations: append(attackDecls, affordMove(sheet)),
-	}, nil
+	sortDeclarations(declarations)
+	return &AffordOutput{Clock: ClockTurn, Declarations: declarations}, nil
 }
 
-// blockedDeclarations answers both of a turn's verbs the same way, for a
-// reason that blocks the whole turn rather than one price: downed, not your
-// turn, or a sheet this build cannot compile. Neither verb's own numbers
-// mean anything against a member who cannot act at all, so both report the
-// SAME Shortfall rather than one going on to compute a real (and
-// misleading) answer for the other.
-func blockedDeclarations(why Shortfall) []Declaration {
-	return []Declaration{
-		{Verb: VerbAttack, Slot: SlotNone, Affordable: false, Shortfall: why.Text, Why: &why},
-		{Verb: VerbMove, Slot: SlotNone, Affordable: false, Shortfall: why.Text, Why: &why},
+// blockedDeclaration is the shape every early per-verb blocker emits:
+// available false, why present, empty id, absent attack, empty candidates,
+// and the fixed target kind for the verb. It never carries a selector id or an
+// AttackRef — those belong to a compiled offer, and a blocker has not
+// compiled one.
+func blockedDeclaration(verb Verb, kind TargetKind, why Shortfall) Declaration {
+	return Declaration{
+		Verb:       verb,
+		Slot:       SlotNone,
+		Available:  false,
+		Why:        &why,
+		ID:         "",
+		TargetKind: kind,
+		Candidates: []TargetCandidate{},
 	}
-}
-
-// attackDeclarationsFor builds one ATTACK declaration per candidate the
-// member currently, live, perceives (holdings whose CurrentVia is
-// non-empty — a memory of somebody no longer in sight is not somebody this
-// member could swing at right now) and who stands within the attack's maximum
-// range in feet. Every declaration shares the SAME affordable/why the economy
-// already decided; what varies per declaration is only the target and whether
-// that maximum-range check passed.
-//
-// NO CANDIDATE IN REACH IS STILL AN ANSWER (rpg-toolkit#1010, rpg-project#249
-// §6): a single declaration with no Target, Affordable false and
-// Why.Reason ShortfallNoTargetInReach — never an empty list, which a client
-// could mistake for "nothing to ask about yet" rather than "nothing is
-// close enough."
-func attackDeclarationsFor(
-	enc *encounter.Encounter, positions map[string]spatial.Position, holdings []intel.Holding,
-	member string, slot Slot, maxRangeFeet int, affordable bool, why *Shortfall,
-) []Declaration {
-	from := positions[member]
-
-	var out []Declaration
-	for _, h := range holdings {
-		subject := string(h.Subject)
-		if subject == member || len(h.CurrentVia) == 0 {
-			continue
-		}
-		to, ok := positions[subject]
-		if !ok || !inRange(enc, from, to, maxRangeFeet) {
-			continue
-		}
-		target := subject
-		out = append(out, Declaration{
-			Verb: VerbAttack, Slot: slot, Target: &target, Affordable: affordable, Why: why,
-			Shortfall: shortfallText(why),
-		})
-	}
-
-	if len(out) == 0 {
-		noTarget := Shortfall{Reason: ShortfallNoTargetInReach, Text: "no target in reach"}
-		return []Declaration{{
-			Verb: VerbAttack, Slot: slot, Affordable: false,
-			Shortfall: noTarget.Text, Why: &noTarget,
-		}}
-	}
-	return out
-}
-
-// shortfallText reads Why.Text, or the empty string for a nil Why — the
-// same value Declaration.Shortfall has always carried, kept in step with
-// Why by construction rather than set separately at each call site.
-func shortfallText(why *Shortfall) string {
-	if why == nil {
-		return ""
-	}
-	return why.Text
-}
-
-// affordMove reports what this member could still spend on movement this
-// turn, off the sheet [Manager.Afford] already loaded and readied above.
-//
-// UNLIKE ATTACK, movement has no fixed price to try paying: what a specific
-// walk costs is a fact about the PATH ([Manager.priceWalk]), and Afford is
-// asked before any path is chosen. So this answers the question Afford CAN
-// answer without one. Remaining is the actual feet left — the number a
-// client bounds its own path preview against — and Affordable answers only
-// whether ANY movement at all is still possible: one cell, five feet, the
-// smallest unit this grid has. Shortfall, when it applies, says so in the
-// same "ft" words [movementShortfall] gives a refused Move, minus a "needed"
-// side this read has no specific request to name.
-func affordMove(sheet *character.Character) Declaration {
-	left := sheet.CapacityLeft(combat.CapacityMovement)
-	decl := Declaration{Verb: VerbMove, Slot: SlotNone, Remaining: &left}
-	if left >= 5 {
-		decl.Affordable = true
-		return decl
-	}
-	why := Shortfall{
-		Reason: ShortfallNoBudget, Currency: CurrencyMovement,
-		// Needed names the smallest step this grid has (five feet, one
-		// cell) rather than a specific request's cost: unlike Attack's
-		// fixed action price, a walk's cost is a fact about a PATH this
-		// read is never given (Declaration.Remaining's own doc), so
-		// "needed" can only say how much the least possible move would
-		// take.
-		Needed: 5, Left: left,
-		Text: fmt.Sprintf("movement: %d ft left", left),
-	}
-	decl.Shortfall = why.Text
-	decl.Why = &why
-	return decl
 }
 
 // currencyOfSlot maps a lit shape onto the ledger word a NoBudget shortfall

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -94,8 +94,7 @@ const (
 // universe lives on the single Attack declaration's Candidates, each carrying
 // its own target-specific availability. The client renders availability,
 // identity, target kind, and candidates verbatim and never derives game rules;
-// Attack, Move, and End Turn regenerate the selected offer before execution
-// (Task 7).
+// Attack, Move, and End Turn regenerate the selected offer before execution.
 type Declaration struct {
 	// Verb is which seam action this prices.
 	Verb Verb `json:"verb"`
@@ -180,21 +179,17 @@ type AffordOutput struct {
 	Declarations []Declaration `json:"declarations"`
 }
 
-// Afford reports what one member can still declare this turn: which of the
-// seam's gated verbs they could pay for right now, and — when they cannot —
-// the same currency-naming text a refused [Manager.Attack] or [Manager.Move]
-// would carry. Move's own declaration (VerbMove, rpg-toolkit#1169) reports
-// Remaining rather than a fixed price, since a walk's cost depends on a path
-// this read is never given — see [affordMove].
+// Afford reports the current compiled Attack, Move, and EndTurn offers for one
+// active turn member. Each carries an opaque selector execution must echo.
+// Move reports Remaining rather than a fixed price because a walk's cost
+// depends on a path this read is never given. On the world clock declarations
+// is the complete empty answer.
 //
 // # The gap this closes
 //
-// Attack refuses a swing nobody can pay for with [ErrCannotAfford], and the
-// refusal is careful to name the currency that ran out. Nothing on the seam
-// said so BEFORE the refusal. A turn UI built against that has exactly two
-// options: offer the button and let the server say no, or re-derive 5e's
-// economy client-side — a level-1 fighter gets one swing, Extra Attack lands
-// at level 5 — which is the Boundary Rule violation this whole seam exists to
+// Without this read a turn UI has exactly two options: offer every button and
+// discover refusals after clicks, or re-derive 5e's economy and target rules
+// client-side. The latter is the Boundary Rule violation this seam exists to
 // prevent. See rpg-toolkit#1138.
 //
 // # A declaration, not the remaining currencies
@@ -209,25 +204,21 @@ type AffordOutput struct {
 //
 // # The same price Attack pays, never a second copy of it
 //
-// This does not reprice the swing by a second route. It calls the identical
-// [Manager.priceSwing] a real swing compiles from, then charges that price
-// through [combat.Pay] — the SAME gate [Manager.Attack]'s door pays through —
-// against a [character.Character] loaded fresh for this call and never saved.
-// A payment that succeeds answers Affordable; one that fails hands back the
-// exact text a refused Attack's door would have produced, because it IS that
-// text: nothing here reimplements what a currency needs or what ran out. If
-// Attack and Afford could ever disagree, one of them would be pricing wrong,
-// and routing both through one gate call is what makes that impossible by
-// construction rather than merely tested for.
+// [compileOffers] assembles and prices one Attack definition, clones the
+// actual SpendProfile into Definition.Cost before hashing it, and asks
+// [combat.CanPay] against the same readied sheet execution will regenerate.
+// Attack then selects and reuses that compiled definition, price, sheet, and
+// shared target preflight. Move likewise reuses its compiled readied sheet;
+// EndTurn compiles from the clock alone.
 //
-// # The economy's answer, not the turn's
+// # The full current gate
 //
-// Attack does not check whose turn it currently is — nothing on this seam
-// does yet, [Manager.EndTurn] aside — so this does not either. Whether a swing
-// would ALSO be refused for arriving out of turn is [Manager.Turn]'s question:
-// folding "not your turn" into a Shortfall here would answer a question this
-// read was never asked, in a currency it does not price. A future turn gate
-// belongs beside Turn's own Active field, not inside a Declaration.
+// The clock-active comparison precedes every sheet load and blocks all three
+// verbs. Downed and unreadable dependencies are then applied per verb: Attack
+// and Move need a standing, readable actor; EndTurn needs only its real clock
+// gate. Candidate and budget failures keep a compiled Attack with a selector
+// and exact reasons, but mark it unavailable; execution treats an echoed
+// now-unavailable selector as [ErrStaleDeclaration].
 //
 // # Reads, and reads only
 //
@@ -241,11 +232,9 @@ type AffordOutput struct {
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
 // ErrNoEncounter, or ErrNoMember if the member is not in this encounter.
-// Returns ErrNoCharacter or ErrBadCharacter if the member is on the turn clock
-// and has no loadable sheet — reachable for a monster or a malformed record,
-// since a character already in a fight has one by construction. Returns
-// ErrBadCost if the rulebook cannot compile this member's own price, which
-// [Manager.Attack] would also refuse the same way. Returns a wrapped error
+// Missing/unreadable actor sheets and attacks are projected as per-verb
+// Unreadable blockers rather than failing the whole read. Returns ErrBadCost if
+// the rulebook cannot compile this member's own price. Returns a wrapped error
 // when a live candidate holds no position in the roster: a live-sight holding
 // whose subject the encounter no longer places is an internal inconsistency
 // this read fails closed on rather than silently omitting the candidate.

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -284,22 +284,13 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 		}}, nil
 	}
 
-	// DOWNED, asked only once we know this member is even the one the
-	// clock is waiting on: a downed member is spliced out of the turn
-	// order and can never be active, so NotYourTurn already covers a
-	// downed BYSTANDER — this is the specific fact a client renders
-	// differently ("you are down" versus "wait your turn") for the member
-	// who somehow is still active despite being down. Downed blocks
-	// Attack/Move but EndTurn follows the clock alone, so EndTurn is still
-	// compiled below even when the member is downed.
-	standing := m.standingFor(ctx, data)
-	down, err := standing.Standing([]encounter.MemberID{encounter.MemberID(in.Member)})
-	if err != nil {
-		return nil, fmt.Errorf("afford: %w", err)
-	}
-	downed := len(down) > 0
-
-	offers, err := m.compileOffers(ctx, enc, data, in.Member, clock, downed)
+	// Attack and Move compile from one strict actor snapshot. loadActorSheet
+	// asks combat.IsDown on that loaded sheet before reading any offer
+	// material, so the blocker and the declaration cannot disagree across two
+	// repository reads. EndTurn remains clock-only when that actor is downed or
+	// unreadable.
+	actor := m.loadActorSheet(ctx, in.Member)
+	offers, err := m.compileOffers(ctx, enc, data, in.Member, clock, actor)
 	if err != nil {
 		return nil, fmt.Errorf("afford: %w", err)
 	}

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -204,7 +204,7 @@ type AffordOutput struct {
 //
 // # The same price Attack pays, never a second copy of it
 //
-// [compileOffers] assembles and prices one Attack definition, clones the
+// [Manager.compileOffersFor] assembles and prices one Attack definition, clones the
 // actual SpendProfile into Definition.Cost before hashing it, and asks
 // [combat.CanPay] against the same readied sheet execution will regenerate.
 // It also gathers and strictly preflights one raw resolution cast. Attack then
@@ -297,7 +297,10 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 	// repository reads. EndTurn remains clock-only when that actor is downed or
 	// unreadable.
 	actor := m.loadActorSheet(ctx, in.Member)
-	offers, err := m.compileOffers(ctx, enc, data, in.Session, in.Member, clock, actor)
+	offers, err := m.compileOffersFor(
+		ctx, enc, data, in.Session, in.Member, clock, actor,
+		VerbAttack, VerbMove, VerbEndTurn,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("afford: %w", err)
 	}

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -45,6 +45,13 @@ const (
 	// clock. Free-roam movement is not priced and so never appears here —
 	// see [Manager.Afford]'s own doc.
 	VerbMove Verb = "move"
+
+	// VerbEndTurn is [Manager.EndTurn]: ending the member's turn. Like Move it
+	// carries no authored action definition, so its declaration selector uses a
+	// sealed variant string rather than a serialized [actions.Definition].
+	// Spelled here so the declaration selector's verb byte is owned by the seam
+	// that prices it, not borrowed from the rulebook's action vocabulary.
+	VerbEndTurn Verb = "end_turn"
 )
 
 // Slot names which of a turn's three economy shapes a [Declaration] draws

--- a/rulebooks/dnd5e/session/afford_test.go
+++ b/rulebooks/dnd5e/session/afford_test.go
@@ -70,6 +70,7 @@ func (s *AffordSuite) attackDecl(out *session.AffordOutput) session.Declaration 
 func (s *AffordSuite) swing() (*session.AttackOutput, error) {
 	return s.mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "skeleton",
+		DeclarationID: currentAttackID(s.T(), s.mgr, "sess", "alice"),
 	})
 }
 
@@ -81,7 +82,10 @@ func (s *AffordSuite) nextTurn() {
 	s.T().Helper()
 	ctx := context.Background()
 
-	_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{
+		Session: "sess", Member: "alice",
+		DeclarationID: currentEndTurnID(s.T(), s.mgr, "sess", "alice"),
+	})
 	s.Require().NoError(err, "ending alice's turn")
 }
 
@@ -143,9 +147,8 @@ func (s *AffordSuite) TestUnavailableMeansAttackRefusesWithTheSameShortfall() {
 
 	_, err = s.swing()
 	s.Require().Error(err, "and there is nothing left to buy a second")
-	s.ErrorIs(err, session.ErrCannotAfford)
-	s.Contains(err.Error(), decl.Why.Text,
-		"Afford's Why.Text must be the SAME currency text the refusal carries, not a second copy of it")
+	s.ErrorIs(err, session.ErrStaleDeclaration,
+		"a now-unavailable echoed offer is stale before resolution's payment door")
 }
 
 // TestBankedSwingIsAvailableAndLightsNoSlot walks Extra Attack's second
@@ -188,8 +191,7 @@ func (s *AffordSuite) TestExtraAttacksThirdSwingIsUnavailable() {
 
 	_, err = s.swing()
 	s.Require().Error(err)
-	s.ErrorIs(err, session.ErrCannotAfford)
-	s.Contains(err.Error(), decl.Why.Text)
+	s.ErrorIs(err, session.ErrStaleDeclaration)
 }
 
 // TestANewTurnRefillsWhatAffordSees is TestANewTurnRefillsTheBank's own claim,
@@ -301,6 +303,7 @@ func (s *AffordSuite) TestNoTargetInReachIsOneAttackDeclarationNotZero() {
 	// contact (encEveryoneSees keeps sight unlimited), just too far to swing.
 	_, err := mgr.Move(context.Background(), &session.MoveInput{
 		Session: "sess", Member: "alice", Path: pathAwayFromSkeleton(),
+		DeclarationID: currentMoveID(s.T(), mgr, "sess", "alice"),
 	})
 	// alice may not be active in every roll of aFight's own initiative, so a
 	// refusal here would mean this fixture cannot walk — fail loudly rather

--- a/rulebooks/dnd5e/session/afford_test.go
+++ b/rulebooks/dnd5e/session/afford_test.go
@@ -52,6 +52,21 @@ func (s *AffordSuite) afford() *session.AffordOutput {
 	return out
 }
 
+// attackDecl returns the single Attack declaration, failing if there is not
+// exactly one.
+func (s *AffordSuite) attackDecl(out *session.AffordOutput) session.Declaration {
+	s.T().Helper()
+	var attack *session.Declaration
+	for i := range out.Declarations {
+		if out.Declarations[i].Verb == session.VerbAttack {
+			s.Require().Nil(attack, "expected exactly one Attack declaration")
+			attack = &out.Declarations[i]
+		}
+	}
+	s.Require().NotNil(attack, "expected exactly one Attack declaration")
+	return *attack
+}
+
 func (s *AffordSuite) swing() (*session.AttackOutput, error) {
 	return s.mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "skeleton",
@@ -79,34 +94,36 @@ func (s *AffordSuite) storedEconomy() *character.ActionEconomyData {
 	return stored.ActionEconomy
 }
 
-// TestAffordableMeansAttackWillNotRefuse is half the load-bearing invariant:
-// Affordable == true implies a following Attack in the same state is NOT
+// TestAvailableMeansAttackWillNotRefuse is half the load-bearing invariant:
+// Available == true implies a following Attack in the same state is NOT
 // refused with ErrCannotAfford.
 //
 // A fresh turn's first swing is the case: nothing has been spent yet, so
 // there is nothing for either verb to disagree about.
-func (s *AffordSuite) TestAffordableMeansAttackWillNotRefuse() {
+func (s *AffordSuite) TestAvailableMeansAttackWillNotRefuse() {
 	s.fightScene(1, 15, 5, 1, 1)
 
 	out := s.afford()
 	s.Equal(session.ClockTurn, out.Clock)
-	s.Require().Len(out.Declarations, 2, "attack and move (rpg-toolkit#1169)")
+	s.Require().Len(out.Declarations, 3, "attack, move and end turn")
 
-	decl := out.Declarations[0]
-	s.Equal(session.VerbAttack, decl.Verb)
-	s.True(decl.Affordable, "a fresh turn can still buy its first swing")
-	s.Empty(decl.Shortfall, "affordable carries no shortfall")
+	decl := s.attackDecl(out)
+	s.True(decl.Available, "a fresh turn can still buy its first swing")
+	s.Nil(decl.Why, "available carries no shortfall")
 	s.Equal(session.SlotAction, decl.Slot, "the first swing of a turn lights the action shape")
+	s.NotEmpty(decl.ID, "a compiled Attack carries a selector ID")
+	s.NotNil(decl.Attack, "a compiled Attack carries its AttackRef")
+	s.Equal(session.TargetMember, decl.TargetKind)
 
 	_, err := s.swing()
 	s.Require().NoError(err, "Afford said yes, so Attack must not refuse with ErrCannotAfford")
 }
 
-// TestUnaffordableMeansAttackRefusesWithTheSameShortfall is the other half:
-// Affordable == false implies a following Attack IS refused with
-// ErrCannotAfford, and Shortfall is the same currency text inside that
+// TestUnavailableMeansAttackRefusesWithTheSameShortfall is the other half:
+// Available == false implies a following Attack IS refused with
+// ErrCannotAfford, and Why.Text is the same currency text inside that
 // refusal — not a paraphrase of it.
-func (s *AffordSuite) TestUnaffordableMeansAttackRefusesWithTheSameShortfall() {
+func (s *AffordSuite) TestUnavailableMeansAttackRefusesWithTheSameShortfall() {
 	s.fightScene(1, 15, 5, 1, 1)
 
 	first, err := s.swing()
@@ -114,32 +131,36 @@ func (s *AffordSuite) TestUnaffordableMeansAttackRefusesWithTheSameShortfall() {
 	s.Require().True(first.Hit)
 
 	out := s.afford()
-	s.Require().Len(out.Declarations, 2, "attack and move (rpg-toolkit#1169)")
-	decl := out.Declarations[0]
-	s.False(decl.Affordable, "nothing left to buy a second swing")
-	s.NotEmpty(decl.Shortfall, "false carries a reason")
+	s.Require().Len(out.Declarations, 3, "attack, move and end turn")
+	decl := s.attackDecl(out)
+	s.False(decl.Available, "nothing left to buy a second swing")
+	s.Require().NotNil(decl.Why)
+	s.NotEmpty(decl.Why.Text, "false carries a reason")
 	s.Equal(session.SlotAction, decl.Slot, "the currency that ran out is the action slot")
+	s.NotEmpty(decl.ID, "a compiled Attack keeps its selector ID even when the budget fails")
+	s.NotNil(decl.Attack, "a compiled Attack keeps its AttackRef even when the budget fails")
+	s.NotEmpty(decl.Candidates, "the candidate rows remain alongside the budget refusal")
 
 	_, err = s.swing()
 	s.Require().Error(err, "and there is nothing left to buy a second")
 	s.ErrorIs(err, session.ErrCannotAfford)
-	s.Contains(err.Error(), decl.Shortfall,
-		"Afford's Shortfall must be the SAME currency text the refusal carries, not a second copy of it")
+	s.Contains(err.Error(), decl.Why.Text,
+		"Afford's Why.Text must be the SAME currency text the refusal carries, not a second copy of it")
 }
 
-// TestBankedSwingIsAffordableAndLightsNoSlot walks Extra Attack's second
-// swing (the brief's own required fixture): affordable, and Slot is SlotNone
+// TestBankedSwingIsAvailableAndLightsNoSlot walks Extra Attack's second
+// swing (the brief's own required fixture): available, and Slot is SlotNone
 // because a banked swing spends only capacity, never a per-turn slot.
-func (s *AffordSuite) TestBankedSwingIsAffordableAndLightsNoSlot() {
+func (s *AffordSuite) TestBankedSwingIsAvailableAndLightsNoSlot() {
 	s.fightScene(5, 1, 1, 1, 1)
 
 	_, err := s.swing()
 	s.Require().NoError(err, "swing 1, bought by the Attack action")
 
 	out := s.afford()
-	decl := out.Declarations[0]
-	s.True(decl.Affordable, "extra attack banked a second swing")
-	s.Empty(decl.Shortfall)
+	decl := s.attackDecl(out)
+	s.True(decl.Available, "extra attack banked a second swing")
+	s.Nil(decl.Why)
 	s.Equal(session.SlotNone, decl.Slot,
 		"a banked swing spends capacity alone — nothing lights the action/bonus/reaction shapes")
 
@@ -147,10 +168,10 @@ func (s *AffordSuite) TestBankedSwingIsAffordableAndLightsNoSlot() {
 	s.Require().NoError(err, "Afford said yes, so Attack must not refuse")
 }
 
-// TestExtraAttacksThirdSwingIsUnaffordable is the same scene's other end: once
+// TestExtraAttacksThirdSwingIsUnavailable is the same scene's other end: once
 // the bank Extra Attack granted is spent, the action itself has also already
 // been spent, and Afford must say so.
-func (s *AffordSuite) TestExtraAttacksThirdSwingIsUnaffordable() {
+func (s *AffordSuite) TestExtraAttacksThirdSwingIsUnavailable() {
 	s.fightScene(5, 1, 1, 1, 1, 1, 1)
 
 	_, err := s.swing()
@@ -159,15 +180,16 @@ func (s *AffordSuite) TestExtraAttacksThirdSwingIsUnaffordable() {
 	s.Require().NoError(err, "swing 2, bought by Extra Attack")
 
 	out := s.afford()
-	decl := out.Declarations[0]
-	s.False(decl.Affordable, "the bank Extra Attack granted is spent")
-	s.Contains(decl.Shortfall, "action",
+	decl := s.attackDecl(out)
+	s.False(decl.Available, "the bank Extra Attack granted is spent")
+	s.Require().NotNil(decl.Why)
+	s.Contains(decl.Why.Text, "action",
 		"the action itself ran out too — it was spent buying the bank on swing 1")
 
 	_, err = s.swing()
 	s.Require().Error(err)
 	s.ErrorIs(err, session.ErrCannotAfford)
-	s.Contains(err.Error(), decl.Shortfall)
+	s.Contains(err.Error(), decl.Why.Text)
 }
 
 // TestANewTurnRefillsWhatAffordSees is TestANewTurnRefillsTheBank's own claim,
@@ -179,19 +201,19 @@ func (s *AffordSuite) TestANewTurnRefillsWhatAffordSees() {
 
 	_, err := s.swing()
 	s.Require().NoError(err)
-	s.False(s.afford().Declarations[0].Affordable, "spent, on turn one")
+	s.False(s.attackDecl(s.afford()).Available, "spent, on turn one")
 
 	s.nextTurn()
 
 	out := s.afford()
-	s.Require().Len(out.Declarations, 2, "attack and move (rpg-toolkit#1169)")
-	s.True(out.Declarations[0].Affordable, "a new turn buys a new swing")
-	s.Equal(session.SlotAction, out.Declarations[0].Slot)
+	s.Require().Len(out.Declarations, 3, "attack, move and end turn")
+	s.True(s.attackDecl(out).Available, "a new turn buys a new swing")
+	s.Equal(session.SlotAction, s.attackDecl(out).Slot)
 }
 
 // TestFreeRoamAffordsNothing is TestFreeRoamChargesNothing's own claim, asked
 // of Afford: a member with no bubble has no economy to report, and the answer
-// is EMPTY, not a Declaration reporting Affordable:true for a free action —
+// is EMPTY, not a Declaration reporting Available:true for a free action —
 // the two would look identical on a boolean and mean different things about
 // why nothing is spent.
 func (s *AffordSuite) TestFreeRoamAffordsNothing() {
@@ -227,7 +249,7 @@ func (s *AffordSuite) TestAffordSavesNothing() {
 	s.Nil(s.storedEconomy(), "a stored sheet starts cold: no economy at all")
 
 	before := s.afford()
-	s.True(before.Declarations[0].Affordable)
+	s.True(s.attackDecl(before).Available)
 	s.Nil(s.storedEconomy(),
 		"asking what alice can afford must not light and persist her turn — a read that ignited "+
 			"the ledger on the way to answering would make asking indistinguishable from swinging")
@@ -241,12 +263,12 @@ func (s *AffordSuite) TestAffordSavesNothing() {
 		"asking again must not touch the sheet the real swing already wrote")
 }
 
-// TestOneDeclarationPerTargetInReach pins rpg-toolkit#1010/rpg-project#249
-// §6: a second monster within reach earns its OWN attack declaration rather
-// than being folded into — or silently excluded from — the first's. Each
-// carries the SAME affordable/slot the economy already decided; only Target
-// varies.
-func (s *AffordSuite) TestOneDeclarationPerTargetInReach() {
+// TestAttackDeclarationCarriesEveryCandidateInReach pins rpg-toolkit#1010/
+// rpg-project#249 §6's reshape: a second monster within reach earns its own
+// candidate row on the single Attack declaration rather than a second
+// declaration. Each candidate carries the SAME slot the economy decided; only
+// the member varies.
+func (s *AffordSuite) TestAttackDeclarationCarriesEveryCandidateInReach() {
 	s.fightScene(1, 15, 5, 1, 1)
 
 	_, err := s.mgr.Spawn(context.Background(), &session.SpawnInput{
@@ -255,26 +277,22 @@ func (s *AffordSuite) TestOneDeclarationPerTargetInReach() {
 	})
 	s.Require().NoError(err)
 
-	out := s.afford()
-	var targets []string
-	attackDecls := 0
-	for _, d := range out.Declarations {
-		if d.Verb != session.VerbAttack {
-			continue
-		}
-		attackDecls++
-		s.Require().NotNil(d.Target, "a declaration naming a real candidate always names it")
-		targets = append(targets, *d.Target)
-		s.True(d.Affordable)
+	attack := s.attackDecl(s.afford())
+	s.ElementsMatch([]string{"skeleton", "skeleton-2"}, candidateIDs(attack.Candidates))
+	for _, c := range attack.Candidates {
+		s.True(c.Available, "every in-reach candidate is available")
+		s.Nil(c.Why)
 	}
-	s.Equal(2, attackDecls, "one declaration per target in reach, not one for the fight")
-	s.ElementsMatch([]string{"skeleton", "skeleton-2"}, targets)
+	s.True(attack.Available)
+	s.Equal(session.SlotAction, attack.Slot)
 }
 
-// TestNoTargetInReachIsOneDeclarationNotZero pins the other half: nothing in
-// reach still answers, once — never an empty attack-declaration list a
-// client could mistake for "nothing to ask about yet."
-func (s *AffordSuite) TestNoTargetInReachIsOneDeclarationNotZero() {
+// TestNoTargetInReachIsOneAttackDeclarationNotZero pins the other half:
+// nothing in reach still answers, once — never an empty attack-declaration
+// list a client could mistake for "nothing to ask about yet." The candidate
+// row remains, each carrying its own target-specific verdict, while the
+// declaration-level Why is NoTargetInReach.
+func (s *AffordSuite) TestNoTargetInReachIsOneAttackDeclarationNotZero() {
 	alice := armedFighter("alice")
 	mgr, _, _, _ := aFight(s.T(), alice, []int{1, 1})
 	s.mgr = mgr
@@ -292,18 +310,14 @@ func (s *AffordSuite) TestNoTargetInReachIsOneDeclarationNotZero() {
 	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)
 
-	var attackDecls []session.Declaration
-	for _, d := range out.Declarations {
-		if d.Verb == session.VerbAttack {
-			attackDecls = append(attackDecls, d)
-		}
-	}
-	s.Require().Len(attackDecls, 1, "one declaration, not zero, when nothing is in reach")
-	decl := attackDecls[0]
-	s.False(decl.Affordable)
-	s.Nil(decl.Target)
-	s.Require().NotNil(decl.Why)
-	s.Equal(session.ShortfallNoTargetInReach, decl.Why.Reason)
+	attack := s.attackDecl(out)
+	s.False(attack.Available)
+	s.Require().NotNil(attack.Why)
+	s.Equal(session.ShortfallNoTargetInReach, attack.Why.Reason)
+	s.Require().Len(attack.Candidates, 1, "the candidate row remains, even out of reach")
+	s.False(attack.Candidates[0].Available)
+	s.Require().NotNil(attack.Candidates[0].Why)
+	s.Equal(session.ShortfallTargetOutOfReach, attack.Candidates[0].Why.Reason)
 }
 
 // pathAwayFromSkeleton walks alice five cells from her spawn (1,1), well
@@ -315,7 +329,7 @@ func pathAwayFromSkeleton() []spatial.Position {
 }
 
 // TestShortfallCarriesTheStructuredCurrency pins rpg-toolkit#1010's other
-// half of #1138's own case: Why is not just Text repeated — Reason, Currency,
+// half of #1138's own case: Why is not just text — Reason, Currency,
 // Needed and Left are the figures a UI acts on, agreeing with Text by
 // construction.
 func (s *AffordSuite) TestShortfallCarriesTheStructuredCurrency() {
@@ -324,14 +338,13 @@ func (s *AffordSuite) TestShortfallCarriesTheStructuredCurrency() {
 	_, err := s.swing()
 	s.Require().NoError(err, "spends the action")
 
-	out := s.afford()
-	decl := out.Declarations[0]
+	decl := s.attackDecl(s.afford())
 	s.Require().NotNil(decl.Why)
 	s.Equal(session.ShortfallNoBudget, decl.Why.Reason)
 	s.Equal(session.CurrencyAction, decl.Why.Currency)
 	s.Equal(1, decl.Why.Needed)
 	s.Equal(0, decl.Why.Left)
-	s.Equal(decl.Shortfall, decl.Why.Text, "Shortfall and Why.Text must agree")
+	s.NotEmpty(decl.Why.Text)
 }
 
 // TestNotYourTurnIsAnnouncedByAfford is the seam's own promise: a client
@@ -375,9 +388,12 @@ func (s *AffordSuite) TestNotYourTurnIsAnnouncedByAfford() {
 	out, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "bob"})
 	s.Require().NoError(err)
 	s.Equal(session.ClockTurn, out.Clock)
-	s.Require().Len(out.Declarations, 2, "attack and move, both blocked the same way")
+	s.Require().Len(out.Declarations, 3, "attack, move and end turn, all blocked the same way")
 	for _, d := range out.Declarations {
-		s.False(d.Affordable)
+		s.False(d.Available)
+		s.Empty(d.ID, "a blocker carries no selector ID")
+		s.Nil(d.Attack)
+		s.Empty(d.Candidates)
 		s.Require().NotNil(d.Why)
 		s.Equal(session.ShortfallNotYourTurn, d.Why.Reason)
 	}

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
@@ -31,8 +30,13 @@ type AttackInput struct {
 	// Attacker is who swings. Required.
 	Attacker string
 
-	// Target is who they swing at. Required.
+	// Target is who they swing at. Required, and must be an available member
+	// candidate on the selected current declaration.
 	Target string
+
+	// DeclarationID is the opaque current Attack selector returned by Afford.
+	// Required. The client echoes it and never parses it.
+	DeclarationID string
 }
 
 // AttackOutput is what the swing produced.
@@ -83,29 +87,30 @@ type AttackOutput struct {
 // which is its caller, and it earns its shape then. The same discipline
 // [DissolveCause] uses for defeat.
 //
-// Main hand, one-handed, melee. Two-handed grips and the off-hand swing are the
-// compiler's own named gaps, and they did NOT arrive with the economy the way
-// this paragraph used to predict: the economy decides how many swings a turn
-// buys, and what a two-handed grip does to one is a question for whoever
-// compiles the attack rather than for whoever prices it.
+// Main hand with the compiler's authored delivery profile. Off-hand variants
+// remain a named gap; two-handed and ranged semantics come from the selected
+// definition rather than from this seam.
 //
 // # A swing costs something, in a fight
 //
 // A character in a fight pays for the swing before it is resolved: the first in
 // a turn takes the Attack action, and what that action banks is what the swings
 // after it spend. A level-1 fighter therefore gets one swing per turn and a
-// level-5 fighter gets two, and the swing after that is refused with
-// [ErrCannotAfford] naming the currency that ran out.
+// level-5 fighter gets two. Afford reports the exhausted offer with its exact
+// NoBudget shortfall; attempting to execute that now-unavailable selector is
+// [ErrStaleDeclaration] before resolution. [ErrCannotAfford] remains the
+// defensive payment-door translation if state changes beneath that final gate.
 //
-// The price is compiled here and charged by resolution's door after pure
-// machine preflight and before its first executable step — so a refused swing
-// rolls nothing, damages nobody, and writes nothing at all. See
-// [Manager.priceSwing] for what a turn costs and
-// [character.CostOfSwing] for how one price is made out of the rulebook's two.
+// The price is compiled into the selected definition before its selector ID is
+// generated, then the same definition and a cloned matching resolution cost are
+// reused here. Resolution charges after pure machine preflight and before its
+// first executable step — so a refused swing rolls nothing, damages nobody,
+// and writes nothing at all. See [Manager.priceSwing] and
+// [character.CostOfSwing].
 //
-// IN FREE ROAM IT COSTS NOTHING, which is a ruling rather than the old gap: the
-// action economy is a fight's economy, and a member on the world clock has no
-// turn to spend a turn's slots from. TestFreeRoamChargesNothing pins it.
+// ATTACK HAS NO WORLD-CLOCK OFFER. Afford returns no declarations in free roam,
+// so there is no valid selector to echo there; Move alone retains its explicit
+// empty-selector world-clock form.
 //
 // # How it runs, and why the order is not a style choice
 //
@@ -132,16 +137,16 @@ type AttackOutput struct {
 // is what keeps that true. A caller told only "it failed" would retry a swing
 // whose damage is on disk.
 //
-// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
-// ErrNoEncounter, ErrNoMember, ErrNotACharacter, ErrNoSheet, ErrNoCharacter,
-// ErrBadCharacter, ErrBadRepository, ErrBadAttack, ErrCannotAfford, ErrBadCost,
-// ErrClosed, or ErrSaveFailed with a populated report.
+// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoDeclarationID,
+// ErrNoSession, ErrNoEncounter, ErrNoMember, ErrNotACharacter, ErrNoSheet,
+// ErrNoCharacter, ErrBadCharacter, ErrBadRepository, ErrBadAttack,
+// ErrStaleDeclaration, ErrCannotAfford, ErrBadCost, ErrClosed, or ErrSaveFailed
+// with a populated report.
 //
-// ErrNoCharacter and ErrBadCharacter mean here exactly what they mean
-// everywhere else in this package: the repository does not hold that sheet,
-// versus it holds bytes that will not reconstitute. A host branches on the
-// difference — re-check the ID, versus go and inspect storage — so the two are
-// worth reading off carefully.
+// ErrNoCharacter and ErrBadCharacter can still identify another participant
+// resolution must load. If the attacker's own sheet is absent or unreadable,
+// Afford instead emits an Unreadable blocker with no selector, so execution has
+// no declaration to echo.
 func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("attack: %w", ErrNilInput)
@@ -165,9 +170,6 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 	}
 	if _, ok := kinds[in.Attacker]; !ok {
 		return nil, fmt.Errorf("attack: attacker %q: %w", in.Attacker, ErrNoMember)
-	}
-	if _, ok := kinds[in.Target]; !ok {
-		return nil, fmt.Errorf("attack: target %q: %w", in.Target, ErrNoMember)
 	}
 	if kinds[in.Attacker] != encounter.MemberKind(KindPlayer) {
 		return nil, fmt.Errorf("attack: attacker %q: %w", in.Attacker, ErrNotACharacter)
@@ -198,6 +200,40 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		return nil, fmt.Errorf("attack: %w", err)
 	}
 
+	// Attack has no world-clock declaration. Its selector is mandatory even
+	// though the turn/downed gates above intentionally keep their historical
+	// precedence: a caller acting out of turn or while downed hears that real
+	// refusal before selection is considered.
+	if ClockKind(clock.Kind) != ClockTurn {
+		if in.DeclarationID == "" {
+			return nil, fmt.Errorf("attack: %w", ErrNoDeclarationID)
+		}
+		return nil, fmt.Errorf("attack: %w", ErrStaleDeclaration)
+	}
+	if in.DeclarationID == "" {
+		return nil, fmt.Errorf("attack: %w", ErrNoDeclarationID)
+	}
+
+	// Regenerate under this verb's already-loaded write scope and select the
+	// exact current offer. compileOffers owns assembly, pricing, selector
+	// identity, and target preflight; execution reuses those compiled values
+	// instead of independently compiling a second attack after selection.
+	offers, err := m.compileOffers(ctx, scope.enc, scope.data, in.Attacker, clock, false)
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", err)
+	}
+	selected, err := selectCompiledOffer(offers, VerbAttack, in.DeclarationID)
+	if err != nil {
+		return nil, fmt.Errorf("attack: %w", err)
+	}
+	candidate, ok := selected.targets[in.Target]
+	if !ok || !candidate.available {
+		return nil, fmt.Errorf("attack: target %q: %w", in.Target, ErrStaleDeclaration)
+	}
+	if selected.attack == nil || selected.price == nil || selected.sheet == nil {
+		return nil, fmt.Errorf("attack: %w", ErrStaleDeclaration)
+	}
+
 	// A member with no stored sheet cannot be swung at: there is nothing to
 	// read an armour class off and nothing for damage to land on. Authored
 	// content placed straight into a world has no sheet until something spawns
@@ -209,37 +245,9 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		}
 	}
 
-	sheet, err := m.loadAttackSheet(ctx, in.Attacker)
-	if err != nil {
-		return nil, fmt.Errorf("attack: %w", err)
-	}
-
-	// THE ONE PLACE A SPEND GOES, and it is the place its own comment predicted.
-	// The economy turned out not to need a machine above this call: the ruling
-	// (docs/ideas/session-sdk/economy-gate.md) put the price on Input as DATA and
-	// the debit at resolution's door, so what belongs here is compiling what this
-	// actor's swing costs — which is a question about a sheet, and this is where
-	// the sheets are. Nothing persistent or wire-shaped assumed attacks were
-	// free, and nothing had to migrate.
-	price, err := m.priceSwing(ctx, scope.enc, in.Attacker, sheet)
-	if err != nil {
-		return nil, fmt.Errorf("attack: %w", err)
-	}
-	var cost = price.cost
-	var profileCost = (*combat.SpendProfile)(nil)
-	if cost != nil {
-		profileCost = cost.Profile
-	}
-	definition, err := character.AssembleAttack(sheet, &character.AssembleAttackInput{
-		Slot: character.SlotMainHand,
-		Cost: profileCost,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("attack: attacker %q: %w: %v", in.Attacker, ErrBadAttack, err)
-	}
-	if cost != nil {
-		cost.Profile = definition.Cost
-	}
+	definition := *selected.attack
+	price := selected.price
+	cost := price.cost
 
 	// The readied sheet goes into the cast rather than the stored one: it is the
 	// sheet whose turn was just lit or refilled, and the door is about to charge
@@ -333,7 +341,7 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 // The ref is the FULL definition.Ref.String — "dnd5e:weapons:longsword",
 // "dnd5e:monster-actions:unarmed-strike" — so the same identity a client
 // maps to a model and icon on a beat is the one a compiled offer carries,
-// and the one Task 7's execution enforcement regenerates from. The same
+// and the one execution regenerates from. The same
 // helper serves all three call sites so they cannot drift.
 //
 // The damage type reported is the FIRST declared pool's, which is every

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -7,12 +7,14 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sort"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monstertraits"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
 )
 
@@ -143,10 +145,13 @@ type AttackOutput struct {
 // ErrStaleDeclaration, ErrCannotAfford, ErrBadCost, ErrClosed, or ErrSaveFailed
 // with a populated report.
 //
-// ErrNoCharacter and ErrBadCharacter can still identify another participant
-// resolution must load. If the attacker's own sheet is absent or unreadable,
-// Afford instead emits an Unreadable blocker with no selector, so execution has
-// no declaration to echo.
+// Participant dependency failures normally surface before this verb through
+// Afford: unreadable targets keep candidate rows with ShortfallUnreadable, an
+// unreadable non-target cast member disables the declaration globally, and an
+// unreadable actor/Attack emits an early blocker with no selector. Echoing an
+// unavailable compiled selector is ErrStaleDeclaration; resolution receives
+// the exact raw cast compilation already preflighted and performs no repository
+// refetch after selection.
 func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("attack: %w", ErrNilInput)
@@ -219,7 +224,7 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 	// exact current offer. compileOffers owns assembly, pricing, selector
 	// identity, and target preflight; execution reuses those compiled values
 	// instead of independently compiling a second attack after selection.
-	offers, err := m.compileOffers(ctx, scope.enc, scope.data, in.Attacker, clock, actor)
+	offers, err := m.compileOffers(ctx, scope.enc, scope.data, scope.session, in.Attacker, clock, actor)
 	if err != nil {
 		return nil, fmt.Errorf("attack: %w", err)
 	}
@@ -231,32 +236,18 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 	if !ok || !candidate.available {
 		return nil, fmt.Errorf("attack: target %q: %w", in.Target, ErrStaleDeclaration)
 	}
-	if selected.attack == nil || selected.price == nil || selected.sheet == nil {
+	if selected.attack == nil || selected.price == nil || selected.sheet == nil || len(selected.cast) == 0 {
 		return nil, fmt.Errorf("attack: %w", ErrStaleDeclaration)
-	}
-
-	// A member with no stored sheet cannot be swung at: there is nothing to
-	// read an armour class off and nothing for damage to land on. Authored
-	// content placed straight into a world has no sheet until something spawns
-	// it, so this is reachable and worth naming here — the alternative is the
-	// strike failing later, further from the cause.
-	if kinds[in.Target] == encounter.MemberKind(KindMonster) {
-		if _, ok := npcSheet(scope.data, in.Target); !ok {
-			return nil, fmt.Errorf("attack: target %q: %w", in.Target, ErrNoSheet)
-		}
 	}
 
 	definition := *selected.attack
 	price := selected.price
 	cost := price.cost
 
-	// The readied sheet goes into the cast rather than the stored one: it is the
-	// sheet whose turn was just lit or refilled, and the door is about to charge
-	// exactly that bank. See swingPrice for why the two travel together.
-	cast, err := m.castFor(ctx, scope, roster, price.payer)
-	if err != nil {
-		return nil, fmt.Errorf("attack: %w", err)
-	}
+	// The selected offer owns the one exact raw cast snapshot gathered and
+	// strictly preflighted during compilation. Resolution reconstitutes those
+	// bytes; execution performs no participant repository read after selection.
+	cast := selected.cast
 	machine, err := resolution.NewAction(&resolution.ActionInput{
 		Definition: definition,
 		AttackerID: in.Attacker,
@@ -551,18 +542,97 @@ func (m *Manager) loadAttackSheet(ctx context.Context, attacker string) (*charac
 	return loaded, nil
 }
 
-// castFor gathers every member of the encounter as a participant.
-//
-// EVERY member, not the two swinging: scope is the caller's and applicability
-// is the effect's own predicate (ADR-0038). A bard three cells away whose
-// Bless is running has to be in the room for their subscription to fire, and
-// deciding they are irrelevant here would be this package deciding a rule.
-//
-// One member may arrive already in hand. The attacker's sheet has had its turn
-// readied by the time the cast is built (see [Manager.priceSwing]), and that
-// readying is state the stored copy does not have — so the readied sheet is
-// substituted rather than re-fetched. Passing nil means nobody was readied,
-// which is what free roam looks like.
+type resolutionDependencyFailure struct {
+	member string
+	err    error
+}
+
+// compileResolutionCast gathers one raw data snapshot for every roster member
+// and strictly preflights each available sheet through the same public pure
+// loaders and attach APIs resolution uses. It returns all dependency failures
+// so offer compilation can preserve every candidate row while applying
+// candidate-specific and global Unreadable gates.
+func (m *Manager) compileResolutionCast(
+	ctx context.Context,
+	data *SessionData,
+	roster []encounter.Member,
+	readied *character.Data,
+) ([]resolution.Participant, []resolutionDependencyFailure) {
+	npcs := make(map[string]*monster.Data, len(data.NPCs))
+	for i := range data.NPCs {
+		npcs[data.NPCs[i].ID] = &data.NPCs[i]
+	}
+
+	cast := make([]resolution.Participant, 0, len(roster))
+	failures := make([]resolutionDependencyFailure, 0)
+	for _, member := range roster {
+		id := string(member.ID)
+		if member.Kind == encounter.MemberKind(KindMonster) {
+			sheet, ok := npcs[id]
+			if !ok {
+				failures = append(failures, resolutionDependencyFailure{member: id, err: ErrNoSheet})
+				continue
+			}
+			cast = append(cast, resolution.Participant{Monster: sheet})
+			continue
+		}
+
+		if readied != nil && readied.ID == id {
+			cast = append(cast, resolution.Participant{Character: readied})
+			continue
+		}
+
+		sheet, err := m.fetchCharacterData(ctx, "participant", id)
+		if err != nil {
+			failures = append(failures, resolutionDependencyFailure{member: id, err: err})
+			continue
+		}
+		if sheet.ID != id {
+			failures = append(failures, resolutionDependencyFailure{
+				member: id,
+				err:    fmt.Errorf("GetCharacter(%q) returned character %q: %w", id, sheet.ID, ErrBadRepository),
+			})
+			continue
+		}
+		cast = append(cast, resolution.Participant{Character: sheet})
+	}
+
+	// Resolution attaches in sorted participant order (R4). Use that order and
+	// one ephemeral bus here too, so preflight is the same one-cast semantics,
+	// not isolated per-sheet checks that could miss an attach interaction.
+	ordered := append([]resolution.Participant(nil), cast...)
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].ID() < ordered[j].ID() })
+	bus := newCallBus()
+	for _, participant := range ordered {
+		id := participant.ID()
+		var err error
+		switch {
+		case participant.Character != nil:
+			var loaded *character.Character
+			loaded, err = character.Load(ctx, participant.Character)
+			if err == nil {
+				err = character.Attach(ctx, loaded, bus)
+			}
+		case participant.Monster != nil:
+			var loaded *monster.Monster
+			loaded, err = monstertraits.LoadMonster(ctx, participant.Monster)
+			if err == nil {
+				err = monstertraits.AttachMonster(ctx, loaded, bus, &diceSeam{roller: m.dice})
+			}
+		default:
+			err = fmt.Errorf("empty participant")
+		}
+		if err != nil {
+			failures = append(failures, resolutionDependencyFailure{member: id, err: err})
+		}
+	}
+
+	return cast, failures
+}
+
+// castFor gathers every member for a monster-driven strike. Player Attack
+// offers use compileResolutionCast instead so Afford can validate and retain
+// the exact raw snapshot selected execution consumes.
 func (m *Manager) castFor(
 	ctx context.Context, scope *writeScope, roster []encounter.Member, readied *character.Data,
 ) ([]resolution.Participant, error) {

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -326,9 +326,15 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 }
 
 // attackRefFor projects a compiled attack profile's identity onto the wire
-// shape — ref, name, damage type — carried on AttackOutput and, via
-// [encounter.AttackIdentity], on the Struck/Missed beat every witness reads
-// (rpg-toolkit#866).
+// shape — ref, name, damage type — carried on AttackOutput, on the
+// Struck/Missed beat every witness reads (rpg-toolkit#866), and on the
+// compiled Attack declaration's AttackRef (rpg-toolkit#272/273).
+//
+// The ref is the FULL definition.Ref.String — "dnd5e:weapons:longsword",
+// "dnd5e:monster-actions:unarmed-strike" — so the same identity a client
+// maps to a model and icon on a beat is the one a compiled offer carries,
+// and the one Task 7's execution enforcement regenerates from. The same
+// helper serves all three call sites so they cannot drift.
 //
 // The damage type reported is the FIRST declared pool's, which is every
 // weapon this assembler produces today. A weapon
@@ -336,7 +342,7 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 // means, and that decision belongs beside the day such a weapon compiles,
 // not guessed at here.
 func attackRefFor(definition combatActions.Definition) AttackRef {
-	ref := AttackRef{Ref: string(definition.Ref.ID), Name: definition.Name}
+	ref := AttackRef{Ref: definition.Ref.String(), Name: definition.Name}
 	if definition.Attack != nil && len(definition.Attack.Damage) > 0 {
 		ref.DamageType = DamageType(definition.Attack.Damage[0].Type)
 	}

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -191,24 +191,25 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 		return nil, fmt.Errorf("attack: attacker %q: %w", in.Attacker, ErrNotYourTurn)
 	}
 
-	// A downed member does not swing. Asked AFTER the roster checks, so naming somebody
-	// who is not here is still ErrNoMember — being down is a fact about a
-	// member, and it means nothing about an ID that is not one. Asked about the
-	// ATTACKER alone: a down target is refused nowhere, deliberately (see
-	// refuseIfDown).
-	if err := refuseIfDown(scope, "attacker", in.Attacker); err != nil {
-		return nil, fmt.Errorf("attack: %w", err)
-	}
-
-	// Attack has no world-clock declaration. Its selector is mandatory even
-	// though the turn/downed gates above intentionally keep their historical
-	// precedence: a caller acting out of turn or while downed hears that real
-	// refusal before selection is considered.
+	// Attack has no world-clock declaration. Keep its independent standing
+	// gate for historical refusal precedence, then reject every selector: there
+	// is no world-clock offer to select.
 	if ClockKind(clock.Kind) != ClockTurn {
+		if err := refuseIfDown(scope, "attacker", in.Attacker); err != nil {
+			return nil, fmt.Errorf("attack: %w", err)
+		}
 		if in.DeclarationID == "" {
 			return nil, fmt.Errorf("attack: %w", ErrNoDeclarationID)
 		}
 		return nil, fmt.Errorf("attack: %w", ErrStaleDeclaration)
+	}
+
+	// The turn path loads the actor strictly ONCE. The downed verdict and every
+	// piece of the regenerated offer are derived from this same snapshot; a
+	// repository cannot answer standing to one gate and downed to compilation.
+	actor := m.loadActorSheet(ctx, in.Attacker)
+	if actor.downed {
+		return nil, fmt.Errorf("attack: attacker %q: %w", in.Attacker, ErrDowned)
 	}
 	if in.DeclarationID == "" {
 		return nil, fmt.Errorf("attack: %w", ErrNoDeclarationID)
@@ -218,7 +219,7 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 	// exact current offer. compileOffers owns assembly, pricing, selector
 	// identity, and target preflight; execution reuses those compiled values
 	// instead of independently compiling a second attack after selection.
-	offers, err := m.compileOffers(ctx, scope.enc, scope.data, in.Attacker, clock, false)
+	offers, err := m.compileOffers(ctx, scope.enc, scope.data, in.Attacker, clock, actor)
 	if err != nil {
 		return nil, fmt.Errorf("attack: %w", err)
 	}

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -221,10 +221,12 @@ func (m *Manager) Attack(ctx context.Context, in *AttackInput) (*AttackOutput, e
 	}
 
 	// Regenerate under this verb's already-loaded write scope and select the
-	// exact current offer. compileOffers owns assembly, pricing, selector
+	// exact current offer. compileOffersFor owns assembly, pricing, selector
 	// identity, and target preflight; execution reuses those compiled values
 	// instead of independently compiling a second attack after selection.
-	offers, err := m.compileOffers(ctx, scope.enc, scope.data, scope.session, in.Attacker, clock, actor)
+	offers, err := m.compileOffersFor(
+		ctx, scope.enc, scope.data, scope.session, in.Attacker, clock, actor, VerbAttack,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("attack: %w", err)
 	}

--- a/rulebooks/dnd5e/session/attack_internal_test.go
+++ b/rulebooks/dnd5e/session/attack_internal_test.go
@@ -136,7 +136,7 @@ func TestRecordProjectsSelectedStrikeDetail(t *testing.T) {
 	payload := string(story[len(story)-1].Payload)
 	require.JSONEq(t,
 		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":9,`+
-			`"critical":false,"attack":{"ref":"longsword","name":"Longsword","damage_type":""},`+
+			`"critical":false,"attack":{"ref":"dnd5e:weapons:longsword","name":"Longsword","damage_type":""},`+
 			`"damage_components":[`+
 			`{"source":"weapon","source_ref":"dnd5e:weapons:longsword","dice":"1d8","final_rolls":[4],"flat_bonus":0,"damage_type":"slashing"},`+
 			`{"source":"monster_trait","source_ref":"dnd5e:monster_traits:immunity","flat_bonus":0,"damage_type":"slashing","multiplier":0}],`+

--- a/rulebooks/dnd5e/session/attack_internal_test.go
+++ b/rulebooks/dnd5e/session/attack_internal_test.go
@@ -295,6 +295,72 @@ func TestProjectCandidatesDefensivelyCopiesWhy(t *testing.T) {
 	require.Equal(t, "original", why.Text)
 }
 
+// TestMoveRegenerationSkipsAttackTargetPreflight proves a current Move
+// selector does not inherit Attack's target dependencies. The selector comes
+// from a normal full Afford compilation; after that, Attack's shared target
+// gate is made unreadable. Regenerating Move must neither ask that gate nor
+// fail because the unrelated Attack can no longer compile.
+func TestMoveRegenerationSkipsAttackTargetPreflight(t *testing.T) {
+	ctx := context.Background()
+	sessions := &strikeSessions{byID: map[string]*SessionData{}}
+	encounters := &strikeEncounters{byID: map[string]*encounter.EncounterData{}}
+	characters := &strikeCharacters{byID: map[string]*character.Data{
+		"alice": strikeFixtureFighter("alice"),
+		"bob":   strikeFixtureFighter("bob"),
+	}}
+	mgr, err := NewManager(&Config{
+		Dice: &scriptedDice{}, TurnDriver: Pass{}, Sessions: sessions, Encounters: encounters,
+		Characters: characters, Events: DiscardEvents{},
+	})
+	require.NoError(t, err)
+
+	world, err := encounter.NewEncounter(&encounter.SetupInput{
+		Striker: encounter.RefusingStriker{}, Sight: aggregateRecordEveryoneSees{},
+		Initiative: aggregateRecordOrderAsGiven{}, TurnDriver: passDriver{}, Standing: aggregateRecordEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: pointyCanvas(), Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 4, 4)}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	require.NoError(t, err)
+	data := world.ToData()
+	delete(data.Clock.Budgets, core.EntityID("alice"))
+	delete(data.Clock.Budgets, core.EntityID("bob"))
+	require.NoError(t, json.Unmarshal([]byte(`[{"order":["alice","bob"],"round":1}]`), &data.Bubbles))
+	_, err = mgr.StartSession(ctx, &StartSessionInput{Session: "sess", Encounter: "world", World: &data})
+	require.NoError(t, err)
+
+	afford, err := mgr.Afford(ctx, &AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	var move Declaration
+	for _, declaration := range afford.Declarations {
+		if declaration.Verb == VerbMove {
+			move = declaration
+			break
+		}
+	}
+	require.True(t, move.Available)
+	require.NotEmpty(t, move.ID)
+
+	calls := 0
+	mgr.targetPreflight = func(
+		_ *encounter.Encounter, _ map[string]spatial.Position, _ []intel.Holding, _ string, _ int,
+	) ([]targetPreflight, error) {
+		calls++
+		return nil, errors.New("injected Attack target preflight failure")
+	}
+
+	moved, err := mgr.Move(ctx, &MoveInput{
+		Session: "sess", Member: "alice", DeclarationID: move.ID,
+		Path: []spatial.Position{{X: 1, Y: 2}},
+	})
+	require.NoError(t, err)
+	require.Len(t, moved.Steps, 1)
+	require.Zero(t, calls, "Move regeneration must not read Attack target dependencies")
+}
+
 // TestInjectedTargetPreflightRefusalChangesAffordAndAttack proves projection
 // and execution share one target gate. The injected refusal appears verbatim
 // on Afford's candidate and makes the echoed Attack selector stale before any

--- a/rulebooks/dnd5e/session/attack_internal_test.go
+++ b/rulebooks/dnd5e/session/attack_internal_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
@@ -259,6 +260,90 @@ func (s *strikeCharacters) GetCharacter(_ context.Context, id string) (*characte
 func (s *strikeCharacters) SaveCharacter(_ context.Context, data *character.Data) error {
 	s.byID[data.ID] = data
 	return nil
+}
+
+func TestProjectCandidatesDefensivelyCopiesWhy(t *testing.T) {
+	why := &Shortfall{Reason: ShortfallTargetOutOfReach, Text: "original"}
+	projected := projectCandidates([]targetPreflight{{member: "bob", available: false, why: why}})
+	require.Len(t, projected, 1)
+	require.NotSame(t, why, projected[0].Why)
+	projected[0].Why.Text = "mutated by caller"
+	require.Equal(t, "original", why.Text)
+}
+
+// TestInjectedTargetPreflightRefusalChangesAffordAndAttack proves projection
+// and execution share one target gate. The injected refusal appears verbatim
+// on Afford's candidate and makes the echoed Attack selector stale before any
+// die rolls; an independent execution preflight would let the attack through.
+func TestInjectedTargetPreflightRefusalChangesAffordAndAttack(t *testing.T) {
+	ctx := context.Background()
+	sessions := &strikeSessions{byID: map[string]*SessionData{}}
+	encounters := &strikeEncounters{byID: map[string]*encounter.EncounterData{}}
+	characters := &strikeCharacters{byID: map[string]*character.Data{
+		"alice": strikeFixtureFighter("alice"),
+		"bob":   strikeFixtureFighter("bob"),
+	}}
+	roller := &scriptedDice{rolls: []int{17, 4}}
+	mgr, err := NewManager(&Config{
+		Dice: roller, TurnDriver: Pass{}, Sessions: sessions, Encounters: encounters,
+		Characters: characters, Events: DiscardEvents{},
+	})
+	require.NoError(t, err)
+
+	world, err := encounter.NewEncounter(&encounter.SetupInput{
+		Striker: encounter.RefusingStriker{}, Sight: aggregateRecordEveryoneSees{},
+		Initiative: aggregateRecordOrderAsGiven{}, TurnDriver: passDriver{}, Standing: aggregateRecordEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: pointyCanvas(), Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 4, 4)}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+	})
+	require.NoError(t, err)
+	data := world.ToData()
+	delete(data.Clock.Budgets, core.EntityID("alice"))
+	delete(data.Clock.Budgets, core.EntityID("bob"))
+	require.NoError(t, json.Unmarshal(
+		[]byte(`[{"order":["alice","bob"],"round":1}]`), &data.Bubbles,
+	))
+	require.NoError(t, func() error {
+		_, startErr := mgr.StartSession(ctx, &StartSessionInput{Session: "sess", Encounter: "world", World: &data})
+		return startErr
+	}())
+
+	injected := Shortfall{Reason: ShortfallTargetOutOfReach, Text: "injected target refusal"}
+	calls := 0
+	mgr.targetPreflight = func(
+		_ *encounter.Encounter, _ map[string]spatial.Position, _ []intel.Holding, member string, _ int,
+	) ([]targetPreflight, error) {
+		calls++
+		require.Equal(t, "alice", member)
+		why := injected
+		return []targetPreflight{{member: "bob", available: false, why: &why}}, nil
+	}
+
+	afford, err := mgr.Afford(ctx, &AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	var attack Declaration
+	for _, declaration := range afford.Declarations {
+		if declaration.Verb == VerbAttack {
+			attack = declaration
+			break
+		}
+	}
+	require.NotEmpty(t, attack.ID)
+	require.False(t, attack.Available)
+	require.Len(t, attack.Candidates, 1)
+	require.Equal(t, injected, *attack.Candidates[0].Why)
+
+	out, err := mgr.Attack(ctx, &AttackInput{
+		Session: "sess", Attacker: "alice", Target: "bob", DeclarationID: attack.ID,
+	})
+	require.ErrorIs(t, err, ErrStaleDeclaration)
+	require.Nil(t, out)
+	require.Equal(t, 2, calls, "Afford and regenerated Attack each use the shared seam")
+	require.Zero(t, roller.next, "the injected refusal precedes every attack roll")
 }
 
 func strikeFixtureFighter(id string) *character.Data {

--- a/rulebooks/dnd5e/session/attack_internal_test.go
+++ b/rulebooks/dnd5e/session/attack_internal_test.go
@@ -215,7 +215,10 @@ func cloneFixture[T any](in *T) (*T, error) {
 	return &out, nil
 }
 
-type strikeSessions struct{ byID map[string]*SessionData }
+type strikeSessions struct {
+	byID  map[string]*SessionData
+	saves int
+}
 
 func (s *strikeSessions) GetSession(_ context.Context, id string) (*SessionData, error) {
 	data, ok := s.byID[id]
@@ -226,12 +229,15 @@ func (s *strikeSessions) GetSession(_ context.Context, id string) (*SessionData,
 }
 
 func (s *strikeSessions) SaveSession(_ context.Context, data *SessionData) error {
+	s.saves++
 	s.byID[data.ID] = data
 	return nil
 }
 
 type strikeEncounters struct {
-	byID map[string]*encounter.EncounterData
+	byID    map[string]*encounter.EncounterData
+	saves   int
+	records int
 }
 
 func (s *strikeEncounters) GetEncounter(_ context.Context, id string) (*encounter.EncounterData, error) {
@@ -243,11 +249,28 @@ func (s *strikeEncounters) GetEncounter(_ context.Context, id string) (*encounte
 }
 
 func (s *strikeEncounters) SaveEncounter(_ context.Context, id string, data *encounter.EncounterData) error {
+	s.saves++
+	if previous, ok := s.byID[id]; ok {
+		before, after := strikeNextSeq(previous), strikeNextSeq(data)
+		if after > before {
+			s.records += int(after - before)
+		}
+	}
 	s.byID[id] = data
 	return nil
 }
 
-type strikeCharacters struct{ byID map[string]*character.Data }
+func strikeNextSeq(data *encounter.EncounterData) uint64 {
+	if data == nil || data.Log.NextSeq == 0 {
+		return 1
+	}
+	return data.Log.NextSeq
+}
+
+type strikeCharacters struct {
+	byID  map[string]*character.Data
+	saves int
+}
 
 func (s *strikeCharacters) GetCharacter(_ context.Context, id string) (*character.Data, error) {
 	data, ok := s.byID[id]
@@ -258,6 +281,7 @@ func (s *strikeCharacters) GetCharacter(_ context.Context, id string) (*characte
 }
 
 func (s *strikeCharacters) SaveCharacter(_ context.Context, data *character.Data) error {
+	s.saves++
 	s.byID[data.ID] = data
 	return nil
 }
@@ -337,6 +361,17 @@ func TestInjectedTargetPreflightRefusalChangesAffordAndAttack(t *testing.T) {
 	require.Len(t, attack.Candidates, 1)
 	require.Equal(t, injected, *attack.Candidates[0].Why)
 
+	// Isolate the attempted Attack from setup and Afford. Counters prove no
+	// repository or story mutation occurred; the state comparison separately
+	// pins position and clock.
+	sessions.saves, encounters.saves, encounters.records, characters.saves = 0, 0, 0, 0
+	beforeState, err := json.Marshal(struct {
+		Clock   any
+		Bubbles any
+		Members any
+	}{encounters.byID["world"].Clock, encounters.byID["world"].Bubbles, encounters.byID["world"].Members})
+	require.NoError(t, err)
+
 	out, err := mgr.Attack(ctx, &AttackInput{
 		Session: "sess", Attacker: "alice", Target: "bob", DeclarationID: attack.ID,
 	})
@@ -344,6 +379,17 @@ func TestInjectedTargetPreflightRefusalChangesAffordAndAttack(t *testing.T) {
 	require.Nil(t, out)
 	require.Equal(t, 2, calls, "Afford and regenerated Attack each use the shared seam")
 	require.Zero(t, roller.next, "the injected refusal precedes every attack roll")
+	require.Zero(t, characters.saves, "target preflight refusal writes no character")
+	require.Zero(t, sessions.saves, "target preflight refusal writes no session")
+	require.Zero(t, encounters.saves, "target preflight refusal writes no encounter")
+	require.Zero(t, encounters.records, "target preflight refusal records no story beat")
+	afterState, err := json.Marshal(struct {
+		Clock   any
+		Bubbles any
+		Members any
+	}{encounters.byID["world"].Clock, encounters.byID["world"].Bubbles, encounters.byID["world"].Members})
+	require.NoError(t, err)
+	require.JSONEq(t, string(beforeState), string(afterState), "target preflight refusal changes no position or clock")
 }
 
 func strikeFixtureFighter(id string) *character.Data {

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -331,12 +331,12 @@ func (s *AttackTestSuite) TestASwingLandsAndTheStoryRecordsIt() {
 	s.Equal("outcome", last.Tags["tag"])
 	s.JSONEq(
 		`{"beat":"struck","actor":"alice","targets":["bob"],"roll":15,"total":20,"against":12,"amount":8,`+
-			`"critical":false,"attack":{"ref":"longsword","name":"Longsword","damage_type":"slashing"},`+
+			`"critical":false,"attack":{"ref":"dnd5e:weapons:longsword","name":"Longsword","damage_type":"slashing"},`+
 			`"damage_components":[`+
 			`{"source":"weapon","source_ref":"dnd5e:weapons:longsword","dice":"1d8","final_rolls":[5],"flat_bonus":0,"damage_type":"slashing"},`+
 			`{"source":"ability","source_ref":"dnd5e:abilities:str","flat_bonus":3,"damage_type":"slashing"}]}`,
 		string(last.Payload))
-	s.Equal(session.AttackRef{Ref: "longsword", Name: "Longsword", DamageType: session.DamageSlashing}, out.Attack)
+	s.Equal(session.AttackRef{Ref: "dnd5e:weapons:longsword", Name: "Longsword", DamageType: session.DamageSlashing}, out.Attack)
 }
 
 // TestAMissIsRecordedToo pins the other arm, including that a miss carries no
@@ -353,7 +353,7 @@ func (s *AttackTestSuite) TestAMissIsRecordedToo() {
 	s.Require().NoError(err)
 	s.JSONEq(
 		`{"beat":"missed","actor":"alice","targets":["bob"],"roll":2,"total":7,"against":12,`+
-			`"attack":{"ref":"longsword","name":"Longsword","damage_type":"slashing"}}`,
+			`"attack":{"ref":"dnd5e:weapons:longsword","name":"Longsword","damage_type":"slashing"}}`,
 		string(story[len(story)-1].Payload))
 }
 

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/suite"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
@@ -98,8 +99,31 @@ func armedFighter(id string) *character.Data {
 // field to make a swing miss changes nothing at all.
 const duelAC = 12
 
-// duelWorld is two armed characters standing next to each other, which is the
-// smallest world where a swing means anything.
+// turnWorld moves the named members from the world clock into one authored
+// turn clock. Tests author the clock directly so initiative never consumes the
+// attack dice whose exact faces they assert.
+func turnWorld(data *encounter.EncounterData, order []string, active int) *encounter.EncounterData {
+	ids := make([]core.EntityID, 0, len(order))
+	for _, member := range order {
+		delete(data.Clock.Budgets, core.EntityID(member))
+		ids = append(ids, core.EntityID(member))
+	}
+	raw, err := json.Marshal([]struct {
+		Order     []core.EntityID `json:"order"`
+		ActiveIdx int             `json:"active_idx"`
+		Round     int             `json:"round"`
+	}{{Order: ids, ActiveIdx: active, Round: 1}})
+	if err != nil {
+		panic(err)
+	}
+	if err := json.Unmarshal(raw, &data.Bubbles); err != nil {
+		panic(err)
+	}
+	return data
+}
+
+// freeRoamDuelWorld is two armed characters standing next to each other, which
+// is the smallest world where a swing means anything.
 //
 // Both sides are CHARACTERS on purpose: damage dirties the target's stored
 // sheet, which is the case that earns Attack its row in the no-clobber pin.
@@ -107,7 +131,7 @@ const duelAC = 12
 // Shared with the event-kind pins (attackevents_test.go), which need the same
 // duel delivered to a real stream rather than discarded. One world, so a
 // fixture drift cannot make the two suites disagree about what was swung at.
-func duelWorld(t fataler) *encounter.EncounterData {
+func freeRoamDuelWorld(t fataler) *encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Striker: encounter.RefusingStriker{}, Sight: encEveryoneSees{},
 		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
 		Standing: encEveryoneStanding{},
@@ -124,6 +148,12 @@ func duelWorld(t fataler) *encounter.EncounterData {
 	}
 	data := enc.ToData()
 	return &data
+}
+
+// duelWorld is the same adjacent-character scene on a turn clock with alice
+// active, so Attack can execute only through the selector Afford authored.
+func duelWorld(t fataler) *encounter.EncounterData {
+	return turnWorld(freeRoamDuelWorld(t), []string{"alice", "bob"}, 0)
 }
 
 // duel wires the duel world to a manager whose events go nowhere.
@@ -160,6 +190,7 @@ func (s *AttackTestSuite) breakableDuel(dice session.Roller) (*session.Manager, 
 func (s *AttackTestSuite) swing(mgr *session.Manager) (*session.AttackOutput, error) {
 	return mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "bob",
+		DeclarationID: currentAttackID(s.T(), mgr, "sess", "alice"),
 	})
 }
 
@@ -214,6 +245,7 @@ func (s *AttackTestSuite) TestAnArmedDuelingFighterResolvesOnTheSessionStack() {
 
 	_, err = mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "bob",
+		DeclarationID: currentAttackID(s.T(), mgr, "sess", "alice"),
 	})
 	s.Require().NoError(err,
 		"an armed Dueling-eligible fighter's swing must not depend on a GameContext the session stack never installs")
@@ -289,12 +321,13 @@ func (s *AttackTestSuite) TestProtectionReactsToANearbyAllysAttackOnTheSessionSt
 	s.Require().NoError(err)
 
 	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
-		Session: "sess", Encounter: "world", World: &world,
+		Session: "sess", Encounter: "world", World: turnWorld(&world, []string{"alice", "bob", "carol"}, 2),
 	})
 	s.Require().NoError(err)
 
 	_, err = mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "carol", Target: "bob",
+		DeclarationID: currentAttackID(s.T(), mgr, "sess", "carol"),
 	})
 	s.Require().NoError(err,
 		"a third member's Protection condition must not depend on a GameContext the session stack never installs")
@@ -394,8 +427,8 @@ func (s *AttackTestSuite) TestASwingNamesTheSheetItWrote() {
 	s.Require().NoError(err)
 	s.Require().True(out.Hit)
 
-	s.Equal([]string{"character:bob", "encounter:world"}, out.Saved.Written,
-		"the damaged sheet is durable and the report has to say so")
+	s.Equal([]string{"character:alice", "character:bob", "encounter:world"}, out.Saved.Written,
+		"the paid attacker and damaged target are durable and the report says so")
 	s.Empty(out.Saved.Failed)
 	s.False(out.Saved.Partial(), "a whole save is not a partial one")
 }
@@ -414,8 +447,8 @@ func (s *AttackTestSuite) TestAMissNamesNoCharacterWrite() {
 	s.Require().NoError(err)
 	s.Require().False(out.Hit)
 
-	s.Equal([]string{"encounter:world"}, out.Saved.Written,
-		"a miss changed no sheet, so the report names no sheet")
+	s.Equal([]string{"character:alice", "encounter:world"}, out.Saved.Written,
+		"a miss changes no target sheet, but the attacker's paid economy is durable")
 }
 
 // TestAFailedWorldSaveStillNamesTheSheetThatLanded is the reason this report
@@ -447,8 +480,8 @@ func (s *AttackTestSuite) TestAFailedWorldSaveStillNamesTheSheetThatLanded() {
 
 	var saved *session.SaveError
 	s.Require().ErrorAs(err, &saved, "the report must survive the error")
-	s.Equal([]string{"character:bob"}, saved.Report.Written,
-		"bob's damaged sheet is already durable — retrying the swing would damage him twice")
+	s.Equal([]string{"character:alice", "character:bob"}, saved.Report.Written,
+		"the paid attacker and damaged target are already durable — retrying would spend and damage twice")
 	s.Equal([]string{"encounter:world"}, saved.Report.Failed,
 		"and the world that would have recorded the blow is what needs repair")
 	s.True(saved.Report.Partial(), "half a save is a repair, not a retry")
@@ -457,45 +490,30 @@ func (s *AttackTestSuite) TestAFailedWorldSaveStillNamesTheSheetThatLanded() {
 		"the write the report names really did land")
 }
 
-// TestFreeRoamChargesNothing is TestNothingSpendsYet, flipped.
-//
-// It used to pin a KNOWN GAP: nothing anywhere spent anything, a character could
-// swing as many times in a turn as the caller asked, and its failure was to be
-// the signal that the economy had landed. The economy has landed
-// (rpg-toolkit#1097), and the same three swings in the same scene still land —
-// which is now a RULING rather than a gap, and that is why the test is renamed
-// instead of deleted.
-//
-// The ruling is that the action economy is a FIGHT's economy. It is not this
-// package's invention: combat.Ledger opens with InCombat and refuses every
-// payment from a holder who is not in a fight, and a member on the world clock
-// has no turn to spend a turn's slots from. The duel below is free roam — two
-// characters standing next to each other, no bubble, no initiative order — so
-// the swing is passed no cost at all.
-//
-// EconomySuite is the other half, and neither test means much alone: the same
-// verb refuses a second swing the moment there is a fight to refuse it in. What
-// would make BOTH wrong is a swing charged where there is no economy to charge
-// it against, which the gate would refuse forever rather than once.
-func (s *AttackTestSuite) TestFreeRoamChargesNothing() {
-	mgr := s.duel(&sequenceDice{rolls: []int{15, 5, 15, 5, 15, 5}})
-
-	turn, err := mgr.Turn(context.Background(), &session.TurnInput{Session: "sess", Member: "alice"})
+// TestFreeRoamAttackHasNoDeclaration pins the production contract: Afford is
+// empty on the world clock, so Attack has no selector to echo there. A direct
+// free-roam swing is invalid input and rolls or writes nothing.
+func (s *AttackTestSuite) TestFreeRoamAttackHasNoDeclaration() {
+	roller := &sequenceDice{rolls: []int{15, 5}}
+	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
+	s.characters = newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
+	mgr, err := session.NewManager(&session.Config{
+		Dice: roller, TurnDriver: session.Pass{}, Sessions: s.sessions, Encounters: s.encounters,
+		Characters: s.characters, Events: session.DiscardEvents{},
+	})
 	s.Require().NoError(err)
-	s.Require().Equal(session.ClockWorld, turn.Clock,
-		"the scene is free roam, which is the whole premise of this test")
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: freeRoamDuelWorld(s.T()),
+	})
+	s.Require().NoError(err)
 
-	for i := 0; i < 3; i++ {
-		out, err := s.swing(mgr)
-		s.Require().NoError(err, "swing %d", i+1)
-		s.True(out.Hit, "swing %d", i+1)
-	}
-
-	s.Equal(28-24, 4, "sanity: the fixture starts damaged, so HP is not clamped at max")
-	s.Less(s.characters.byID["bob"].HitPoints, 24,
-		"three uncharged swings all landed — off the turn clock there is no economy")
-	s.Nil(s.characters.byID["alice"].ActionEconomy,
-		"and nothing lit one on her sheet: free roam is not a turn")
+	out, err := mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "bob",
+	})
+	s.ErrorIs(err, session.ErrNoDeclarationID)
+	s.Nil(out)
+	s.Zero(roller.next, "the selector gate precedes every attack roll")
+	s.Equal(24, s.characters.byID["bob"].HitPoints)
 }
 
 // TestAMonsterAttackerIsRefused pins v1's scope as a decision with a successor.
@@ -544,7 +562,7 @@ func (s *AttackTestSuite) TestAMonsterAttackerIsRefused() {
 // does not change and no host that wrote against it has to. Scope by the case,
 // shape for the future.
 func (s *AttackTestSuite) TestTheInputIsMemberNeutral() {
-	s.Equal([]string{"Session", "Attacker", "Target"}, structFields(session.AttackInput{}),
+	s.Equal([]string{"Session", "Attacker", "Target", "DeclarationID"}, structFields(session.AttackInput{}),
 		"a character-shaped field here would make the v1 scope permanent")
 }
 
@@ -565,8 +583,11 @@ func (s *AttackTestSuite) TestRefusals() {
 	_, err = mgr.Attack(ctx, &session.AttackInput{Session: "sess", Attacker: "nobody", Target: "bob"})
 	s.ErrorIs(err, session.ErrNoMember)
 
-	_, err = mgr.Attack(ctx, &session.AttackInput{Session: "sess", Attacker: "alice", Target: "nobody"})
-	s.ErrorIs(err, session.ErrNoMember)
+	_, err = mgr.Attack(ctx, &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "nobody",
+		DeclarationID: currentAttackID(s.T(), mgr, "sess", "alice"),
+	})
+	s.ErrorIs(err, session.ErrStaleDeclaration)
 }
 
 // TestAnEmptyHandThrowsAnUnarmedStrike pins rpg-toolkit#1168 at the seam: an
@@ -601,7 +622,7 @@ func (s *AttackTestSuite) TestAnEmptyHandThrowsAnUnarmedStrike() {
 	s.Require().NoError(err)
 	data := enc.ToData()
 	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
-		Session: "sess", Encounter: "world", World: &data,
+		Session: "sess", Encounter: "world", World: turnWorld(&data, []string{"alice", "bob"}, 0),
 	})
 	s.Require().NoError(err)
 
@@ -637,7 +658,7 @@ func reachWorld(t fataler, bobAt spatial.Position) *encounter.EncounterData {
 		t.Fatalf("building the reach world: %v", err)
 	}
 	data := enc.ToData()
-	return &data
+	return turnWorld(&data, []string{"alice", "bob"}, 0)
 }
 
 // TestOutOfReachIsRefused pins rpg-toolkit#1010 at the seam: a target beyond
@@ -661,8 +682,8 @@ func (s *AttackTestSuite) TestOutOfReachIsRefused() {
 	s.Require().NoError(err)
 
 	_, err = s.swing(mgr)
-	s.ErrorIs(err, session.ErrOutOfReach)
-	s.Contains(err.Error(), "bob")
+	s.ErrorIs(err, session.ErrStaleDeclaration,
+		"a current offer with no available target is unavailable at selection")
 }
 
 // TestReachPropertyExtendsToTwoCells pins the other half: a weapon carrying
@@ -787,12 +808,13 @@ func (s *AttackTestSuite) TestASheetlessTargetIsRefusedByName() {
 	s.Require().NoError(err)
 	data := enc.ToData()
 	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
-		Session: "sess", Encounter: "world", World: &data,
+		Session: "sess", Encounter: "world", World: turnWorld(&data, []string{"alice", "ogre"}, 0),
 	})
 	s.Require().NoError(err)
 
 	_, err = mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "ogre",
+		DeclarationID: currentAttackID(s.T(), mgr, "sess", "alice"),
 	})
 	s.ErrorIs(err, session.ErrNoSheet)
 }
@@ -831,7 +853,7 @@ func (s *AttackTestSuite) duelAmong(members []string, sheets ...*character.Data)
 	data := enc.ToData()
 
 	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
-		Session: "sess", Encounter: "world", World: &data,
+		Session: "sess", Encounter: "world", World: turnWorld(&data, members, 0),
 	})
 	s.Require().NoError(err)
 	return mgr
@@ -868,8 +890,8 @@ func (s *AttackTestSuite) TestAnAbsentAttackerSheetIsAbsentRatherThanCorrupt() {
 
 	_, err := s.swing(mgr)
 	s.Require().Error(err)
-	s.ErrorIs(err, session.ErrNoCharacter, "the repository does not hold alice at all")
-	s.NotErrorIs(err, session.ErrBadCharacter, "absent is not corrupt")
+	s.ErrorIs(err, session.ErrNoDeclarationID,
+		"an unreadable dependency produces a blocker, never an executable selector")
 }
 
 func (s *AttackTestSuite) TestAnUnreadableAttackerSheetIsCorruptRatherThanAbsent() {
@@ -877,8 +899,8 @@ func (s *AttackTestSuite) TestAnUnreadableAttackerSheetIsCorruptRatherThanAbsent
 
 	_, err := s.swing(mgr)
 	s.Require().Error(err)
-	s.ErrorIs(err, session.ErrBadCharacter, "alice's bytes are there and cannot be read")
-	s.NotErrorIs(err, session.ErrNoCharacter, "corrupt is not absent")
+	s.ErrorIs(err, session.ErrNoDeclarationID,
+		"an unreadable dependency produces a blocker, never an executable selector")
 }
 
 // TestAnAbsentBystanderSheetIsAbsentRatherThanCorrupt covers the castFor path:
@@ -912,7 +934,7 @@ func rangedDuelWorld(t fataler, targetX float64) *encounter.EncounterData {
 		t.Fatalf("building ranged duel: %v", err)
 	}
 	data := enc.ToData()
-	return &data
+	return turnWorld(&data, []string{"alice", "bob"}, 0)
 }
 
 func (s *AttackTestSuite) rangedDuel(targetX float64, roller *sequenceDice) *session.Manager {
@@ -947,6 +969,6 @@ func (s *AttackTestSuite) TestCharacterLongbowAttacksAtLongRangeWithDisadvantage
 func (s *AttackTestSuite) TestOutOfRangeAttackRollsNothing() {
 	roller := &sequenceDice{rolls: []int{17, 4}}
 	_, err := s.swing(s.rangedDuel(123, roller)) // 122 cells = 610 feet
-	s.Require().ErrorIs(err, session.ErrOutOfReach)
+	s.Require().ErrorIs(err, session.ErrStaleDeclaration)
 	s.Zero(roller.next)
 }

--- a/rulebooks/dnd5e/session/attack_test.go
+++ b/rulebooks/dnd5e/session/attack_test.go
@@ -778,15 +778,11 @@ func (s *AttackTestSuite) TestNotYourTurnIsRefused() {
 		"the clock is asked before the sheet is — a refusal this early must never have loaded it")
 }
 
-// TestASheetlessTargetIsRefusedByName covers content standing in a world that
-// nobody spawned.
-//
-// An authored monster has no stored sheet until Spawn records one, so there is
-// nothing to read an armour class off and nothing for damage to land on. The
-// strike would fail on its own, but further from the cause and in the
-// resolution module's vocabulary — this refuses earlier, names who, and keeps
-// that module's sentinels off the seam.
-func (s *AttackTestSuite) TestASheetlessTargetIsRefusedByName() {
+// TestAffordThenAttackRefusesASheetlessTargetBeforeExecution covers content
+// standing in a world that nobody spawned. Afford and unchanged Attack must
+// agree before resolution: the candidate remains visible but is Unreadable,
+// the declaration is unavailable, and echoing its selector mutates nothing.
+func (s *AttackTestSuite) TestAffordThenAttackRefusesASheetlessTargetBeforeExecution() {
 	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
 	s.characters = newFakeCharacters(armedFighter("alice"))
 	mgr, err := session.NewManager(&session.Config{
@@ -812,11 +808,27 @@ func (s *AttackTestSuite) TestASheetlessTargetIsRefusedByName() {
 	})
 	s.Require().NoError(err)
 
+	afford, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	decl := requireSingleAttackDeclaration(s.T(), afford.Declarations)
+	s.False(decl.Available, "a sheetless target cannot produce an executable Attack")
+	s.Require().NotNil(decl.Why)
+	s.Equal(session.ShortfallUnreadable, decl.Why.Reason)
+	s.Require().Len(decl.Candidates, 1)
+	s.Equal("ogre", decl.Candidates[0].Member)
+	s.False(decl.Candidates[0].Available)
+	s.Require().NotNil(decl.Candidates[0].Why)
+	s.Equal(session.ShortfallUnreadable, decl.Candidates[0].Why.Reason)
+
+	beforeSessionSaves, beforeEncounterSaves, beforeCharacterSaves :=
+		s.sessions.saves, s.encounters.saves, s.characters.saves
 	_, err = mgr.Attack(context.Background(), &session.AttackInput{
-		Session: "sess", Attacker: "alice", Target: "ogre",
-		DeclarationID: currentAttackID(s.T(), mgr, "sess", "alice"),
+		Session: "sess", Attacker: "alice", Target: "ogre", DeclarationID: decl.ID,
 	})
-	s.ErrorIs(err, session.ErrNoSheet)
+	s.ErrorIs(err, session.ErrStaleDeclaration)
+	s.Equal(beforeSessionSaves, s.sessions.saves)
+	s.Equal(beforeEncounterSaves, s.encounters.saves)
+	s.Equal(beforeCharacterSaves, s.characters.saves)
 }
 
 // duelAmong wires a manager whose world holds the named players and whose
@@ -907,18 +919,76 @@ func (s *AttackTestSuite) TestAnUnreadableAttackerSheetIsCorruptRatherThanAbsent
 // a member who is neither swinging nor being swung at still joins the cast,
 // because applicability is an effect's own predicate (ADR-0038). Their sheet
 // being absent is the same failure as the attacker's and must read the same way.
-func (s *AttackTestSuite) TestAnAbsentBystanderSheetIsAbsentRatherThanCorrupt() {
-	mgr := s.duelAmong([]string{"alice", "bob", "carol"}, armedFighter("alice"), armedFighter("bob"))
+func (s *AttackTestSuite) TestUnreadableTargetAndParticipantBlockAffordBeforeUnchangedAttack() {
+	tests := []struct {
+		name             string
+		sheets           []*character.Data
+		unreadableMember string
+		candidate        bool
+	}{
+		{
+			name: "unreadable target is a candidate refusal",
+			sheets: []*character.Data{
+				armedFighter("alice"), unreadableFighter("bob"),
+			},
+			unreadableMember: "bob",
+			candidate:        true,
+		},
+		{
+			name: "unreadable non-target participant is a global refusal",
+			sheets: []*character.Data{
+				armedFighter("alice"), armedFighter("bob"), unreadableFighter("carol"),
+			},
+			unreadableMember: "carol",
+			candidate:        false,
+		},
+	}
 
-	_, err := s.swing(mgr)
-	s.Require().Error(err)
-	s.ErrorIs(err, session.ErrNoCharacter, "carol is in the roster and not in the repository")
-	s.NotErrorIs(err, session.ErrBadCharacter, "absent is not corrupt")
+	for _, tc := range tests {
+		s.Run(tc.name, func() {
+			members := []string{"alice", "bob"}
+			if tc.unreadableMember == "carol" {
+				members = append(members, "carol")
+			}
+			mgr := s.duelAmong(members, tc.sheets...)
+			if !tc.candidate {
+				// Carol remains a resolution-required roster participant but is
+				// not a live target candidate for Alice.
+				injectHolding(s.T(), s.encounters, tc.unreadableMember, nil)
+			}
 
-	// The role noun earns its keep here more than anywhere else: the host asked
-	// alice to swing at bob and gets back a complaint about carol, who it never
-	// named. "participant" is the word that explains why she was read at all.
-	s.Contains(err.Error(), `participant "carol"`, "say which part the missing member was playing")
+			afford, err := mgr.Afford(context.Background(), &session.AffordInput{
+				Session: "sess", Member: "alice",
+			})
+			s.Require().NoError(err)
+			decl := requireSingleAttackDeclaration(s.T(), afford.Declarations)
+			s.False(decl.Available, "Afford must not advertise an Attack whose cast cannot attach")
+			s.Require().NotNil(decl.Why)
+			s.Equal(session.ShortfallUnreadable, decl.Why.Reason)
+
+			bob := decl.Candidates[0]
+			s.Equal("bob", bob.Member)
+			if tc.candidate {
+				s.False(bob.Available)
+				s.Require().NotNil(bob.Why)
+				s.Equal(session.ShortfallUnreadable, bob.Why.Reason)
+			} else {
+				s.True(bob.Available, "the readable target keeps its independent reach fact")
+				s.Nil(bob.Why)
+			}
+
+			beforeSessionSaves, beforeEncounterSaves, beforeCharacterSaves :=
+				s.sessions.saves, s.encounters.saves, s.characters.saves
+			out, err := mgr.Attack(context.Background(), &session.AttackInput{
+				Session: "sess", Attacker: "alice", Target: "bob", DeclarationID: decl.ID,
+			})
+			s.ErrorIs(err, session.ErrStaleDeclaration)
+			s.Nil(out)
+			s.Equal(beforeSessionSaves, s.sessions.saves)
+			s.Equal(beforeEncounterSaves, s.encounters.saves)
+			s.Equal(beforeCharacterSaves, s.characters.saves)
+		})
+	}
 }
 func rangedDuelWorld(t fataler, targetX float64) *encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{Striker: encounter.RefusingStriker{}, Sight: encEveryoneSees{},

--- a/rulebooks/dnd5e/session/attackevents_test.go
+++ b/rulebooks/dnd5e/session/attackevents_test.go
@@ -56,6 +56,7 @@ func (s *AttackEventsTestSuite) duelWithStream(dice session.Roller) *session.Man
 func (s *AttackEventsTestSuite) swing(mgr *session.Manager) *session.AttackOutput {
 	out, err := mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "bob",
+		DeclarationID: currentAttackID(s.T(), mgr, "sess", "alice"),
 	})
 	s.Require().NoError(err)
 	return out

--- a/rulebooks/dnd5e/session/boundary_test.go
+++ b/rulebooks/dnd5e/session/boundary_test.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
 )
 
 // BoundaryTestSuite enforces S2: no inner type crosses this package's exported
@@ -373,6 +375,18 @@ func fieldIsExported(field *ast.Field) bool {
 func TestBoundarySuite(t *testing.T) {
 	require.NotEmpty(t, forbiddenPrefix)
 	suite.Run(t, new(BoundaryTestSuite))
+}
+
+// TestExecutionInputsCarryOnlyTheSelectorEcho pins the three changed host
+// boundaries exactly. DeclarationID is the sole new authority-bearing field;
+// no compiled definition, spend profile, candidate, or inner type crossed S2.
+func TestExecutionInputsCarryOnlyTheSelectorEcho(t *testing.T) {
+	require.Equal(t, []string{"Session", "Attacker", "Target", "DeclarationID"},
+		structFields(session.AttackInput{}))
+	require.Equal(t, []string{"Session", "Member", "DeclarationID", "Path"},
+		structFields(session.MoveInput{}))
+	require.Equal(t, []string{"Session", "Member", "DeclarationID"},
+		structFields(session.EndTurnInput{}))
 }
 
 // structFields reports the exported field names of a struct value, so a test

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -55,6 +55,28 @@ func run(w io.Writer) error {
 	return err
 }
 
+// compiledMoveID returns the non-empty Move selector the workbench can echo.
+// A blocked Move is reported before the mutating verb is called, preserving the
+// declaration's own explanation when Afford supplied one.
+func compiledMoveID(declarations []session.Declaration) (string, error) {
+	var why string
+	for _, declaration := range declarations {
+		if declaration.Verb != session.VerbMove {
+			continue
+		}
+		if declaration.ID != "" {
+			return declaration.ID, nil
+		}
+		if declaration.Why != nil && declaration.Why.Text != "" {
+			why = declaration.Why.Text
+		}
+	}
+	if why != "" {
+		return "", fmt.Errorf("no compiled Move declaration: %s", why)
+	}
+	return "", fmt.Errorf("no compiled Move declaration")
+}
+
 // loadedDice is this host's source of randomness, and it is here because a
 // fight now starts by itself: sight starts it, mid-walk, and something must be
 // able to say who acts first at that moment.
@@ -365,12 +387,9 @@ func drive(out *bytes.Buffer) error {
 	if err != nil {
 		return err
 	}
-	var moveID string
-	for _, declaration := range afford.Declarations {
-		if declaration.Verb == session.VerbMove {
-			moveID = declaration.ID
-			break
-		}
+	moveID, err := compiledMoveID(afford.Declarations)
+	if err != nil {
+		return err
 	}
 	aliceWalk, err := mgr.Move(ctx, &session.MoveInput{
 		Session: "crypt-run", Member: "alice", Path: vaultPath, DeclarationID: moveID,

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main.go
@@ -361,8 +361,19 @@ func drive(out *bytes.Buffer) error {
 	// refused outright (rpg-toolkit#1169), and it is still her turn: she
 	// leads the vault fight's own initiative order.
 	vaultPath := []spatial.Position{cellAt(7, 1), cellAt(7, 2)}
+	afford, err := mgr.Afford(ctx, &session.AffordInput{Session: "crypt-run", Member: "alice"})
+	if err != nil {
+		return err
+	}
+	var moveID string
+	for _, declaration := range afford.Declarations {
+		if declaration.Verb == session.VerbMove {
+			moveID = declaration.ID
+			break
+		}
+	}
 	aliceWalk, err := mgr.Move(ctx, &session.MoveInput{
-		Session: "crypt-run", Member: "alice", Path: vaultPath,
+		Session: "crypt-run", Member: "alice", Path: vaultPath, DeclarationID: moveID,
 	})
 	if err != nil {
 		return err

--- a/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
+++ b/rulebooks/dnd5e/session/cmd/session-workbench/main_test.go
@@ -7,7 +7,69 @@ import (
 	"bytes"
 	"strings"
 	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
 )
+
+// TestCompiledMoveIDFailsBeforeMove pins the workbench's host-side declaration
+// handoff: an absent or blocked Move is explained before an empty selector ever
+// reaches the mutating verb.
+func TestCompiledMoveIDFailsBeforeMove(t *testing.T) {
+	tests := []struct {
+		name         string
+		declarations []session.Declaration
+		wantID       string
+		wantErr      string
+	}{
+		{
+			name: "compiled Move",
+			declarations: []session.Declaration{
+				{Verb: session.VerbAttack, ID: "attack"},
+				{Verb: session.VerbMove, ID: "move"},
+			},
+			wantID: "move",
+		},
+		{
+			name:    "Move absent",
+			wantErr: "no compiled Move declaration",
+		},
+		{
+			name: "Move blocked without prose",
+			declarations: []session.Declaration{
+				{Verb: session.VerbMove},
+			},
+			wantErr: "no compiled Move declaration",
+		},
+		{
+			name: "Move blocker explains why",
+			declarations: []session.Declaration{
+				{Verb: session.VerbMove, Why: &session.Shortfall{Text: "member is unreadable"}},
+			},
+			wantErr: "member is unreadable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			id, err := compiledMoveID(tt.declarations)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("compiledMoveID() error = %v, want text %q", err, tt.wantErr)
+				}
+				if id != "" {
+					t.Fatalf("compiledMoveID() id = %q on failure", id)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("compiledMoveID() error = %v", err)
+			}
+			if id != tt.wantID {
+				t.Fatalf("compiledMoveID() id = %q, want %q", id, tt.wantID)
+			}
+		})
+	}
+}
 
 // TestWorkbenchRuns exists because of a lesson this repo learned the expensive
 // way: the encounter's workbench was dead on startup for six review passes,

--- a/rulebooks/dnd5e/session/death_test.go
+++ b/rulebooks/dnd5e/session/death_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -126,6 +127,7 @@ func (s *DeathTestSuite) spawnSkeleton() {
 func (s *DeathTestSuite) aliceSwings() *session.AttackOutput {
 	out, err := s.mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "skeleton",
+		DeclarationID: currentAttackID(s.T(), s.mgr, "sess", "alice"),
 	})
 	s.Require().NoError(err)
 
@@ -420,14 +422,17 @@ func (s *DeathTestSuite) TestNothingReachesAClientUnnamed() {
 // this package can drive a character to zero in: Attack compiles character
 // attackers only, so a monster cannot be the one who does it.
 func (s *DeathTestSuite) duelAtZero() {
+	s.characters.byID["bob"].Level = 5
 	_, err := s.mgr.StartSession(context.Background(), &session.StartSessionInput{
-		Session: "sess", Encounter: "world", World: duelWorld(s.T()),
+		Session: "sess", Encounter: "world",
+		World: turnWorld(freeRoamDuelWorld(s.T()), []string{"alice", "bob"}, 1),
 	})
 	s.Require().NoError(err)
 
 	for i := 0; i < 4 && s.characters.byID["alice"].HitPoints > 0; i++ {
 		_, err = s.mgr.Attack(context.Background(), &session.AttackInput{
 			Session: "sess", Attacker: "bob", Target: "alice",
+			DeclarationID: currentAttackID(s.T(), s.mgr, "sess", "bob"),
 		})
 		s.Require().NoError(err)
 	}
@@ -446,8 +451,10 @@ func (s *DeathTestSuite) duelAtZero() {
 // Two characters, because Attack compiles character attackers only: bob is the
 // only thing in this package that can drive alice to zero.
 func (s *DeathTestSuite) TestTheKillingBlowNoticesACHARACTERToo() {
+	s.characters.byID["bob"].Level = 5
 	_, err := s.mgr.StartSession(context.Background(), &session.StartSessionInput{
-		Session: "sess", Encounter: "world", World: duelWorld(s.T()),
+		Session: "sess", Encounter: "world",
+		World: turnWorld(freeRoamDuelWorld(s.T()), []string{"alice", "bob"}, 1),
 	})
 	s.Require().NoError(err)
 	s.stream.published = nil
@@ -455,6 +462,7 @@ func (s *DeathTestSuite) TestTheKillingBlowNoticesACHARACTERToo() {
 	for i := 0; i < 4 && s.characters.byID["alice"].HitPoints > 0; i++ {
 		_, aerr := s.mgr.Attack(context.Background(), &session.AttackInput{
 			Session: "sess", Attacker: "bob", Target: "alice",
+			DeclarationID: currentAttackID(s.T(), s.mgr, "sess", "bob"),
 		})
 		s.Require().NoError(aerr)
 	}
@@ -508,12 +516,14 @@ func (s *DeathTestSuite) TestASwingThatCannotRecordStillNamesTheSheetItWrote() {
 	s.Require().NoError(err)
 
 	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
-		Session: "sess", Encounter: "world", World: duelWorld(s.T()),
+		Session: "sess", Encounter: "world",
+		World: turnWorld(freeRoamDuelWorld(s.T()), []string{"alice", "bob"}, 1),
 	})
 	s.Require().NoError(err)
 
 	_, err = mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "bob", Target: "alice",
+		DeclarationID: currentAttackID(s.T(), mgr, "sess", "bob"),
 	})
 	s.Require().Error(err)
 	s.ErrorIs(err, errStoreWentAway, "the host's own failure is not flattened into ours")
@@ -582,11 +592,20 @@ func (s *DeathTestSuite) TestAMemberStillUpIsNotRefused() {
 func (s *DeathTestSuite) TestAKillingBlowAboutADownedMemberIsStillLegal() {
 	s.duelAtZero()
 
-	out, err := s.mgr.Attack(context.Background(), &session.AttackInput{
-		Session: "sess", Attacker: "bob", Target: "alice",
-	})
-	s.Require().NoError(err, "a down TARGET is not a refused verb")
-	s.NotZero(out.Seq, "and the blow is recorded like any other")
+	story, err := s.mgr.Story(context.Background(), &session.StoryInput{Session: "sess", Member: "bob"})
+	s.Require().NoError(err)
+	s.Require().NotEmpty(story)
+	lastStrike := false
+	for _, event := range story {
+		var beat struct {
+			Beat    string   `json:"beat"`
+			Targets []string `json:"targets"`
+		}
+		if json.Unmarshal(event.Payload, &beat) == nil && beat.Beat == "struck" && slices.Contains(beat.Targets, "alice") {
+			lastStrike = true
+		}
+	}
+	s.True(lastStrike, "the blow that made alice down was still recorded about her")
 }
 
 // TestTheReadsStayOpenToTheDowned is the rest of fork (a): a downed member is

--- a/rulebooks/dnd5e/session/declaration_id.go
+++ b/rulebooks/dnd5e/session/declaration_id.go
@@ -1,0 +1,224 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
+
+	"github.com/cyberphone/json-canonicalization/go/src/webpki.org/jsoncanonicalizer"
+)
+
+// Declaration selector version and the sealed variant strings for the verbs
+// that carry no authored action definition. Any change to these literals, the
+// selector document shape, or the verb/slot bytes requires a selector-version
+// bump — see docs/ideas/session-combat/experience/design.md.
+const (
+	declarationDomain    = "session-declaration:v1"
+	declarationPrefix    = "v1."
+	variantMoveSealed    = "session:move:v1"
+	variantEndTurnSealed = "session:end-turn:v1"
+)
+
+// ErrDeclarationIDCollision is returned by [indexCompiledOffers] when two
+// non-identical compiled offers collide on the same declaration ID. Afford and
+// execution fail closed as an internal provider defect rather than selecting
+// either offer; the same offer recurring with the same ID is not a collision.
+var ErrDeclarationIDCollision = errors.New(
+	"declaration id collision between non-identical offers")
+
+// declarationIDInput is the material a declaration selector is built from. It
+// is the seam-internal shape Task 6's compiled-offer builder feeds to
+// [declarationID]; it never crosses the host boundary.
+type declarationIDInput struct {
+	// Session is the session the declaration belongs to.
+	Session string
+	// Member is the acting member the declaration is priced for.
+	Member string
+	// Verb is the seam verb. Must be one of [VerbAttack], [VerbMove],
+	// [VerbEndTurn]; any other byte is rejected.
+	Verb Verb
+	// Slot is the economy shape this declaration would spend. Must be one of
+	// [SlotNone], [SlotAction], [SlotBonus], [SlotReaction]; any other byte is
+	// rejected.
+	Slot Slot
+	// Attack is the complete validated [combatActions.Definition] for
+	// [VerbAttack]. It must be non-nil for [VerbAttack] and nil for
+	// [VerbMove]/[VerbEndTurn], whose selectors use sealed variant strings
+	// instead.
+	Attack *combatActions.Definition
+}
+
+// selectorDocument is the canonical JSON value a declaration ID is derived
+// from. Field order is irrelevant: the whole document is canonicalized with
+// RFC 8785 before hashing, which fixes object-key ordering, string escaping,
+// number rendering, array framing, and whitespace.
+type selectorDocument struct {
+	Domain  string          `json:"domain"`
+	Session string          `json:"session"`
+	Member  string          `json:"member"`
+	Verb    string          `json:"verb"`
+	Slot    string          `json:"slot"`
+	Variant json.RawMessage `json:"variant"`
+}
+
+// declarationID builds the canonical, full-SHA-256 declaration selector for one
+// compiled offer variant.
+//
+// The selector document carries exactly these keys — domain, session, member,
+// verb, slot, variant — with the verb/slot bytes taken from the seam's own
+// typed constants. For [VerbAttack] the variant is the JSON value produced by
+// serializing the complete validated [combatActions.Definition], so the
+// definition's existing presence semantics (nil vs non-nil empty SpendProfile,
+// omitempty on nil/empty maps and slices) are the selector material. For
+// [VerbMove] and [VerbEndTurn] the variant is a sealed string.
+//
+// The document is canonicalized with the JSON Canonicalization Scheme
+// (RFC 8785) via [jsoncanonicalizer.Transform], hashed with SHA-256, and
+// encoded as unpadded base64url after the prefix "v1.". The full digest is
+// encoded with no truncation. Numbers outside RFC 8785's interoperable exact
+// range are rejected by the canonicalizer rather than approximated.
+func declarationID(input declarationIDInput) (string, error) {
+	if err := validateDeclarationVerbSlot(input.Verb, input.Slot); err != nil {
+		return "", err
+	}
+
+	variant, err := selectorVariant(input.Verb, input.Attack)
+	if err != nil {
+		return "", err
+	}
+
+	doc := selectorDocument{
+		Domain:  declarationDomain,
+		Session: input.Session,
+		Member:  input.Member,
+		Verb:    string(input.Verb),
+		Slot:    string(input.Slot),
+		Variant: variant,
+	}
+
+	raw, err := json.Marshal(doc)
+	if err != nil {
+		return "", fmt.Errorf("declaration selector marshal: %w", err)
+	}
+
+	canonical, err := jsoncanonicalizer.Transform(raw)
+	if err != nil {
+		return "", fmt.Errorf("declaration selector canonicalization: %w", err)
+	}
+
+	sum := sha256.Sum256(canonical)
+	return declarationPrefix + base64.RawURLEncoding.EncodeToString(sum[:]), nil
+}
+
+// validateDeclarationVerbSlot rejects any verb or slot byte outside the seam's
+// closed enum, so a new verb/slot string cannot silently produce a selector
+// under the current version without an explicit bump.
+func validateDeclarationVerbSlot(verb Verb, slot Slot) error {
+	switch verb {
+	case VerbAttack, VerbMove, VerbEndTurn:
+	default:
+		return fmt.Errorf("unsupported declaration verb %q", verb)
+	}
+	switch slot {
+	case SlotNone, SlotAction, SlotBonus, SlotReaction:
+	default:
+		return fmt.Errorf("unsupported declaration slot %q", slot)
+	}
+	return nil
+}
+
+// selectorVariant builds the variant JSON value for one verb. Move and EndTurn
+// use sealed strings; Attack serializes the complete validated definition.
+func selectorVariant(verb Verb, attack *combatActions.Definition) (json.RawMessage, error) {
+	switch verb {
+	case VerbMove:
+		if attack != nil {
+			return nil, fmt.Errorf("move declaration must not carry an attack definition")
+		}
+		return json.RawMessage(`"` + variantMoveSealed + `"`), nil
+	case VerbEndTurn:
+		if attack != nil {
+			return nil, fmt.Errorf("end-turn declaration must not carry an attack definition")
+		}
+		return json.RawMessage(`"` + variantEndTurnSealed + `"`), nil
+	case VerbAttack:
+		if attack == nil {
+			return nil, fmt.Errorf("attack declaration requires an attack definition")
+		}
+		// Validate the complete definition before serialization: this is the
+		// gate that rejects an unvalidated profile and malformed embedded raw
+		// JSON (condition parameters) upstream of canonicalization.
+		if err := attack.Validate(); err != nil {
+			return nil, fmt.Errorf("attack definition is invalid: %w", err)
+		}
+		raw, err := json.Marshal(attack)
+		if err != nil {
+			return nil, fmt.Errorf("attack definition marshal: %w", err)
+		}
+		// Defensive: encoding/json embeds [json.RawMessage] fields verbatim
+		// without parsing them, so a malformed embedded blob could slip past
+		// Validate into a malformed selector document. Reject it here rather
+		// than letting the canonicalizer be the only guard.
+		if !json.Valid(raw) {
+			return nil, fmt.Errorf("attack definition marshal produced malformed JSON")
+		}
+		return json.RawMessage(raw), nil
+	default:
+		// Unreachable after validateDeclarationVerbSlot; kept for completeness.
+		return nil, fmt.Errorf("unsupported declaration verb %q", verb)
+	}
+}
+
+// indexCompiledOffers is the collision guard Task 6 uses when projecting
+// compiled offers. It keys offers by their declaration ID — computed through
+// an injected ID function — and fails closed when two non-identical offers
+// collide on the same ID. Identical offers may share an ID (recurrence), which
+// is not a collision.
+//
+// The primitive is generic over the offer identity so Task 6 can substitute its
+// own compiledOffer type without reshaping this guard; it owns no rules and
+// holds no offer beyond the ID index.
+type indexCompiledOffers[T any] struct {
+	entries map[string]T
+	id      func(T) (string, error)
+	equal   func(a, b T) bool
+}
+
+// newIndexCompiledOffers creates an empty collision guard. id computes the
+// declaration ID for an offer; equal reports whether two offers are the same
+// offer, so a recurring offer does not count as a collision.
+func newIndexCompiledOffers[T any](
+	id func(T) (string, error),
+	equal func(a, b T) bool,
+) *indexCompiledOffers[T] {
+	return &indexCompiledOffers[T]{
+		entries: make(map[string]T),
+		id:      id,
+		equal:   equal,
+	}
+}
+
+// add records offer under its declaration ID. It returns [ErrDeclarationIDCollision]
+// when the ID is already present and the existing offer is not equal to offer.
+// An ID-function error propagates unchanged.
+func (idx *indexCompiledOffers[T]) add(offer T) error {
+	id, err := idx.id(offer)
+	if err != nil {
+		return err
+	}
+	if existing, ok := idx.entries[id]; ok {
+		if idx.equal(existing, offer) {
+			return nil
+		}
+		return ErrDeclarationIDCollision
+	}
+	idx.entries[id] = offer
+	return nil
+}

--- a/rulebooks/dnd5e/session/declaration_id.go
+++ b/rulebooks/dnd5e/session/declaration_id.go
@@ -34,7 +34,7 @@ var ErrDeclarationIDCollision = errors.New(
 	"declaration id collision between non-identical offers")
 
 // declarationIDInput is the material a declaration selector is built from. It
-// is the seam-internal shape Task 6's compiled-offer builder feeds to
+// is the seam-internal shape the compiled-offer builder feeds to
 // [declarationID]; it never crosses the host boundary.
 type declarationIDInput struct {
 	// Session is the session the declaration belongs to.
@@ -176,13 +176,13 @@ func selectorVariant(verb Verb, attack *combatActions.Definition) (json.RawMessa
 	}
 }
 
-// indexCompiledOffers is the collision guard Task 6 uses when projecting
+// indexCompiledOffers is the collision guard offer compilation uses when projecting
 // compiled offers. It keys offers by their declaration ID — computed through
 // an injected ID function — and fails closed when two non-identical offers
 // collide on the same ID. Identical offers may share an ID (recurrence), which
 // is not a collision.
 //
-// The primitive is generic over the offer identity so Task 6 can substitute its
+// The primitive is generic over the offer identity so compilation can use its
 // own compiledOffer type without reshaping this guard; it owns no rules and
 // holds no offer beyond the ID index.
 type indexCompiledOffers[T any] struct {

--- a/rulebooks/dnd5e/session/declaration_id.go
+++ b/rulebooks/dnd5e/session/declaration_id.go
@@ -26,11 +26,11 @@ const (
 	variantEndTurnSealed = "session:end-turn:v1"
 )
 
-// ErrDeclarationIDCollision is returned by [indexCompiledOffers] when two
-// non-identical compiled offers collide on the same declaration ID. Afford and
-// execution fail closed as an internal provider defect rather than selecting
-// either offer; the same offer recurring with the same ID is not a collision.
-var ErrDeclarationIDCollision = errors.New(
+// errDeclarationIDCollision is returned internally when two non-identical
+// compiled offers collide on one declaration ID. It is a provider defect, not
+// a host-facing remedy, so Afford/execution fail closed without exporting a new
+// session sentinel.
+var errDeclarationIDCollision = errors.New(
 	"declaration id collision between non-identical offers")
 
 // declarationIDInput is the material a declaration selector is built from. It
@@ -115,6 +115,26 @@ func declarationID(input declarationIDInput) (string, error) {
 
 	sum := sha256.Sum256(canonical)
 	return declarationPrefix + base64.RawURLEncoding.EncodeToString(sum[:]), nil
+}
+
+func canonicalSelectorVariant(raw json.RawMessage) (json.RawMessage, error) {
+	wrapped, err := json.Marshal(struct {
+		Variant json.RawMessage `json:"variant"`
+	}{Variant: raw})
+	if err != nil {
+		return nil, fmt.Errorf("declaration selector variant marshal: %w", err)
+	}
+	canonical, err := jsoncanonicalizer.Transform(wrapped)
+	if err != nil {
+		return nil, fmt.Errorf("declaration selector variant canonicalization: %w", err)
+	}
+	var out struct {
+		Variant json.RawMessage `json:"variant"`
+	}
+	if err := json.Unmarshal(canonical, &out); err != nil {
+		return nil, fmt.Errorf("declaration selector canonical variant read: %w", err)
+	}
+	return out.Variant, nil
 }
 
 // validateDeclarationVerbSlot rejects any verb or slot byte outside the seam's
@@ -205,9 +225,9 @@ func newIndexCompiledOffers[T any](
 	}
 }
 
-// add records offer under its declaration ID. It returns [ErrDeclarationIDCollision]
-// when the ID is already present and the existing offer is not equal to offer.
-// An ID-function error propagates unchanged.
+// add records offer under its declaration ID. It returns
+// errDeclarationIDCollision when the ID is already present and the existing
+// offer is not equal to offer. An ID-function error propagates unchanged.
 func (idx *indexCompiledOffers[T]) add(offer T) error {
 	id, err := idx.id(offer)
 	if err != nil {
@@ -217,7 +237,7 @@ func (idx *indexCompiledOffers[T]) add(offer T) error {
 		if idx.equal(existing, offer) {
 			return nil
 		}
-		return ErrDeclarationIDCollision
+		return errDeclarationIDCollision
 	}
 	idx.entries[id] = offer
 	return nil

--- a/rulebooks/dnd5e/session/declaration_id_test.go
+++ b/rulebooks/dnd5e/session/declaration_id_test.go
@@ -10,8 +10,6 @@ import (
 
 	"github.com/stretchr/testify/require"
 
-	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
-	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
@@ -419,10 +417,3 @@ func newInjectedIDError() error { return &injectedIDError{msg: "injected id fail
 type injectedIDError struct{ msg string }
 
 func (e *injectedIDError) Error() string { return e.msg }
-
-// keep coreCombat/coreResources imports referenced for fixture richness if the
-// golden fixture is later extended with slot/pool costs.
-var (
-	_ = coreCombat.ActionStandard
-	_ = coreResources.ResourceKey("ki")
-)

--- a/rulebooks/dnd5e/session/declaration_id_test.go
+++ b/rulebooks/dnd5e/session/declaration_id_test.go
@@ -1,0 +1,428 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/saves"
+)
+
+// goldenAttackDefinition mirrors the validated fixture in the actions package
+// (rulebooks/dnd5e/combat/actions/definition_test.go) so the Attack selector
+// golden pins the canonical form of a real, complete Definition — not a
+// hand-authored JSON string.
+func goldenAttackDefinition() combatActions.Definition {
+	profile := combatActions.AttackProfile{
+		Category: combatActions.AttackCategoryWeapon,
+		Delivery: combatActions.AttackDelivery{
+			Melee: &combatActions.MeleeDelivery{ReachFeet: 5},
+		},
+		AttackBonus: 5,
+		Ability: &combatActions.AbilityContribution{
+			Ability:  abilities.STR,
+			Modifier: 3,
+		},
+		Weapon: &combatActions.WeaponContext{Ref: refs.Weapons.Longsword()},
+		Damage: []damage.Damage{{
+			Dice:       "1d8",
+			Type:       damage.Slashing,
+			Properties: []damage.Property{damage.AddsAttackAbilityModifier},
+		}},
+	}
+	return combatActions.Definition{
+		Ref:    *refs.Weapons.Longsword(),
+		Name:   "Longsword",
+		Cost:   &combat.SpendProfile{Capacity: map[combat.CapacityType]int{combat.CapacityAttack: 1}},
+		Attack: &profile,
+	}
+}
+
+func TestMoveDeclarationIDGolden(t *testing.T) {
+	got, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbMove, Slot: SlotNone,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "v1.Mhnl9aRJjeAvMxtlbRFFHVH-XoMkgR4l1pasCSyzrjc", got)
+}
+
+func TestEndTurnDeclarationIDGolden(t *testing.T) {
+	got, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbEndTurn, Slot: SlotNone,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "v1.yZ1FHWnV7SnulpNVV4kz1BSkslDxfXr-lEINSahGUDo", got)
+}
+
+func TestAttackDeclarationIDGolden(t *testing.T) {
+	def := goldenAttackDefinition()
+	require.NoError(t, def.Validate())
+
+	got, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Slot: SlotAction, Attack: &def,
+	})
+	require.NoError(t, err)
+	require.Equal(t, "v1.ZmGXGvVkJHmrxzEhR7xYqlIEkrB6xRsawMp6l4UX6fM", got)
+}
+
+func TestDeclarationIDMapInsertionOrderIsCanonical(t *testing.T) {
+	base := goldenAttackDefinition()
+
+	// Two profiles with the same multi-key SpendProfile content, written with
+	// different map-literal key order. RFC 8785 canonicalization fixes key
+	// order, so the selector IDs must agree regardless of how the maps were
+	// assembled.
+	defA := base
+	defA.Cost = &combat.SpendProfile{
+		Capacity: map[combat.CapacityType]int{
+			combat.CapacityAttack:   1,
+			combat.CapacityMovement: 5,
+		},
+	}
+	defB := base
+	defB.Cost = &combat.SpendProfile{
+		Capacity: map[combat.CapacityType]int{
+			combat.CapacityMovement: 5,
+			combat.CapacityAttack:   1,
+		},
+	}
+
+	idA, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Slot: SlotAction, Attack: &defA,
+	})
+	require.NoError(t, err)
+	idB, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Slot: SlotAction, Attack: &defB,
+	})
+	require.NoError(t, err)
+	require.Equal(t, idA, idB, "map insertion order must not affect the selector ID")
+}
+
+func TestDeclarationIDNilVsEmptySpendProfileNormalization(t *testing.T) {
+	base := goldenAttackDefinition()
+
+	// nil Cost: the "cost" key is omitted entirely by omitempty.
+	nilCost := base
+	nilCost.Cost = nil
+
+	// Non-nil empty SpendProfile: all internal maps are nil, so omitempty
+	// leaves "cost": {} — distinct from a nil cost.
+	emptyCost := base
+	emptyCost.Cost = &combat.SpendProfile{}
+
+	// Non-nil SpendProfile with empty (non-nil) maps: omitempty omits empty
+	// maps, so this canonicalizes to "cost": {} too — the SAME selector
+	// material as the all-nil-maps profile above.
+	emptyMapCost := base
+	emptyMapCost.Cost = &combat.SpendProfile{
+		Capacity: map[combat.CapacityType]int{},
+	}
+
+	in := declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Slot: SlotAction,
+	}
+
+	idNil, err := declarationID(withAttack(in, &nilCost))
+	require.NoError(t, err)
+	idEmpty, err := declarationID(withAttack(in, &emptyCost))
+	require.NoError(t, err)
+	idEmptyMap, err := declarationID(withAttack(in, &emptyMapCost))
+	require.NoError(t, err)
+
+	require.NotEqual(t, idNil, idEmpty,
+		"a nil cost and a non-nil empty SpendProfile are distinct selector material")
+	require.Equal(t, idEmpty, idEmptyMap,
+		"nil and empty maps within a non-nil SpendProfile normalize to the same selector material")
+}
+
+func TestDeclarationIDEmbeddedRawJSONCanonicalization(t *testing.T) {
+	base := goldenAttackDefinition()
+
+	// Two equivalent condition-parameter blobs written with different key
+	// order. The canonicalizer normalizes object key order, so the IDs agree.
+	// Each variant is deep-copied from the base fixture so the shared Attack
+	// pointer is not aliased across the two mutations.
+	defA := base.Clone()
+	defA.Attack.OnHit = []combatActions.ConditionApplication{{
+		Ref:        *refs.Conditions.Prone(),
+		Parameters: json.RawMessage(`{"duration":1,"level":2}`),
+		Save:       saves.NewSaveGate(abilities.STR, 11),
+	}}
+	defB := base.Clone()
+	defB.Attack.OnHit = []combatActions.ConditionApplication{{
+		Ref:        *refs.Conditions.Prone(),
+		Parameters: json.RawMessage(`{"level":2,"duration":1}`),
+		Save:       saves.NewSaveGate(abilities.STR, 11),
+	}}
+
+	in := declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Slot: SlotAction,
+	}
+	idA, err := declarationID(withAttack(in, &defA))
+	require.NoError(t, err)
+	idB, err := declarationID(withAttack(in, &defB))
+	require.NoError(t, err)
+	require.Equal(t, idA, idB,
+		"embedded raw JSON with different key order must canonicalize to the same selector ID")
+}
+
+func TestDeclarationIDChangedProfileChangesID(t *testing.T) {
+	base := goldenAttackDefinition()
+
+	// Deep-copy so the reach mutation does not alias the base Attack pointer.
+	changed := base.Clone()
+	changed.Attack.Delivery.Melee.ReachFeet = 10
+
+	in := declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Slot: SlotAction,
+	}
+	idBase, err := declarationID(withAttack(in, &base))
+	require.NoError(t, err)
+	idChanged, err := declarationID(withAttack(in, &changed))
+	require.NoError(t, err)
+	require.NotEqual(t, idBase, idChanged,
+		"a changed attack profile must produce a different selector ID")
+}
+
+func TestDeclarationIDSameStateRecurrence(t *testing.T) {
+	in := declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Slot: SlotAction, Attack: ptrDefinition(goldenAttackDefinition()),
+	}
+	first, err := declarationID(in)
+	require.NoError(t, err)
+	second, err := declarationID(in)
+	require.NoError(t, err)
+	require.Equal(t, first, second,
+		"the same selector input must receive the same ID when state recurs")
+}
+
+func TestDeclarationIDFullDigestPayload(t *testing.T) {
+	got, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbMove, Slot: SlotNone,
+	})
+	require.NoError(t, err)
+
+	require.True(t, strings.HasPrefix(got, "v1."),
+		"selector ID must carry the v1. prefix; got %q", got)
+	digest := strings.TrimPrefix(got, "v1.")
+	require.Len(t, digest, 43,
+		"the base64url digest payload must be the full 43-character SHA-256 encoding; got %q", digest)
+	require.NotContains(t, digest, "=",
+		"the digest payload must be unpadded base64url; got %q", digest)
+}
+
+func TestDeclarationIDRejectsUnsupportedVerb(t *testing.T) {
+	_, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: Verb("fly"), Slot: SlotNone,
+	})
+	require.Error(t, err)
+}
+
+func TestDeclarationIDRejectsUnsupportedSlot(t *testing.T) {
+	_, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbMove, Slot: Slot("legendary"),
+	})
+	require.Error(t, err)
+}
+
+func TestDeclarationIDRejectsAttackWithoutDefinition(t *testing.T) {
+	_, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Slot: SlotAction,
+	})
+	require.Error(t, err)
+}
+
+func TestDeclarationIDRejectsMoveWithAttackDefinition(t *testing.T) {
+	def := goldenAttackDefinition()
+	_, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbMove, Slot: SlotNone, Attack: &def,
+	})
+	require.Error(t, err)
+}
+
+func TestDeclarationIDRejectsUnvalidatedAttackDefinition(t *testing.T) {
+	def := goldenAttackDefinition()
+	def.Attack = nil // invalid: exactly one profile required
+	_, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Slot: SlotAction, Attack: &def,
+	})
+	require.Error(t, err)
+}
+
+func TestDeclarationIDRejectsMalformedEmbeddedRawJSON(t *testing.T) {
+	def := goldenAttackDefinition()
+	def.Attack.OnHit = []combatActions.ConditionApplication{{
+		Ref:        *refs.Conditions.Prone(),
+		Parameters: json.RawMessage(`{"duration":1,`), // malformed
+		Save:       saves.NewSaveGate(abilities.STR, 11),
+	}}
+	// Definition.Validate rejects malformed Parameters before serialization.
+	_, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Slot: SlotAction, Attack: &def,
+	})
+	require.Error(t, err)
+}
+
+func TestDeclarationIDRejectsNonRFCNumber(t *testing.T) {
+	// A SpendProfile amount is an int and always RFC 8785-interoperable, so the
+	// canonicalizer itself is the guard that fails on a non-interoperable
+	// number. We exercise it by feeding a variant whose embedded raw JSON
+	// carries a number outside RFC 8785's exact integer range; the
+	// canonicalizer must reject it rather than approximate.
+	def := goldenAttackDefinition()
+	def.Attack.OnHit = []combatActions.ConditionApplication{{
+		Ref:        *refs.Conditions.Prone(),
+		Parameters: json.RawMessage(`{"overflow":1e999}`),
+		Save:       saves.NewSaveGate(abilities.STR, 11),
+	}}
+	// json.Valid accepts 1e999, so Definition.Validate does not catch it; the
+	// canonicalizer is the guard that fails closed.
+	require.True(t, json.Valid(def.Attack.OnHit[0].Parameters))
+
+	_, err := declarationID(declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Slot: SlotAction, Attack: &def,
+	})
+	require.Error(t, err, "a number outside RFC 8785's exact range must fail rather than approximate")
+}
+
+func TestDeclarationIDSlotsDistinct(t *testing.T) {
+	def := goldenAttackDefinition()
+	in := declarationIDInput{
+		Session: "session-1", Member: "fighter-1",
+		Verb: VerbAttack, Attack: &def,
+	}
+	idAction, err := declarationID(withSlot(in, SlotAction))
+	require.NoError(t, err)
+	idBonus, err := declarationID(withSlot(in, SlotBonus))
+	require.NoError(t, err)
+	idNone, err := declarationID(withSlot(in, SlotNone))
+	require.NoError(t, err)
+	require.NotEqual(t, idAction, idBonus)
+	require.NotEqual(t, idAction, idNone)
+	require.NotEqual(t, idBonus, idNone)
+}
+
+// testOffer is the minimal identity the collision index carries in these tests.
+// Task 6 will substitute its own compiledOffer; here we only prove the
+// fail-closed primitive over an injected ID function.
+type testOffer struct {
+	name string
+}
+
+func TestCompiledOfferCollisionDuplicateIDFailClosed(t *testing.T) {
+	equalByName := func(a, b testOffer) bool { return a.name == b.name }
+
+	t.Run("non-identical offers with the same ID fail closed", func(t *testing.T) {
+		// Injected ID function forces a collision: every offer maps to the
+		// same selector ID.
+		idx := newIndexCompiledOffers(
+			func(testOffer) (string, error) { return "v1.colliding", nil },
+			equalByName,
+		)
+
+		require.NoError(t, idx.add(testOffer{name: "alpha"}))
+		err := idx.add(testOffer{name: "beta"})
+		require.ErrorIs(t, err, ErrDeclarationIDCollision)
+	})
+
+	t.Run("identical offers with the same ID are recurrence, not collision", func(t *testing.T) {
+		idx := newIndexCompiledOffers(
+			func(testOffer) (string, error) { return "v1.recurring", nil },
+			equalByName,
+		)
+
+		require.NoError(t, idx.add(testOffer{name: "alpha"}))
+		require.NoError(t, idx.add(testOffer{name: "alpha"}))
+	})
+
+	t.Run("ID function error propagates", func(t *testing.T) {
+		idx := newIndexCompiledOffers(
+			func(testOffer) (string, error) { return "", errInjectedID },
+			equalByName,
+		)
+		err := idx.add(testOffer{name: "alpha"})
+		require.ErrorIs(t, err, errInjectedID)
+	})
+
+	t.Run("real declarationID distinguishes distinct Move offers", func(t *testing.T) {
+		// Integration: the injected ID function is the real declarationID over
+		// a Move offer, proving the primitive composes with the selector.
+		idFor := func(o testOffer) (string, error) {
+			return declarationID(declarationIDInput{
+				Session: "session-1", Member: o.name,
+				Verb: VerbMove, Slot: SlotNone,
+			})
+		}
+		idx := newIndexCompiledOffers(idFor, equalByName)
+
+		require.NoError(t, idx.add(testOffer{name: "fighter-1"}))
+		require.NoError(t, idx.add(testOffer{name: "rogue-2"}))
+		// A second distinct member colliding is impossible here because the
+		// IDs differ; this just exercises the happy path through the real
+		// selector.
+	})
+}
+
+// withAttack returns a copy of in carrying the given attack definition, so the
+// table-style tests above can vary one field without repeating the whole input.
+func withAttack(in declarationIDInput, def *combatActions.Definition) declarationIDInput {
+	out := in
+	out.Attack = def
+	return out
+}
+
+func withSlot(in declarationIDInput, slot Slot) declarationIDInput {
+	out := in
+	out.Slot = slot
+	return out
+}
+
+func ptrDefinition(d combatActions.Definition) *combatActions.Definition {
+	return &d
+}
+
+// errInjectedID is a sentinel the collision tests inject through the ID
+// function to prove errors propagate unchanged.
+var errInjectedID = newInjectedIDError()
+
+func newInjectedIDError() error { return &injectedIDError{msg: "injected id failure"} }
+
+type injectedIDError struct{ msg string }
+
+func (e *injectedIDError) Error() string { return e.msg }
+
+// keep coreCombat/coreResources imports referenced for fixture richness if the
+// golden fixture is later extended with slot/pool costs.
+var (
+	_ = coreCombat.ActionStandard
+	_ = coreResources.ResourceKey("ki")
+)

--- a/rulebooks/dnd5e/session/declaration_id_test.go
+++ b/rulebooks/dnd5e/session/declaration_id_test.go
@@ -349,7 +349,7 @@ func TestCompiledOfferCollisionDuplicateIDFailClosed(t *testing.T) {
 
 		require.NoError(t, idx.add(testOffer{name: "alpha"}))
 		err := idx.add(testOffer{name: "beta"})
-		require.ErrorIs(t, err, ErrDeclarationIDCollision)
+		require.ErrorIs(t, err, errDeclarationIDCollision)
 	})
 
 	t.Run("identical offers with the same ID are recurrence, not collision", func(t *testing.T) {
@@ -360,6 +360,39 @@ func TestCompiledOfferCollisionDuplicateIDFailClosed(t *testing.T) {
 
 		require.NoError(t, idx.add(testOffer{name: "alpha"}))
 		require.NoError(t, idx.add(testOffer{name: "alpha"}))
+	})
+
+	t.Run("RFC8785-equivalent map order is recurrence, not collision", func(t *testing.T) {
+		left := goldenAttackDefinition()
+		left.Attack.OnHit = []combatActions.ConditionApplication{{
+			Ref: *refs.Conditions.Prone(), Parameters: json.RawMessage(`{"first":1,"second":2}`),
+			Save: saves.NewSaveGate(abilities.STR, 11),
+		}}
+		right := left.Clone()
+		right.Attack.OnHit[0].Parameters = json.RawMessage(`{"second":2,"first":1}`)
+
+		leftID, err := declarationID(declarationIDInput{
+			Session: "session-1", Member: "fighter-1", Verb: VerbAttack, Slot: SlotAction, Attack: &left,
+		})
+		require.NoError(t, err)
+		rightID, err := declarationID(declarationIDInput{
+			Session: "session-1", Member: "fighter-1", Verb: VerbAttack, Slot: SlotAction, Attack: &right,
+		})
+		require.NoError(t, err)
+		require.Equal(t, leftID, rightID, "RFC8785 canonical selectors are equal")
+		leftVariant, err := selectorVariant(VerbAttack, &left)
+		require.NoError(t, err)
+		rightVariant, err := selectorVariant(VerbAttack, &right)
+		require.NoError(t, err)
+		require.NotEqual(t, string(leftVariant), string(rightVariant),
+			"the fixture must reach equality with different raw object order")
+
+		offers := []compiledOffer{
+			{declaration: Declaration{ID: leftID}, verb: VerbAttack, slot: SlotAction, variant: leftVariant},
+			{declaration: Declaration{ID: rightID}, verb: VerbAttack, slot: SlotAction, variant: rightVariant},
+		}
+		require.NoError(t, guardOfferCollisions(offers),
+			"raw JSON object order must not turn equivalent offers into a collision")
 	})
 
 	t.Run("ID function error propagates", func(t *testing.T) {

--- a/rulebooks/dnd5e/session/doc.go
+++ b/rulebooks/dnd5e/session/doc.go
@@ -93,8 +93,11 @@
 // require that ID back; Move requires it on the turn clock and requires it
 // empty on the world clock, where Afford deliberately returns no declarations.
 //
-// A mutating verb reloads current state, regenerates the offer, and selects the
-// echoed ID before touching dice, movement, storage, or story. Unknown,
+// A mutating verb reloads current state, regenerates only its own offer, and
+// selects the echoed ID before touching dice, movement, storage, or story.
+// Turn-clock Move therefore never inherits Attack pricing, target-view, or
+// participant-cast dependencies; Afford still compiles all verbs from one actor
+// snapshot. Unknown,
 // mismatched, now-unavailable, and target-invalid selection is
 // ErrStaleDeclaration; omission is ErrNoDeclarationID. IDs are selectors, not
 // authorization or idempotency tokens: the host still binds the acting member

--- a/rulebooks/dnd5e/session/doc.go
+++ b/rulebooks/dnd5e/session/doc.go
@@ -101,11 +101,12 @@
 // to its authenticated caller.
 //
 // The compiled object never crosses S2. For Attack it privately carries the
-// complete priced definition, matching resolution cost/readied payer, and the
-// shared candidate preflight. Execution reuses those values rather than
-// selecting one definition and independently compiling another. EndTurn is
-// intentionally clock-only; it does not inherit Attack/Move sheet, standing,
-// or economy gates.
+// complete priced definition, matching resolution cost/readied payer, shared
+// candidate preflight, and one raw participant-data cast. Compilation strictly
+// exercises that cast through the same public character/monster load-and-attach
+// APIs resolution uses. Execution reuses those exact raw participant values and
+// never refetches a participant after selection. EndTurn is intentionally
+// clock-only; it does not inherit Attack/Move sheet, standing, or economy gates.
 //
 // # The suspension spine, and where it went
 //

--- a/rulebooks/dnd5e/session/doc.go
+++ b/rulebooks/dnd5e/session/doc.go
@@ -85,6 +85,28 @@
 // persisted in every stored world; kindOf is where the two meet. See ErrDowned
 // and EventDowned.
 //
+// # Compiled declarations are the execution trust boundary
+//
+// Afford is the one current action surface on the turn clock. It compiles an
+// Attack, Move, and EndTurn offer, projects only seam-owned values, and gives
+// each compiled offer an opaque deterministic selector. Attack and EndTurn
+// require that ID back; Move requires it on the turn clock and requires it
+// empty on the world clock, where Afford deliberately returns no declarations.
+//
+// A mutating verb reloads current state, regenerates the offer, and selects the
+// echoed ID before touching dice, movement, storage, or story. Unknown,
+// mismatched, now-unavailable, and target-invalid selection is
+// ErrStaleDeclaration; omission is ErrNoDeclarationID. IDs are selectors, not
+// authorization or idempotency tokens: the host still binds the acting member
+// to its authenticated caller.
+//
+// The compiled object never crosses S2. For Attack it privately carries the
+// complete priced definition, matching resolution cost/readied payer, and the
+// shared candidate preflight. Execution reuses those values rather than
+// selecting one definition and independently compiling another. EndTurn is
+// intentionally clock-only; it does not inherit Attack/Move sheet, standing,
+// or economy gates.
+//
 // # The suspension spine, and where it went
 //
 // S5 and S7 were laws here through v0.2.0: Pending was the one suspension

--- a/rulebooks/dnd5e/session/economy.go
+++ b/rulebooks/dnd5e/session/economy.go
@@ -79,9 +79,9 @@ type swingPrice struct {
 // It was shipped anyway, deliberately, when nothing read it: movement cost
 // nothing (the ruling's fork (d)), so no profile named CapacityMovement and no
 // path spent it, and this line was named as the one that would have to grow a
-// real answer the day that changed. That day is rpg-toolkit#1169:
-// [Manager.priceWalk] now spends exactly the MovementRemaining this call
-// seeds, through the identical [combat.Pay] gate a swing pays through. The
+// real answer the day that changed. That day is rpg-toolkit#1169: turn-clock
+// [Manager.Move] now spends exactly the MovementRemaining this call seeds,
+// through the identical [combat.Pay] gate a swing pays through. The
 // haste/slow gap is unchanged and still real — a speed computed where
 // conditions can be asked is still above this seam — but it is no longer
 // theoretical, and the day it is closed this comment is where to start.

--- a/rulebooks/dnd5e/session/economy_test.go
+++ b/rulebooks/dnd5e/session/economy_test.go
@@ -150,6 +150,7 @@ func aFight(
 func (s *EconomySuite) swing() (*session.AttackOutput, error) {
 	return s.mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "skeleton",
+		DeclarationID: currentAttackID(s.T(), s.mgr, "sess", "alice"),
 	})
 }
 
@@ -164,7 +165,10 @@ func (s *EconomySuite) nextTurn() {
 	s.T().Helper()
 	ctx := context.Background()
 
-	_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	_, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{
+		Session: "sess", Member: "alice",
+		DeclarationID: currentEndTurnID(s.T(), s.mgr, "sess", "alice"),
+	})
 	s.Require().NoError(err, "ending alice's turn")
 
 	turn, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
@@ -218,11 +222,8 @@ func (s *EconomySuite) TestALevel1FightersSecondSwingIsRefused() {
 
 	_, err = s.swing()
 	s.Require().Error(err, "and there is nothing left to buy a second")
-	s.ErrorIs(err, session.ErrCannotAfford)
-	s.Contains(err.Error(), "action",
-		"the refusal names the currency that ran out")
-	s.Contains(err.Error(), "alice",
-		"and who ran out of it")
+	s.ErrorIs(err, session.ErrStaleDeclaration,
+		"a selector whose current offer is unavailable is stale before resolution")
 }
 
 // TestTheRefusalIsOursAndNotResolutions is the #1058/#1066 law reaching the
@@ -241,7 +242,7 @@ func (s *EconomySuite) TestTheRefusalIsOursAndNotResolutions() {
 	_, err = s.swing()
 	s.Require().Error(err)
 
-	s.ErrorIs(err, session.ErrCannotAfford, "the host is answered in this package's vocabulary")
+	s.ErrorIs(err, session.ErrStaleDeclaration, "the host is answered in this package's vocabulary")
 	s.NotErrorIs(err, resolution.ErrCannotPay,
 		"and cannot reach resolution's, which would couple it to a module we intend to replace")
 	s.NotErrorIs(err, resolution.ErrBadCost)
@@ -266,9 +267,7 @@ func (s *EconomySuite) TestExtraAttackBuysASecondSwing() {
 
 	_, err = s.swing()
 	s.Require().Error(err, "swing 3 has nothing left")
-	s.ErrorIs(err, session.ErrCannotAfford)
-	s.Contains(err.Error(), "action",
-		"and it is the action that ran out — the bank was emptied by the swing before")
+	s.ErrorIs(err, session.ErrStaleDeclaration)
 }
 
 // TestARefusedSwingWritesNothing is the #1056 shape asked of the economy.
@@ -294,7 +293,7 @@ func (s *EconomySuite) TestARefusedSwingWritesNothing() {
 	economyBefore := *s.storedEconomy()
 
 	_, err = s.swing()
-	s.Require().ErrorIs(err, session.ErrCannotAfford)
+	s.Require().ErrorIs(err, session.ErrStaleDeclaration)
 
 	s.Equal(hpBefore, s.storedSkeleton(), "a refused swing damaged nobody")
 	s.Len(s.story(), storyBefore, "and recorded no beat")
@@ -322,7 +321,7 @@ func (s *EconomySuite) TestTheFirstSwingSurvivesTheRefusal() {
 	s.Require().Equal(8, first.Damage, "15 + 3 STR + 2 proficiency lands; the die scripted to 5 plus 3 deals 8")
 
 	_, err = s.swing()
-	s.Require().ErrorIs(err, session.ErrCannotAfford)
+	s.Require().ErrorIs(err, session.ErrStaleDeclaration)
 
 	s.Equal(13-8, s.storedSkeleton(), "the blow that landed is still on the stored sheet")
 	s.NotEmpty(s.story(), "and its beat is still in the story")
@@ -342,7 +341,7 @@ func (s *EconomySuite) TestANewTurnRefillsTheBank() {
 	_, err := s.swing()
 	s.Require().NoError(err)
 	_, err = s.swing()
-	s.Require().ErrorIs(err, session.ErrCannotAfford, "spent, on turn one")
+	s.Require().ErrorIs(err, session.ErrStaleDeclaration, "spent, on turn one")
 
 	s.nextTurn()
 
@@ -409,6 +408,6 @@ func (s *EconomySuite) TestTheTurnIsLitOnceAndSpentFromThereafter() {
 	s.Zero(lit.ActionsRemaining, "and the action it cost is spent")
 
 	_, err = s.swing()
-	s.ErrorIs(err, session.ErrCannotAfford,
+	s.ErrorIs(err, session.ErrStaleDeclaration,
 		"a second ask must not re-light the turn — that would refill the bank it just spent")
 }

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -341,17 +341,16 @@ var (
 	// malformed declared action, or a weapon the strike has no semantics for.
 	ErrBadAttack = errors.New("attack cannot be made")
 
-	// ErrOutOfReach is returned when Attack names a target further from the
-	// attacker than the compiled delivery permits: one cell for ordinary melee,
-	// two for Reach weapons (rpg-toolkit#1010), and beyond long range for a
-	// supported ranged weapon. Targets inside a ranged weapon's normal and long
-	// brackets still resolve; only beyond long range reaches this sentinel.
+	// ErrOutOfReach is Attack's final defensive resolution validation when a
+	// target is further away than the selected definition's delivery permits:
+	// one cell for ordinary melee, two for Reach weapons (rpg-toolkit#1010),
+	// and beyond long range for a supported ranged weapon.
 	//
-	// Afford's per-target ATTACK declarations are this same gate asked
-	// ahead of time: a target this seam would refuse with ErrOutOfReach is
-	// an unavailable candidate row. When no candidate is in reach at all,
-	// Afford still answers once — a single Attack declaration with
-	// Available false, Why.Reason ShortfallNoTargetInReach — rather than
+	// Normal execution refuses reach changes earlier as ErrStaleDeclaration:
+	// Afford projects the shared preflight as candidate availability, and Attack
+	// regenerates and selects that current candidate before resolution. When no
+	// candidate is in reach, Afford still answers once — a single unavailable
+	// Attack declaration with Why.Reason ShortfallNoTargetInReach — rather than
 	// an empty list a client could mistake for "nothing to ask about yet."
 	ErrOutOfReach = errors.New("no target in reach")
 

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -110,6 +110,19 @@ var (
 	// ErrNoMemberID is returned when a verb is given an empty member ID.
 	ErrNoMemberID = errors.New("empty member id")
 
+	// ErrNoDeclarationID is returned when Attack or EndTurn omits the opaque
+	// selector echoed from Afford, or when a turn-clock Move omits it. A
+	// world-clock Move is the deliberate exception: Afford has no world-clock
+	// declarations, so its selector must be empty.
+	ErrNoDeclarationID = errors.New("empty declaration id")
+
+	// ErrStaleDeclaration is returned when an echoed selector does not name the
+	// verb's one current compiled offer, when that offer is now unavailable, or
+	// when Attack's selected target is absent or unavailable in its current
+	// candidate set. It is a current-world refusal: callers refresh Turn and
+	// Afford and never retry the mutation automatically.
+	ErrStaleDeclaration = errors.New("declaration is stale")
+
 	// ErrNoMember is returned when a verb names a member the encounter does
 	// not hold.
 	ErrNoMember = errors.New("no such member")
@@ -336,16 +349,17 @@ var (
 	//
 	// Afford's per-target ATTACK declarations are this same gate asked
 	// ahead of time: a target this seam would refuse with ErrOutOfReach is
-	// a target no declaration names. When no candidate is in reach at all,
-	// Afford still answers once — a single declaration naming no target,
-	// Affordable false, Why.Reason ShortfallNoTargetInReach — rather than
+	// an unavailable candidate row. When no candidate is in reach at all,
+	// Afford still answers once — a single Attack declaration with
+	// Available false, Why.Reason ShortfallNoTargetInReach — rather than
 	// an empty list a client could mistake for "nothing to ask about yet."
 	ErrOutOfReach = errors.New("no target in reach")
 
-	// ErrCannotAfford is returned when an actor cannot pay for what they
-	// declared: a second swing in a turn that bought only one, a level-5
-	// fighter's third, an action after the action was spent, or a walk longer
-	// than the turn's remaining movement (rpg-toolkit#1169).
+	// ErrCannotAfford is returned when the final payment door cannot pay for
+	// what an actor declared. Move reaches it when the selected path is longer
+	// than the turn's remaining movement (rpg-toolkit#1169). Attack normally
+	// exposes exhaustion in Afford and rejects the now-unavailable selector as
+	// ErrStaleDeclaration; this remains its defensive resolution translation.
 	//
 	// THIS IS A FACT ABOUT THE GAME, not about the code, and that is the whole
 	// reason it is separate from ErrBadCost. A player who has run out of actions

--- a/rulebooks/dnd5e/session/example_session_test.go
+++ b/rulebooks/dnd5e/session/example_session_test.go
@@ -166,6 +166,7 @@ func Example_theFightThatStartsItself() {
 	// the top of the fight.
 	out, err = mgr.Move(ctx, &session.MoveInput{
 		Session: "run", Member: "alice", Path: []spatial.Position{hexCell(1, 3)},
+		DeclarationID: currentMoveID(panicFataler{}, mgr, "run", "alice"),
 	})
 	if err != nil {
 		panic(err)

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.35.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
+	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467
 	github.com/stretchr/testify v1.11.1
 )
 

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -26,6 +26,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0 h1:Ftc+y0U
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.12.0/go.mod h1:HzM2KKrpUlpOLfesRkxy8V8enQdmRzvsisZrEuB9BM8=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
+github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=
+github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467/go.mod h1:uzvlm1mxhHkdfqitSA92i7Se+S9ksOn3a3qmv/kyOCw=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=

--- a/rulebooks/dnd5e/session/manager_test.go
+++ b/rulebooks/dnd5e/session/manager_test.go
@@ -171,6 +171,37 @@ func testCharacters() *fakeCharacters {
 	)
 }
 
+// currentDeclaration returns the server-authored current offer for one verb.
+// Mutation tests call this exactly where a real client would refresh Afford;
+// no helper guesses or reconstructs a selector.
+func currentDeclaration(
+	t fataler, mgr *session.Manager, sessionID, member string, verb session.Verb,
+) session.Declaration {
+	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: sessionID, Member: member})
+	if err != nil {
+		t.Fatalf("afford %s for %s: %v", verb, member, err)
+	}
+	for _, declaration := range out.Declarations {
+		if declaration.Verb == verb {
+			return declaration
+		}
+	}
+	t.Fatalf("afford returned no %s declaration for %s", verb, member)
+	return session.Declaration{}
+}
+
+func currentAttackID(t fataler, mgr *session.Manager, sessionID, member string) string {
+	return currentDeclaration(t, mgr, sessionID, member, session.VerbAttack).ID
+}
+
+func currentMoveID(t fataler, mgr *session.Manager, sessionID, member string) string {
+	return currentDeclaration(t, mgr, sessionID, member, session.VerbMove).ID
+}
+
+func currentEndTurnID(t fataler, mgr *session.Manager, sessionID, member string) string {
+	return currentDeclaration(t, mgr, sessionID, member, session.VerbEndTurn).ID
+}
+
 // fakeStream records what was published.
 type fakeStream struct {
 	published []session.Event

--- a/rulebooks/dnd5e/session/manager_test.go
+++ b/rulebooks/dnd5e/session/manager_test.go
@@ -40,7 +40,8 @@ func copyOf[T any](in *T) (*T, error) {
 // if a test double needed more than get-and-put to satisfy it, the interface
 // would be asking too much of a real store.
 type fakeSessions struct {
-	byID map[string]*session.SessionData
+	byID  map[string]*session.SessionData
+	saves int
 }
 
 func newFakeSessions() *fakeSessions {
@@ -56,13 +57,16 @@ func (f *fakeSessions) GetSession(_ context.Context, id string) (*session.Sessio
 }
 
 func (f *fakeSessions) SaveSession(_ context.Context, data *session.SessionData) error {
+	f.saves++
 	f.byID[data.ID] = data
 	return nil
 }
 
 // fakeEncounters is an in-memory EncounterRepository.
 type fakeEncounters struct {
-	byID map[string]*encounter.EncounterData
+	byID    map[string]*encounter.EncounterData
+	saves   int
+	records int
 }
 
 func newFakeEncounters() *fakeEncounters {
@@ -78,13 +82,32 @@ func (f *fakeEncounters) GetEncounter(_ context.Context, id string) (*encounter.
 }
 
 func (f *fakeEncounters) SaveEncounter(_ context.Context, id string, data *encounter.EncounterData) error {
+	f.saves++
+	if previous, ok := f.byID[id]; ok {
+		before, after := storedNextSeq(previous), storedNextSeq(data)
+		if after > before {
+			f.records += int(after - before)
+		}
+	}
 	f.byID[id] = data
 	return nil
+}
+
+// storedNextSeq normalizes record.LogData's zero encoding for a fresh log to
+// the runtime next sequence, so fakeEncounters can count appended story beats.
+func storedNextSeq(data *encounter.EncounterData) uint64 {
+	if data == nil || data.Log.NextSeq == 0 {
+		return 1
+	}
+	return data.Log.NextSeq
 }
 
 // fakeCharacters is an in-memory CharacterRepository.
 type fakeCharacters struct {
 	byID map[string]*character.Data
+
+	// saves counts durable character writes independently of stored values.
+	saves int
 
 	// loads counts GetCharacter calls, so a test can assert that loading
 	// happens per call rather than being cached between them.
@@ -132,6 +155,7 @@ func cloneCharacter(in *character.Data) *character.Data {
 }
 
 func (f *fakeCharacters) SaveCharacter(_ context.Context, data *character.Data) error {
+	f.saves++
 	f.byID[data.ID] = data
 	return nil
 }

--- a/rulebooks/dnd5e/session/monster_turn_test.go
+++ b/rulebooks/dnd5e/session/monster_turn_test.go
@@ -119,7 +119,7 @@ func (s *MonsterTurnTestSuite) TestSkeletonAttacksFromRange() {
 	s.Equal([]string{"fighter", "skel-1"}, spawned.Formed.Order, "fighter's ID sorts first, so the tied roll breaks to her")
 
 	before := len(s.storyBeats(mgr, "fighter"))
-	out, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter"})
+	out, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter", DeclarationID: currentEndTurnID(s.T(), mgr, "sess", "fighter")})
 	s.Require().NoError(err, "the skeleton's whole turn — strike, end — drives inside this one call")
 
 	// Isolated to what THIS EndTurn call itself produced, with the earlier
@@ -241,7 +241,7 @@ func (s *MonsterTurnTestSuite) TestBadIntentEndsOnlyTheMonstersTurn() {
 	s.Require().NotNil(spawned.Formed)
 
 	before := len(s.storyBeats(mgr, "fighter"))
-	out, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter"})
+	out, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter", DeclarationID: currentEndTurnID(s.T(), mgr, "sess", "fighter")})
 	s.Require().NoError(err, "a bad intent must not surface as an error on the caller's own verb")
 	s.Equal("fighter", out.Next)
 	s.True(out.RoundWrapped)
@@ -324,7 +324,7 @@ func (s *MonsterTurnTestSuite) TestPassDriverStillPasses() {
 	s.Require().NotNil(spawned.Formed)
 
 	before := len(s.storyBeats(mgr, "fighter"))
-	out, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter"})
+	out, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter", DeclarationID: currentEndTurnID(s.T(), mgr, "sess", "fighter")})
 	s.Require().NoError(err)
 	s.Equal("fighter", out.Next)
 	s.True(out.RoundWrapped)
@@ -433,7 +433,7 @@ func (s *MonsterTurnTestSuite) TestRoundTwoStruckReachesTheLiveSubscriber() {
 	// needs no declared action before EndTurn, and skipping it keeps the
 	// skeleton's own 13 hit points out of this gate's way entirely (the
 	// evidence's own skeleton-1 survived every round it is about).
-	_, err = mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter"})
+	_, err = mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter", DeclarationID: currentEndTurnID(s.T(), mgr, "sess", "fighter")})
 	s.Require().NoError(err)
 	_, ok := skelStruckFighter(stream.published)
 	s.Require().True(ok, "round 1's own struck beat must reach the live subscriber (control)")
@@ -454,7 +454,7 @@ func (s *MonsterTurnTestSuite) TestRoundTwoStruckReachesTheLiveSubscriber() {
 	// arrived at the client's stream, though the story log recorded it
 	// correctly.
 	stream.published = nil // isolate what THIS EndTurn's own publish call delivers
-	_, err = mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter"})
+	_, err = mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter", DeclarationID: currentEndTurnID(s.T(), mgr, "sess", "fighter")})
 	s.Require().NoError(err)
 	s.Require().NotEmpty(stream.published)
 	round2First := stream.published[0].Seq
@@ -515,7 +515,7 @@ func (s *MonsterTurnTestSuite) TestLiveDeliveryAndStoryCatchUpAreByteEqual() {
 	s.Require().NoError(err)
 	s.Require().NotNil(spawned.Formed, "the skeleton's driven turn is this test's whole point")
 
-	_, err = mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter"})
+	_, err = mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter", DeclarationID: currentEndTurnID(s.T(), mgr, "sess", "fighter")})
 	s.Require().NoError(err, "the skeleton's whole turn — strike, end — drives inside this one call")
 
 	// live is everything the fake stream delivered to fighter across the

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -212,7 +212,7 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		if in.DeclarationID == "" {
 			return nil, fmt.Errorf("move: %w", ErrNoDeclarationID)
 		}
-		offers, compileErr := m.compileOffers(ctx, scope.enc, scope.data, in.Member, clock, actor)
+		offers, compileErr := m.compileOffers(ctx, scope.enc, scope.data, scope.session, in.Member, clock, actor)
 		if compileErr != nil {
 			return nil, fmt.Errorf("move: %w", compileErr)
 		}

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -25,6 +25,10 @@ type MoveInput struct {
 	// Member is the member walking.
 	Member string
 
+	// DeclarationID is the opaque current Move selector returned by Afford.
+	// It is required on the turn clock and must be empty on the world clock.
+	DeclarationID string
+
 	// Path is the cells to walk through, in order, each adjacent to the last
 	// and the first adjacent to where the member currently stands.
 	//
@@ -116,9 +120,10 @@ type MoveOutput struct {
 // # On the turn clock, a walk spends movement (rpg-toolkit#1169)
 //
 // A member IN A FIGHT may still walk — only when it is their turn, and only as
-// far as their turn's movement reaches. [Manager.priceWalk] compiles the whole
-// requested path at 5 feet per cell and charges it through [combat.Pay] BEFORE
-// any cell is entered, the same door [Manager.Attack] pays a swing through: a
+// far as their turn's movement reaches. The echoed Move offer supplies the
+// already-loaded, turn-readied sheet; this verb compiles the whole requested
+// path at 5 feet per cell and charges it through [combat.Pay] BEFORE any cell is
+// entered, the same door [Manager.Attack] pays a swing through: a
 // path that costs more than the turn has left is refused whole, naming the
 // currency, and not one cell of it happens. Whose turn it is is not re-derived
 // here — [encounter.Step] is the one place that gate lives, and its refusal
@@ -141,19 +146,19 @@ type MoveOutput struct {
 // what is crossable, which is the duplication this walk exists without. The
 // caller sees no difference: a refused walk returns an error, and nothing is
 // persisted or published, because the encounter that moved in memory is
-// discarded unsaved. The same is true of a charged sheet: [Manager.priceWalk]
-// mutates a [character.Character] loaded fresh for this call, and a walk that
-// fails after paying simply never hands that sheet to [Manager.saveWalker] —
+// discarded unsaved. The same is true of a charged sheet: offer regeneration
+// loads and readies a [character.Character] fresh for this call, and a walk
+// that fails after paying simply never hands that sheet to [Manager.saveWalker] —
 // nothing durable ever saw the spend.
 //
-// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrEmptyPath,
-// ErrBrokenPath for a path with a gap in it, ErrNoSession, ErrNoEncounter,
-// ErrNoMember, ErrClosed, ErrBadPosition for a cell no room owns OR a cell the
-// walker is already standing on, ErrNoCrossing for a step into another room
-// with no doorway joining it, ErrNotYourTurn for a bubble member asked to walk
-// out of turn, ErrCannotAfford naming the movement that ran short,
-// ErrBadCharacter or ErrBadCost if the walker's own sheet cannot be priced, or
-// ErrSaveFailed with a populated report.
+// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoDeclarationID,
+// ErrStaleDeclaration, ErrEmptyPath, ErrBrokenPath for a path with a gap in it,
+// ErrNoSession, ErrNoEncounter, ErrNoMember, ErrClosed, ErrBadPosition for a
+// cell no room owns OR a cell the walker is already standing on, ErrNoCrossing
+// for a step into another room with no doorway joining it, ErrNotYourTurn for a
+// bubble member asked to walk out of turn, ErrCannotAfford naming the movement
+// that ran short, ErrBadCharacter or ErrBadCost if the walker's own sheet
+// cannot be priced, or ErrSaveFailed with a populated report.
 func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("move: %w", ErrNilInput)
@@ -179,13 +184,13 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 	// is loaded at all (Copilot finding on #1171). If it is not your turn,
 	// nothing else about you is this call's business yet: encounter.Step's
 	// own gate would eventually refuse a non-active bubble member's first
-	// step with ErrNotActive regardless, but by then refuseIfDown and
-	// priceWalk would both already have loaded a sheet, and combat.Pay might
+	// step with ErrNotActive regardless, but by then refuseIfDown and offer
+	// compilation would both already have loaded a sheet, and combat.Pay might
 	// already have refused with a MISLEADING currency shortfall — a
 	// non-active member low on movement would be told "movement: X ft
 	// needed" instead of "not your turn", naming the wrong reason. This is
 	// not a second copy of Step's rule: it is the same fact, ClockOf, that
-	// Manager.Turn and priceWalk already read for their own purposes, read
+	// Manager.Turn and offer compilation already read for their own purposes, read
 	// once more here before anything else touches this member at all.
 	clock, err := scope.enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(in.Member)})
 	if err != nil {
@@ -212,15 +217,42 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		return nil, fmt.Errorf("move: %w", err)
 	}
 
-	cost, err := m.priceWalk(ctx, scope, in.Member, clock, len(in.Path))
-	if err != nil {
-		return nil, fmt.Errorf("move: %w", err)
+	var cost *walkCost
+	if ClockKind(clock.Kind) == ClockTurn {
+		if in.DeclarationID == "" {
+			return nil, fmt.Errorf("move: %w", ErrNoDeclarationID)
+		}
+		offers, compileErr := m.compileOffers(ctx, scope.enc, scope.data, in.Member, clock, false)
+		if compileErr != nil {
+			return nil, fmt.Errorf("move: %w", compileErr)
+		}
+		selected, selectErr := selectCompiledOffer(offers, VerbMove, in.DeclarationID)
+		if selectErr != nil {
+			return nil, fmt.Errorf("move: %w", selectErr)
+		}
+		if selected.sheet == nil {
+			return nil, fmt.Errorf("move: %w", ErrStaleDeclaration)
+		}
+		feet := 5 * len(in.Path)
+		cost = &walkCost{
+			profile: &combat.SpendProfile{Capacity: map[combat.CapacityType]int{combat.CapacityMovement: feet}},
+			sheet:   selected.sheet,
+			feet:    feet,
+		}
+	} else {
+		// Afford deliberately returns no world-clock declarations. Empty is the
+		// only valid selector there; a non-empty ID left over from a dissolved
+		// fight must not turn into a free move.
+		if in.DeclarationID != "" {
+			return nil, fmt.Errorf("move: %w", ErrStaleDeclaration)
+		}
+		cost = &walkCost{}
 	}
 
 	// THE ONE PLACE A SPEND GOES for this verb, mirroring Attack's own comment
-	// at its call site: nil profile means FREE ROAM ONLY — priceWalk refuses
-	// with ErrNoCharacter/ErrBadCharacter for anyone else on the turn clock it
-	// cannot load, rather than silently pricing them as free. combat.Pay
+	// at its call site: nil profile means FREE ROAM ONLY — turn-clock offer
+	// compilation blocks a member whose sheet it cannot load rather than
+	// silently pricing them as free. combat.Pay
 	// treats a nil profile as a free action by its own contract (see
 	// [combat.SpendProfile]), so this branch is a shortcut rather than a
 	// second free-action path.
@@ -278,8 +310,8 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 // reinvented: both fields nil is a price of nothing, never a missing one.
 type walkCost struct {
 	// profile is what the door charges for this walk, or nil to charge
-	// nothing — free roam, or a member the session holds no character sheet
-	// for.
+	// nothing on the world clock. A turn-clock member without a loadable sheet
+	// never produces a selectable Move offer.
 	profile *combat.SpendProfile
 
 	// sheet is the walker's own sheet with its turn readied, ready to be
@@ -290,74 +322,6 @@ type walkCost struct {
 	// feet is the requested path's price, named separately from profile so a
 	// refusal can quote it without re-deriving it from a map lookup.
 	feet int
-}
-
-// priceWalk works out what walking `cells` cells costs this member, and
-// readies the sheet the door will charge for it — [Manager.priceSwing]'s own
-// shape, adapted to a currency priced by the CALL rather than compiled once
-// per actor.
-//
-// clock is the caller's OWN ClockOf read, passed in rather than re-fetched:
-// [Manager.Move] already reads it to gate on whose turn it is before this is
-// ever called, and a second read here would ask the composition the same
-// question twice in one verb.
-//
-// # Free roam charges nothing, the same ruling priceSwing states
-//
-// [combat.Ledger] opens with InCombat and refuses every payment from a holder
-// who is not in one, so a walk off the turn clock is priced nothing rather
-// than being handed a cost the gate would refuse outright — this is the ONLY
-// case that returns a nil profile. A member the session holds no character
-// sheet for — a monster, reachable only if a host calls this verb for one,
-// since the pump moves monsters through [encounter.Encounter]'s own silent
-// stepTo and never through this seam — is NOT priced nothing: it is refused,
-// by the load below, exactly the way [Manager.Afford] already lets that case
-// speak for itself rather than silently treating it as free.
-//
-// # What a path costs is the path's business, never the profile's
-//
-// Movement is 5 feet per cell, computed HERE, per call, rather than compiled
-// onto a [combat.SpendProfile] the way an attack's price is. That split is not
-// this seam's invention — the profile's own doc says per-unit movement cost is
-// "deliberately not here" — and it is the whole of what the movement design
-// addendum (rpg-toolkit#1035) named as the ONE thing E1's foundation had to
-// leave room for: "one key constant [5 feet] and one discipline [per-unit
-// cost stays out of the profile]". This is that constant's first caller.
-//
-// # readyForTurn is shared with priceSwing, not duplicated
-//
-// The same function lights a cold sheet or refreshes a stale one for either
-// verb — whichever of Attack or Move a member's turn asks for FIRST is the one
-// that ignites it, and the other finds it already lit. See readyForTurn's own
-// comment for why the session is the layer that has to do this at all.
-//
-// Returns ErrNoCharacter, ErrBadCharacter, or ErrBadCost.
-func (m *Manager) priceWalk(
-	ctx context.Context, scope *writeScope, member string, clock *encounter.ClockOfOutput, cells int,
-) (*walkCost, error) {
-	if ClockKind(clock.Kind) != ClockTurn {
-		return &walkCost{}, nil
-	}
-
-	data, err := m.fetchCharacterData(ctx, "member", member)
-	if err != nil {
-		return nil, err
-	}
-	sheet, err := character.Load(ctx, data)
-	if err != nil {
-		return nil, fmt.Errorf("member %q: %w: %v", member, ErrBadCharacter, err)
-	}
-
-	if err := readyForTurn(ctx, sheet, clock.Round); err != nil {
-		return nil, fmt.Errorf("member %q: %w: %v", member, ErrBadCost, err)
-	}
-
-	feet := 5 * cells
-	return &walkCost{
-		profile: &combat.SpendProfile{Capacity: map[combat.CapacityType]int{combat.CapacityMovement: feet}},
-		sheet:   sheet,
-		feet:    feet,
-	}, nil
 }
 
 // movementShortfall composes the "ft"-suffixed text a refused Move and

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -200,29 +200,19 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		return nil, fmt.Errorf("move: %w", ErrNotYourTurn)
 	}
 
-	// A downed member does not walk. Asked after the path is VALIDATED and
-	// the TURN GATE has passed, and before a single cell is entered, which is
-	// where R5 puts every other refusal: naming a member who is not here, a
-	// route that is not a walk, or a member whose turn has not come still
-	// answers what it always answered, and a walk this refuses has moved
-	// nobody.
-	//
-	// REACHABLE INSIDE A FIGHT NOW, unlike before rpg-toolkit#1169: a bubble
-	// member used to be refused the verb outright, so a downed one could
-	// never reach this check from here. The active member can now walk, and
-	// nothing in the composition splices a downed member out of initiative on
-	// its own (rpg-toolkit#1077's own ruling) — so this is exactly where a
-	// downed member whose turn the clock IS waiting on still gets refused.
-	if err = refuseIfDown(scope, "member", in.Member); err != nil {
-		return nil, fmt.Errorf("move: %w", err)
-	}
-
 	var cost *walkCost
 	if ClockKind(clock.Kind) == ClockTurn {
+		// The turn path loads the actor strictly ONCE. Its downed verdict and
+		// regenerated Move offer use this same sheet, preventing a sequenced
+		// repository from changing the answer between the blocker and selector.
+		actor := m.loadActorSheet(ctx, in.Member)
+		if actor.downed {
+			return nil, fmt.Errorf("move: member %q: %w", in.Member, ErrDowned)
+		}
 		if in.DeclarationID == "" {
 			return nil, fmt.Errorf("move: %w", ErrNoDeclarationID)
 		}
-		offers, compileErr := m.compileOffers(ctx, scope.enc, scope.data, in.Member, clock, false)
+		offers, compileErr := m.compileOffers(ctx, scope.enc, scope.data, in.Member, clock, actor)
 		if compileErr != nil {
 			return nil, fmt.Errorf("move: %w", compileErr)
 		}
@@ -240,6 +230,12 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 			feet:    feet,
 		}
 	} else {
+		// World Move keeps its independent standing gate. It has no compiled
+		// actor sheet or declaration, and free-roam movement semantics remain
+		// separate from the turn economy.
+		if err = refuseIfDown(scope, "member", in.Member); err != nil {
+			return nil, fmt.Errorf("move: %w", err)
+		}
 		// Afford deliberately returns no world-clock declarations. Empty is the
 		// only valid selector there; a non-empty ID left over from a dissolved
 		// fight must not turn into a free move.

--- a/rulebooks/dnd5e/session/move.go
+++ b/rulebooks/dnd5e/session/move.go
@@ -205,6 +205,8 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		// The turn path loads the actor strictly ONCE. Its downed verdict and
 		// regenerated Move offer use this same sheet, preventing a sequenced
 		// repository from changing the answer between the blocker and selector.
+		// Only Move is regenerated: Attack pricing, assembly, target view and
+		// participant preflight are unrelated dependencies of this execution.
 		actor := m.loadActorSheet(ctx, in.Member)
 		if actor.downed {
 			return nil, fmt.Errorf("move: member %q: %w", in.Member, ErrDowned)
@@ -212,7 +214,9 @@ func (m *Manager) Move(ctx context.Context, in *MoveInput) (*MoveOutput, error) 
 		if in.DeclarationID == "" {
 			return nil, fmt.Errorf("move: %w", ErrNoDeclarationID)
 		}
-		offers, compileErr := m.compileOffers(ctx, scope.enc, scope.data, scope.session, in.Member, clock, actor)
+		offers, compileErr := m.compileOffersFor(
+			ctx, scope.enc, scope.data, scope.session, in.Member, clock, actor, VerbMove,
+		)
 		if compileErr != nil {
 			return nil, fmt.Errorf("move: %w", compileErr)
 		}

--- a/rulebooks/dnd5e/session/move_turnclock_test.go
+++ b/rulebooks/dnd5e/session/move_turnclock_test.go
@@ -148,7 +148,7 @@ func (s *MoveTurnClockSuite) TestActiveMemberSpendsMovementAndAffordSeesIt() {
 	// of the arithmetic.
 	decl := s.moveDecl(s.afford("alice"))
 	s.Equal(session.VerbMove, decl.Verb)
-	s.True(decl.Affordable, "15 feet is still enough for at least one more cell")
+	s.True(decl.Available, "15 feet is still enough for at least one more cell")
 	s.Require().NotNil(decl.Remaining, "Move's declaration always carries Remaining")
 	s.Equal(15, *decl.Remaining)
 	s.Equal(session.SlotNone, decl.Slot, "movement is capacity, never a per-turn slot")
@@ -204,7 +204,7 @@ func (s *MoveTurnClockSuite) TestEndTurnRefreshesMovementForTheNextRound() {
 	s.Equal(2, turn.Round)
 
 	decl := s.moveDecl(s.afford("alice"))
-	s.True(decl.Affordable)
+	s.True(decl.Available)
 	s.Require().NotNil(decl.Remaining)
 	s.Equal(30, *decl.Remaining, "a new turn re-seeds MovementRemaining from speed, not from where it was left")
 }

--- a/rulebooks/dnd5e/session/move_turnclock_test.go
+++ b/rulebooks/dnd5e/session/move_turnclock_test.go
@@ -92,6 +92,14 @@ func (s *MoveTurnClockSuite) afford(member string) *session.AffordOutput {
 	return out
 }
 
+func (s *MoveTurnClockSuite) endTurn(ctx context.Context, member string) (*session.EndTurnOutput, error) {
+	s.T().Helper()
+	return s.mgr.EndTurn(ctx, &session.EndTurnInput{
+		Session: "sess", Member: member,
+		DeclarationID: currentEndTurnID(s.T(), s.mgr, "sess", member),
+	})
+}
+
 // moveDecl finds the VerbMove declaration, failing loudly if Afford ever
 // stops carrying one — a silent absence would read as "nothing to report"
 // rather than as the regression it is.
@@ -125,7 +133,7 @@ func (s *MoveTurnClockSuite) where(member string) spatial.Position {
 // case: a 3-cell walk, on the turn clock, by the active member.
 func (s *MoveTurnClockSuite) TestActiveMemberSpendsMovementAndAffordSeesIt() {
 	out, err := s.mgr.Move(context.Background(), &session.MoveInput{
-		Session: "sess", Member: "alice",
+		Session: "sess", Member: "alice", DeclarationID: currentMoveID(s.T(), s.mgr, "sess", "alice"),
 		Path: []spatial.Position{{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}},
 	})
 	s.Require().NoError(err, "alice is active, and 3 cells cost 15 of her 30 feet")
@@ -159,13 +167,13 @@ func (s *MoveTurnClockSuite) TestActiveMemberSpendsMovementAndAffordSeesIt() {
 // the currency, and the sheet it would have spent from is untouched.
 func (s *MoveTurnClockSuite) TestOverBudgetWalkIsRefusedWholeAndNothingIsSaved() {
 	_, err := s.mgr.Move(context.Background(), &session.MoveInput{
-		Session: "sess", Member: "alice",
+		Session: "sess", Member: "alice", DeclarationID: currentMoveID(s.T(), s.mgr, "sess", "alice"),
 		Path: []spatial.Position{{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}},
 	})
 	s.Require().NoError(err, "spends 15, leaves 15")
 
 	_, err = s.mgr.Move(context.Background(), &session.MoveInput{
-		Session: "sess", Member: "alice",
+		Session: "sess", Member: "alice", DeclarationID: currentMoveID(s.T(), s.mgr, "sess", "alice"),
 		Path: []spatial.Position{{X: 1, Y: 5}, {X: 1, Y: 6}, {X: 1, Y: 7}, {X: 1, Y: 8}},
 	})
 	s.Require().Error(err, "20 feet needed, 15 left")
@@ -186,16 +194,16 @@ func (s *MoveTurnClockSuite) TestEndTurnRefreshesMovementForTheNextRound() {
 	ctx := context.Background()
 
 	_, err := s.mgr.Move(ctx, &session.MoveInput{
-		Session: "sess", Member: "alice",
+		Session: "sess", Member: "alice", DeclarationID: currentMoveID(s.T(), s.mgr, "sess", "alice"),
 		Path: []spatial.Position{{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}},
 	})
 	s.Require().NoError(err, "spends 15 of alice's 30")
 
-	ended, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	ended, err := s.endTurn(ctx, "alice")
 	s.Require().NoError(err)
 	s.Equal("bob", ended.Next, "a real player does not auto-resolve — the order simply advances")
 
-	_, err = s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "bob"})
+	_, err = s.endTurn(ctx, "bob")
 	s.Require().NoError(err, "bob's own turn, spending nothing, still ends cleanly")
 
 	turn, err := s.mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
@@ -216,7 +224,7 @@ func (s *MoveTurnClockSuite) TestEndTurnRefreshesMovementForTheNextRound() {
 func (s *MoveTurnClockSuite) TestNotActiveMoveIsRefusedWithTheNamedSentinel() {
 	ctx := context.Background()
 
-	ended, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	ended, err := s.endTurn(ctx, "alice")
 	s.Require().NoError(err)
 	s.Require().Equal("bob", ended.Next, "control: it is now genuinely bob's turn")
 
@@ -240,7 +248,7 @@ func (s *MoveTurnClockSuite) TestNotActiveMoveIsRefusedWithTheNamedSentinel() {
 func (s *MoveTurnClockSuite) TestNotActiveWinsOverAffordability() {
 	ctx := context.Background()
 
-	ended, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	ended, err := s.endTurn(ctx, "alice")
 	s.Require().NoError(err)
 	s.Require().Equal("bob", ended.Next, "control: it is now genuinely bob's turn")
 
@@ -262,6 +270,33 @@ func (s *MoveTurnClockSuite) TestNotActiveWinsOverAffordability() {
 
 	s.Equal(before, s.characters.asked["alice"],
 		"the clock is asked before the sheet is — a refusal this early must never have loaded it")
+}
+
+// TestTurnClockMoveRequiresCurrentSelector pins both halves of the Move
+// contract: a turn-clock walk cannot omit its current offer, while a selector
+// that belonged to the fight stays stale after the fight dissolves and must
+// never become permission for a free world-clock move.
+func (s *MoveTurnClockSuite) TestTurnClockMoveRequiresCurrentSelector() {
+	ctx := context.Background()
+	path := []spatial.Position{{X: 1, Y: 2}}
+
+	out, err := s.mgr.Move(ctx, &session.MoveInput{Session: "sess", Member: "alice", Path: path})
+	s.ErrorIs(err, session.ErrNoDeclarationID)
+	s.Nil(out)
+	s.Equal(spatial.Position{X: 1, Y: 1}, s.where("alice"))
+
+	selector := s.moveDecl(s.afford("alice")).ID
+	_, err = s.mgr.Dissolve(ctx, &session.DissolveInput{
+		Session: "sess", Member: "alice", Cause: session.ByDecision(),
+	})
+	s.Require().NoError(err)
+
+	out, err = s.mgr.Move(ctx, &session.MoveInput{
+		Session: "sess", Member: "alice", Path: path, DeclarationID: selector,
+	})
+	s.ErrorIs(err, session.ErrStaleDeclaration)
+	s.Nil(out)
+	s.Equal(spatial.Position{X: 1, Y: 1}, s.where("alice"), "the stale turn selector moved no cell")
 }
 
 // TestWorldClockMoveNeverTouchesTheEconomy is the brief's fifth case: free
@@ -298,7 +333,7 @@ func (s *MoveTurnClockSuite) TestWorldClockMoveNeverTouchesTheEconomy() {
 	stored, ok := characters.byID["alice"]
 	s.Require().True(ok)
 	s.Nil(stored.ActionEconomy,
-		"a free-roam walk must never ready, let alone spend from, a sheet — priceWalk skips it by clock kind alone")
+		"a free-roam walk must never ready, let alone spend from, a sheet — world Move skips offer compilation")
 
 	direct, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "alice"})
 	s.Require().NoError(err)
@@ -325,6 +360,7 @@ func (s *MoveTurnClockSuite) TestMovedTurnEndedAndFightStartedCarryTypedBodies()
 
 	_, err := s.mgr.Move(ctx, &session.MoveInput{
 		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 2}},
+		DeclarationID: currentMoveID(s.T(), s.mgr, "sess", "alice"),
 	})
 	s.Require().NoError(err)
 
@@ -335,7 +371,7 @@ func (s *MoveTurnClockSuite) TestMovedTurnEndedAndFightStartedCarryTypedBodies()
 	s.Equal("alice", movedBody.Member)
 	s.Equal(spatial.Position{X: 1, Y: 2}, movedBody.To)
 
-	ended, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	ended, err := s.endTurn(ctx, "alice")
 	s.Require().NoError(err)
 	s.Equal("bob", ended.Next)
 

--- a/rulebooks/dnd5e/session/offers.go
+++ b/rulebooks/dnd5e/session/offers.go
@@ -25,8 +25,8 @@ import (
 //
 // ONE COMPILED OFFER PER VERB/ACTION/SPEND VARIANT. v1 has exactly one spend
 // variant per verb — the next swing's profile for Attack, SlotNone for Move
-// and EndTurn — so compileOffers produces one offer per verb. The day a
-// bonus-action strike lands, it arrives as a second Attack offer with a
+// and EndTurn — so full Afford compilation produces one offer per verb. The day
+// a bonus-action strike lands, it arrives as a second Attack offer with a
 // distinct slot, and the collision guard keys the two apart by selector
 // material.
 //
@@ -94,10 +94,11 @@ type targetPreflight struct {
 	why *Shortfall
 }
 
-// compileOffers builds the full set of compiled offers for one member on the
-// turn clock, applying the per-verb blocker matrix. It is the single
-// producer [Manager.Afford] projects from, and the source execution regenerates
-// before selecting an echoed ID.
+// compileOffersFor builds only the requested compiled offers for one member on
+// the turn clock, applying the same per-verb blocker matrix. [Manager.Afford]
+// requests all three verbs from one actor snapshot; Move and Attack each request
+// only their own offer before selecting an echoed ID. EndTurn execution keeps
+// its direct clock-only builder.
 //
 // BUILD ORDER FOLLOWS THE BLOCKER MATRIX. EndTurn is built first from the
 // clock alone — it is governed solely by its clock/turn gate, so it stays
@@ -105,14 +106,16 @@ type targetPreflight struct {
 // use the one strict actorSheet supplied by the caller: combat.IsDown on that
 // sheet blocks both, an unreadable character (ErrBadCharacter) blocks both, and
 // a bad Attack compilation (ErrBadAttack) blocks Attack alone while Move
-// continues off the readied sheet. NotYourTurn is handled before actor loading.
+// continues off the readied sheet. Actor blocking and turn readying happen once
+// regardless of how many verbs were requested. NotYourTurn is handled before
+// actor loading.
 //
 // Every compiled Attack, turn-clock Move, and EndTurn receives a selector ID
 // through [declarationID]; blockers carry an empty ID, no AttackRef, and an
 // empty candidate slice. The collision guard fails closed when two
 // non-identical compiled offers share an ID — offer equality compares selector
 // material (verb, slot, variant), never candidate state.
-func (m *Manager) compileOffers(
+func (m *Manager) compileOffersFor(
 	ctx context.Context,
 	enc *encounter.Encounter,
 	data *SessionData,
@@ -120,10 +123,20 @@ func (m *Manager) compileOffers(
 	member string,
 	clock *encounter.ClockOfOutput,
 	actor actorSheet,
+	verbs ...Verb,
 ) ([]compiledOffer, error) {
-	endTurn, err := m.buildEndTurnOffer(sessionID, member)
-	if err != nil {
-		return nil, err
+	requested := make(map[Verb]bool, len(verbs))
+	for _, verb := range verbs {
+		requested[verb] = true
+	}
+
+	var endTurn compiledOffer
+	if requested[VerbEndTurn] {
+		var err error
+		endTurn, err = m.buildEndTurnOffer(sessionID, member)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// UNREADABLE CHARACTER: actor is the strict load Attack and Move execute
@@ -136,11 +149,11 @@ func (m *Manager) compileOffers(
 			Reason: ShortfallUnreadable,
 			Text:   fmt.Errorf("member %q: %w: %v", member, ErrBadCharacter, actor.err).Error(),
 		}
-		return []compiledOffer{
+		return finishRequestedOffers(requested,
 			blockedCompiledOffer(VerbAttack, TargetMember, why),
 			blockedCompiledOffer(VerbMove, TargetPath, why),
 			endTurn,
-		}, nil
+		)
 	}
 
 	sheet := actor.sheet
@@ -149,20 +162,20 @@ func (m *Manager) compileOffers(
 			Reason: ShortfallUnreadable,
 			Text:   fmt.Errorf("member %q: %w", member, ErrBadCharacter).Error(),
 		}
-		return []compiledOffer{
+		return finishRequestedOffers(requested,
 			blockedCompiledOffer(VerbAttack, TargetMember, why),
 			blockedCompiledOffer(VerbMove, TargetPath, why),
 			endTurn,
-		}, nil
+		)
 	}
 
 	if actor.downed {
 		why := Shortfall{Reason: ShortfallDowned, Text: "member is downed"}
-		return []compiledOffer{
+		return finishRequestedOffers(requested,
 			blockedCompiledOffer(VerbAttack, TargetMember, why),
 			blockedCompiledOffer(VerbMove, TargetPath, why),
 			endTurn,
-		}, nil
+		)
 	}
 
 	// Ready the sheet for the turn: Move reads CapacityLeft off the readied
@@ -173,9 +186,16 @@ func (m *Manager) compileOffers(
 		return nil, fmt.Errorf("%w: %v", ErrBadCost, err)
 	}
 
-	move, err := buildMoveOffer(sessionID, member, sheet)
-	if err != nil {
-		return nil, err
+	var move compiledOffer
+	if requested[VerbMove] {
+		var err error
+		move, err = buildMoveOffer(sessionID, member, sheet)
+		if err != nil {
+			return nil, err
+		}
+	}
+	if !requested[VerbAttack] {
+		return finishRequestedOffers(requested, move, endTurn)
 	}
 
 	// Price BEFORE assembly. The complete Definition is selector material, so
@@ -204,11 +224,11 @@ func (m *Manager) compileOffers(
 			Reason: ShortfallUnreadable,
 			Text:   fmt.Errorf("member %q: %w: %v", member, ErrBadAttack, err).Error(),
 		}
-		return []compiledOffer{
+		return finishRequestedOffers(requested,
 			blockedCompiledOffer(VerbAttack, TargetMember, why),
 			move,
 			endTurn,
-		}, nil
+		)
 	}
 	price.cost.Profile = combatActions.CloneSpendProfile(definition.Cost)
 	slot := slotOf(definition.Cost)
@@ -325,7 +345,19 @@ func (m *Manager) compileOffers(
 		variant: attackVariant,
 	}
 
-	offers := []compiledOffer{attack, move, endTurn}
+	return finishRequestedOffers(requested, attack, move, endTurn)
+}
+
+// finishRequestedOffers filters candidate offers to the requested verbs and
+// runs every compiled selector through the collision guard. Zero-value
+// candidates are ignored; blockers are retained by their declaration verb.
+func finishRequestedOffers(requested map[Verb]bool, candidates ...compiledOffer) ([]compiledOffer, error) {
+	offers := make([]compiledOffer, 0, len(requested))
+	for _, offer := range candidates {
+		if requested[offer.declaration.Verb] {
+			offers = append(offers, offer)
+		}
+	}
 	if err := guardOfferCollisions(offers); err != nil {
 		return nil, err
 	}
@@ -333,7 +365,7 @@ func (m *Manager) compileOffers(
 }
 
 // actorSheet is one strict repository snapshot for Attack and turn-clock Move.
-// Its error is carried into compileOffers so Afford can project an Unreadable
+// Its error is carried into compileOffersFor so Afford can project an Unreadable
 // blocker while execution can still select against exactly the same compiled
 // shape. A successful result always has a non-nil sheet.
 type actorSheet struct {
@@ -344,7 +376,7 @@ type actorSheet struct {
 
 // loadActorSheet performs the one strict actor load shared by the downed gate,
 // offer compilation, pricing, and execution. combat.IsDown is evaluated once
-// on that sheet so callers and compileOffers reuse one verdict as well as one
+// on that sheet so callers and compileOffersFor reuse one verdict as well as one
 // repository snapshot.
 func (m *Manager) loadActorSheet(ctx context.Context, member string) actorSheet {
 	sheet, err := m.loadAttackSheet(ctx, member)
@@ -622,7 +654,7 @@ func verbRank(v Verb) int {
 
 // sortDeclarations orders the projected declarations by the seam's
 // documented verb rank, so [Manager.Afford]'s output is deterministic
-// regardless of the build order compileOffers happens to use.
+// regardless of the build order compileOffersFor happens to use.
 func sortDeclarations(decls []Declaration) {
 	sort.SliceStable(decls, func(i, j int) bool {
 		return verbRank(decls[i].Verb) < verbRank(decls[j].Verb)

--- a/rulebooks/dnd5e/session/offers.go
+++ b/rulebooks/dnd5e/session/offers.go
@@ -1,0 +1,490 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// compiledOffer is the internal, per-verb compiled declaration Task 6 builds
+// and Task 7 re-validates before execution. It never crosses the host
+// boundary: only its [Declaration] projection does.
+//
+// ONE COMPILED OFFER PER VERB/ACTION/SPEND VARIANT. v1 has exactly one spend
+// variant per verb — the next swing's profile for Attack, SlotNone for Move
+// and EndTurn — so compileOffers produces one offer per verb. The day a
+// bonus-action strike lands, it arrives as a second Attack offer with a
+// distinct slot, and the collision guard keys the two apart by selector
+// material.
+//
+// The [targets] map is the shared, target-specific gate result Task 7 enforces
+// against a chosen target before executing: it carries each candidate's
+// reach verdict keyed by member ID, independent of the declaration's global
+// turn/economy gate. It is populated for VerbAttack only.
+type compiledOffer struct {
+	// declaration is the public projection a host reads. Its ID is the
+	// selector for this compiled offer, empty on a blocker.
+	declaration Declaration
+	// attack is the complete validated action definition for VerbAttack.
+	// Non-nil for a compiled Attack, nil for Move/EndTurn and every blocker.
+	attack *combatActions.Definition
+	// targets is the per-candidate reach verdict for VerbAttack, keyed by
+	// candidate member ID. Empty for Move/EndTurn and every blocker. Task 7
+	// looks a chosen target up here to re-enforce reach before execution.
+	targets map[string]targetPreflight
+	// verb and slot are the selector material the declaration ID is derived
+	// from, kept here so the collision guard can compare offers by selector
+	// material rather than candidate state.
+	verb Verb
+	slot Slot
+	// variant is the canonical selector-variant bytes the declaration ID is
+	// derived from — a sealed string for Move/EndTurn, the marshaled
+	// definition for Attack. Equality compares these bytes so two offers
+	// with the same selector material are recurrence, not a collision.
+	variant json.RawMessage
+}
+
+// targetPreflight is the shared, target-specific gate result for one
+// candidate. Reused by Task 7's execution enforcement: the executor looks a
+// chosen target up by member ID and refuses when available is false, echoing
+// why verbatim. Never crosses the host boundary.
+type targetPreflight struct {
+	// member is the candidate member ID.
+	member string
+	// available is the target-specific reach verdict, independent of the
+	// declaration's global turn/economy gate.
+	available bool
+	// why is present if and only if available is false. Carries a
+	// candidate-level reason (ShortfallTargetOutOfReach today); global
+	// turn/economy reasons are never copied here.
+	why *Shortfall
+}
+
+// compileOffers builds the full set of compiled offers for one member on the
+// turn clock, applying the per-verb blocker matrix. It is the single
+// producer [Manager.Afford] projects from, and the single source Task 7
+// re-validates against before execution.
+//
+// BUILD ORDER FOLLOWS THE BLOCKER MATRIX. EndTurn is built first from the
+// clock alone — it is governed solely by its clock/turn gate, so it stays
+// compiled through Downed and an unreadable character. Move and Attack both
+// need the sheet: Downed blocks both, an unreadable character (ErrBadCharacter)
+// blocks both, and a bad Attack compilation (ErrBadAttack) blocks Attack alone
+// while Move continues off the readied sheet. NotYourTurn is handled by the
+// caller, which returns all three verbs blocked without loading a sheet.
+//
+// Every compiled Attack, turn-clock Move, and EndTurn receives a selector ID
+// through [declarationID]; blockers carry an empty ID, no AttackRef, and an
+// empty candidate slice. The collision guard fails closed when two
+// non-identical compiled offers share an ID — offer equality compares selector
+// material (verb, slot, variant), never candidate state.
+func (m *Manager) compileOffers(
+	ctx context.Context,
+	enc *encounter.Encounter,
+	data *SessionData,
+	member string,
+	clock *encounter.ClockOfOutput,
+	downed bool,
+) ([]compiledOffer, error) {
+	endTurn, err := m.buildEndTurnOffer(data.ID, member)
+	if err != nil {
+		return nil, err
+	}
+
+	if downed {
+		why := Shortfall{Reason: ShortfallDowned, Text: "member is downed"}
+		return []compiledOffer{
+			blockedCompiledOffer(VerbAttack, TargetMember, why),
+			blockedCompiledOffer(VerbMove, TargetPath, why),
+			endTurn,
+		}, nil
+	}
+
+	// UNREADABLE CHARACTER: the same load Attack's own door runs, so the two
+	// cannot disagree about whether a sheet exists to answer anything about.
+	// ErrBadCharacter (no sheet, or bytes that will not reconstitute) blocks
+	// Attack and Move — there is no sheet to read movement or compile a swing
+	// from — while EndTurn, already built from the clock alone, continues.
+	sheet, err := m.loadAttackSheet(ctx, member)
+	if err != nil {
+		why := Shortfall{
+			Reason: ShortfallUnreadable,
+			Text:   fmt.Errorf("member %q: %w: %v", member, ErrBadCharacter, err).Error(),
+		}
+		return []compiledOffer{
+			blockedCompiledOffer(VerbAttack, TargetMember, why),
+			blockedCompiledOffer(VerbMove, TargetPath, why),
+			endTurn,
+		}, nil
+	}
+
+	// Ready the sheet for the turn: Move reads CapacityLeft off the readied
+	// sheet, and Attack's price is the same readying's CostOfSwing. One
+	// readying serves both — priceSwing below re-readies idempotently, a
+	// no-op once the economy is filed under this turn.
+	if err := readyForTurn(ctx, sheet, clock.Round); err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrBadCost, err)
+	}
+
+	move, err := buildMoveOffer(data.ID, member, sheet)
+	if err != nil {
+		return nil, err
+	}
+
+	// BAD ATTACK COMPILATION: a sheet that loads fine but names a weapon
+	// this build cannot compile blocks Attack only — Move and EndTurn
+	// continue, because Move reads the readied sheet's movement capacity and
+	// EndTurn reads only the clock.
+	definition, err := character.AssembleAttack(sheet, &character.AssembleAttackInput{Slot: character.SlotMainHand})
+	if err != nil {
+		why := Shortfall{
+			Reason: ShortfallUnreadable,
+			Text:   fmt.Errorf("member %q: %w: %v", member, ErrBadAttack, err).Error(),
+		}
+		return []compiledOffer{
+			blockedCompiledOffer(VerbAttack, TargetMember, why),
+			move,
+			endTurn,
+		}, nil
+	}
+
+	// Price the swing for the budget gate and the slot. priceSwing is the
+	// SAME gate Attack's door pays through; a failure here is a hard error
+	// rather than a declaration, because the rulebook cannot compile this
+	// member's own price and [Manager.Attack] would refuse the same way.
+	price, err := m.priceSwing(ctx, enc, member, sheet)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrBadCost, err)
+	}
+	// price.cost is never nil here: priceSwing returns a nil cost only on
+	// the world clock, already ruled out by the caller.
+	slot := slotOf(price.cost.Profile)
+
+	// Budget gate, asked non-mutatingly through the SAME check combat.Pay
+	// runs to completion before touching anything. The sheet this call
+	// loaded is shared with Move above, so the gate must not spend from it;
+	// CanPay is exactly the check, and a failing check leaves the ledger
+	// untouched for the move declaration already built.
+	budgetOK := combat.CanPay(sheet, price.cost.Profile)
+	var budgetWhy *Shortfall
+	if !budgetOK {
+		sf := shortfallForPay(sheet, price.cost.Profile, slot)
+		budgetWhy = &sf
+	}
+
+	roster, err := enc.Members()
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrBadCost, translate(err))
+	}
+	positions := rosterPositions(roster)
+
+	holdings, err := enc.View(&encounter.ViewInput{Member: encounter.MemberID(member)})
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrBadCost, translate(err))
+	}
+
+	candidates, err := buildTargetPreflight(enc, positions, holdings, member, definition.Attack.Delivery.MaxRangeFeet())
+	if err != nil {
+		return nil, err
+	}
+
+	// Top Attack available requires the global budget gate AND at least one
+	// candidate in reach. The global budget reason takes precedence over the
+	// no-target-in-reach reason at the declaration level; if the budget
+	// passes but no candidate is in reach, the declaration's Why is
+	// NoTargetInReach while the candidate rows remain, each carrying its own
+	// target-specific verdict.
+	anyAvailable := false
+	for _, c := range candidates {
+		if c.available {
+			anyAvailable = true
+			break
+		}
+	}
+	attackAvailable := budgetOK && anyAvailable
+	var attackWhy *Shortfall
+	switch {
+	case !budgetOK:
+		attackWhy = budgetWhy
+	case !anyAvailable:
+		noTarget := Shortfall{Reason: ShortfallNoTargetInReach, Text: "no target in reach"}
+		attackWhy = &noTarget
+	}
+
+	attackRef := attackRefFor(definition)
+	attackID, attackVariant, err := selectorIDFor(data.ID, member, VerbAttack, slot, &definition)
+	if err != nil {
+		return nil, err
+	}
+
+	targets := make(map[string]targetPreflight, len(candidates))
+	for _, c := range candidates {
+		targets[c.member] = c
+	}
+
+	attack := compiledOffer{
+		declaration: Declaration{
+			Verb:       VerbAttack,
+			Slot:       slot,
+			Available:  attackAvailable,
+			Why:        attackWhy,
+			ID:         attackID,
+			Attack:     &attackRef,
+			TargetKind: TargetMember,
+			Candidates: projectCandidates(candidates),
+		},
+		attack:  &definition,
+		targets: targets,
+		verb:    VerbAttack,
+		slot:    slot,
+		variant: attackVariant,
+	}
+
+	offers := []compiledOffer{attack, move, endTurn}
+	if err := guardOfferCollisions(offers); err != nil {
+		return nil, err
+	}
+	return offers, nil
+}
+
+// buildEndTurnOffer builds the compiled EndTurn declaration from the clock
+// alone. EndTurn is governed solely by its clock/turn gate; the caller has
+// already ruled out NotYourTurn, so EndTurn is available here. Downed and an
+// unreadable character do not reach it — it carries no sheet, no candidates,
+// and no currency.
+func (m *Manager) buildEndTurnOffer(session, member string) (compiledOffer, error) {
+	id, variant, err := selectorIDFor(session, member, VerbEndTurn, SlotNone, nil)
+	if err != nil {
+		return compiledOffer{}, err
+	}
+	return compiledOffer{
+		declaration: Declaration{
+			Verb:       VerbEndTurn,
+			Slot:       SlotNone,
+			Available:  true,
+			ID:         id,
+			TargetKind: TargetNone,
+			Candidates: []TargetCandidate{},
+		},
+		verb:    VerbEndTurn,
+		slot:    SlotNone,
+		variant: variant,
+	}, nil
+}
+
+// buildMoveOffer builds the compiled Move declaration off the readied sheet.
+// Move has no fixed price until a path is chosen, so Available answers only
+// whether ANY step at all is still possible — one cell, five feet, the
+// smallest unit this grid has — and Remaining is the actual feet left.
+func buildMoveOffer(session, member string, sheet *character.Character) (compiledOffer, error) {
+	id, variant, err := selectorIDFor(session, member, VerbMove, SlotNone, nil)
+	if err != nil {
+		return compiledOffer{}, err
+	}
+	left := sheet.CapacityLeft(combat.CapacityMovement)
+	decl := Declaration{
+		Verb:       VerbMove,
+		Slot:       SlotNone,
+		Remaining:  &left,
+		ID:         id,
+		TargetKind: TargetPath,
+		Candidates: []TargetCandidate{},
+	}
+	if left >= 5 {
+		decl.Available = true
+		return compiledOffer{declaration: decl, verb: VerbMove, slot: SlotNone, variant: variant}, nil
+	}
+	why := Shortfall{
+		Reason:   ShortfallNoBudget,
+		Currency: CurrencyMovement,
+		// Needed names the smallest step this grid has (five feet, one cell)
+		// rather than a specific request's cost: unlike Attack's fixed
+		// action price, a walk's cost is a fact about a PATH this read is
+		// never given, so "needed" can only say how much the least possible
+		// move would take.
+		Needed: 5,
+		Left:   left,
+		Text:   fmt.Sprintf("movement: %d ft left", left),
+	}
+	decl.Why = &why
+	return compiledOffer{declaration: decl, verb: VerbMove, slot: SlotNone, variant: variant}, nil
+}
+
+// blockedCompiledOffer is the compiledOffer shape every early per-verb
+// blocker emits: an empty selector ID, no AttackRef, an empty candidate
+// slice, and the fixed target kind for the verb. It carries no selector
+// material — a blocker has not compiled an offer — so it is skipped by the
+// collision guard.
+func blockedCompiledOffer(verb Verb, kind TargetKind, why Shortfall) compiledOffer {
+	return compiledOffer{
+		declaration: blockedDeclaration(verb, kind, why),
+	}
+}
+
+// buildTargetPrefflight enumerates the ruled candidate universe for one
+// compiled Attack: every live CurrentVia-nonempty holding except the actor,
+// exactly once, sorted by member ID. Stale memories (empty CurrentVia) and
+// the actor are excluded. A live candidate whose position is missing from the
+// roster is an internal inconsistency this read fails closed on rather than
+// silently omitting.
+//
+// Each candidate's availability is the target-specific reach gate,
+// independent of the declaration's global turn/economy gate: in range
+// carries available true, out of range carries available false with a
+// ShortfallTargetOutOfReach why. The declaration-level NoTargetInReach
+// reason is decided by the caller from whether any candidate is available,
+// not here.
+func buildTargetPreflight(
+	enc *encounter.Encounter,
+	positions map[string]spatial.Position,
+	holdings []intel.Holding,
+	member string,
+	maxRangeFeet int,
+) ([]targetPreflight, error) {
+	// Collect the live candidate universe first, sorted by member ID so the
+	// projection is deterministic regardless of holding iteration order.
+	candidateIDs := make([]string, 0, len(holdings))
+	for _, h := range holdings {
+		subject := string(h.Subject)
+		if subject == member || len(h.CurrentVia) == 0 {
+			continue
+		}
+		candidateIDs = append(candidateIDs, subject)
+	}
+	sort.Strings(candidateIDs)
+
+	from, ok := positions[member]
+	if !ok {
+		// The actor's own position is missing: this is an internal
+		// inconsistency the same law applies to — a live candidate without a
+		// position fails closed, and so does the actor the candidates are
+		// measured from.
+		return nil, fmt.Errorf("attack offers: actor %q has no position in the roster", member)
+	}
+
+	out := make([]targetPreflight, 0, len(candidateIDs))
+	for _, id := range candidateIDs {
+		to, ok := positions[id]
+		if !ok {
+			// A live candidate the encounter no longer places is never
+			// silently omitted: it fails the read so the inconsistency is
+			// surfaced rather than hidden as a missing row.
+			return nil, fmt.Errorf("attack offers: live candidate %q has no position in the roster", id)
+		}
+		if inRange(enc, from, to, maxRangeFeet) {
+			out = append(out, targetPreflight{member: id, available: true})
+			continue
+		}
+		why := Shortfall{Reason: ShortfallTargetOutOfReach, Text: "target out of reach"}
+		out = append(out, targetPreflight{member: id, available: false, why: &why})
+	}
+	return out, nil
+}
+
+// projectCandidates copies the internal preflight slice into the public
+// candidate slice, preserving the sorted order buildTargetPreflight fixed.
+func projectCandidates(candidates []targetPreflight) []TargetCandidate {
+	out := make([]TargetCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, TargetCandidate{
+			Member:    c.member,
+			Available: c.available,
+			Why:       c.why,
+		})
+	}
+	return out
+}
+
+// selectorIDFor computes both the declaration selector ID and the canonical
+// selector-variant bytes for one compiled offer. The variant is kept on the
+// compiledOffer so the collision guard can compare offers by selector
+// material rather than candidate state. For Move and EndTurn the variant is
+// a sealed string; for Attack it is the marshaled, validated definition.
+func selectorIDFor(
+	session, member string, verb Verb, slot Slot, attack *combatActions.Definition,
+) (id string, variant json.RawMessage, err error) {
+	variant, err = selectorVariant(verb, attack)
+	if err != nil {
+		return "", nil, err
+	}
+	id, err = declarationID(declarationIDInput{
+		Session: session,
+		Member:  member,
+		Verb:    verb,
+		Slot:    slot,
+		Attack:  attack,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+	return id, variant, nil
+}
+
+// guardOfferCollisions runs the compiled offers with non-empty selector IDs
+// through the collision guard. Blockers carry empty IDs and are skipped —
+// they are distinct by verb by construction and hold no selector material.
+// Two non-identical compiled offers sharing an ID fail closed as an internal
+// provider defect; a recurring offer (same selector material) is not a
+// collision.
+func guardOfferCollisions(offers []compiledOffer) error {
+	idx := newIndexCompiledOffers(
+		func(o compiledOffer) (string, error) { return o.declaration.ID, nil },
+		offerSelectorEqual,
+	)
+	for _, o := range offers {
+		if o.declaration.ID == "" {
+			continue
+		}
+		if err := idx.add(o); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// offerSelectorEqual reports whether two compiled offers share selector
+// material — verb, slot, and the canonical variant bytes the declaration ID
+// is derived from. Candidate state is deliberately excluded: two offers
+// with the same selector but different candidate positions are the same
+// offer recurring, not a collision.
+func offerSelectorEqual(a, b compiledOffer) bool {
+	return a.verb == b.verb && a.slot == b.slot && bytes.Equal(a.variant, b.variant)
+}
+
+// verbRank orders declarations in the deterministic output order the seam
+// promises: Attack first, then Move, then EndTurn — the order a turn panel
+// renders its action, movement and end-turn controls. Assertions may rely on
+// this order; it never depends on candidate state.
+func verbRank(v Verb) int {
+	switch v {
+	case VerbAttack:
+		return 0
+	case VerbMove:
+		return 1
+	case VerbEndTurn:
+		return 2
+	default:
+		return 3
+	}
+}
+
+// sortDeclarations orders the projected declarations by the seam's
+// documented verb rank, so [Manager.Afford]'s output is deterministic
+// regardless of the build order compileOffers happens to use.
+func sortDeclarations(decls []Declaration) {
+	sort.SliceStable(decls, func(i, j int) bool {
+		return verbRank(decls[i].Verb) < verbRank(decls[j].Verb)
+	})
+}

--- a/rulebooks/dnd5e/session/offers.go
+++ b/rulebooks/dnd5e/session/offers.go
@@ -15,6 +15,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
@@ -52,6 +53,11 @@ type compiledOffer struct {
 	// price is the exact Attack price compiled into attack.Cost and handed to
 	// resolution. Nil for Move, EndTurn, and blockers.
 	price *swingPrice
+	// cast is the one raw resolution-participant snapshot gathered and strictly
+	// preflighted while this Attack offer was compiled. Selected execution hands
+	// these exact data pointers to resolution and never refetches a participant.
+	// Empty for Move, EndTurn, and blockers.
+	cast []resolution.Participant
 	// verb and slot are the selector material the declaration ID is derived
 	// from, kept here so the collision guard can compare offers by selector
 	// material rather than candidate state.
@@ -110,11 +116,12 @@ func (m *Manager) compileOffers(
 	ctx context.Context,
 	enc *encounter.Encounter,
 	data *SessionData,
+	sessionID string,
 	member string,
 	clock *encounter.ClockOfOutput,
 	actor actorSheet,
 ) ([]compiledOffer, error) {
-	endTurn, err := m.buildEndTurnOffer(data.ID, member)
+	endTurn, err := m.buildEndTurnOffer(sessionID, member)
 	if err != nil {
 		return nil, err
 	}
@@ -166,7 +173,7 @@ func (m *Manager) compileOffers(
 		return nil, fmt.Errorf("%w: %v", ErrBadCost, err)
 	}
 
-	move, err := buildMoveOffer(data.ID, member, sheet)
+	move, err := buildMoveOffer(sessionID, member, sheet)
 	if err != nil {
 		return nil, err
 	}
@@ -234,7 +241,34 @@ func (m *Manager) compileOffers(
 		return nil, err
 	}
 
-	// Top Attack available requires the global budget gate AND at least one
+	// Compile the raw resolution cast once, then strictly exercise the same
+	// public character/monster load-and-attach APIs resolution uses. Candidate
+	// failures stay on their rows; any unreadable participant also disables the
+	// declaration globally because resolution's pass-everyone cast could not
+	// start against any selected target. The ephemeral attach bus and loaded
+	// runtime values die here; only the exact raw data snapshot is retained.
+	cast, dependencyFailures := m.compileResolutionCast(ctx, data, roster, price.payer)
+	var dependencyWhy *Shortfall
+	for _, failure := range dependencyFailures {
+		why := Shortfall{
+			Reason: ShortfallUnreadable,
+			Text:   fmt.Sprintf("resolution participant %q is unreadable: %v", failure.member, failure.err),
+		}
+		if dependencyWhy == nil {
+			copied := why
+			dependencyWhy = &copied
+		}
+		for i := range candidates {
+			if candidates[i].member == failure.member {
+				candidates[i].available = false
+				candidateWhy := why
+				candidates[i].why = &candidateWhy
+				break
+			}
+		}
+	}
+
+	// Top Attack available requires the global dependency and budget gates AND at least one
 	// candidate in reach. The global budget reason takes precedence over the
 	// no-target-in-reach reason at the declaration level; if the budget
 	// passes but no candidate is in reach, the declaration's Why is
@@ -247,9 +281,11 @@ func (m *Manager) compileOffers(
 			break
 		}
 	}
-	attackAvailable := budgetOK && anyAvailable
+	attackAvailable := dependencyWhy == nil && budgetOK && anyAvailable
 	var attackWhy *Shortfall
 	switch {
+	case dependencyWhy != nil:
+		attackWhy = dependencyWhy
 	case !budgetOK:
 		attackWhy = budgetWhy
 	case !anyAvailable:
@@ -258,7 +294,7 @@ func (m *Manager) compileOffers(
 	}
 
 	attackRef := attackRefFor(definition)
-	attackID, attackVariant, err := selectorIDFor(data.ID, member, VerbAttack, slot, &definition)
+	attackID, attackVariant, err := selectorIDFor(sessionID, member, VerbAttack, slot, &definition)
 	if err != nil {
 		return nil, err
 	}
@@ -283,6 +319,7 @@ func (m *Manager) compileOffers(
 		targets: targets,
 		sheet:   sheet,
 		price:   price,
+		cast:    cast,
 		verb:    VerbAttack,
 		slot:    slot,
 		variant: attackVariant,
@@ -507,6 +544,10 @@ func selectorIDFor(
 	if err != nil {
 		return "", nil, err
 	}
+	variant, err = canonicalSelectorVariant(variant)
+	if err != nil {
+		return "", nil, err
+	}
 	id, err = declarationID(declarationIDInput{
 		Session: session,
 		Member:  member,
@@ -543,12 +584,23 @@ func guardOfferCollisions(offers []compiledOffer) error {
 }
 
 // offerSelectorEqual reports whether two compiled offers share selector
-// material — verb, slot, and the canonical variant bytes the declaration ID
-// is derived from. Candidate state is deliberately excluded: two offers
-// with the same selector but different candidate positions are the same
-// offer recurring, not a collision.
+// material — verb, slot, and the RFC 8785 canonical variant bytes the
+// declaration ID is derived from. Candidate and raw-cast state are deliberately
+// excluded: two offers with the same selector but different current world data
+// are the same offer recurring, not a collision.
 func offerSelectorEqual(a, b compiledOffer) bool {
-	return a.verb == b.verb && a.slot == b.slot && bytes.Equal(a.variant, b.variant)
+	if a.verb != b.verb || a.slot != b.slot {
+		return false
+	}
+	aVariant, err := canonicalSelectorVariant(a.variant)
+	if err != nil {
+		return false
+	}
+	bVariant, err := canonicalSelectorVariant(b.variant)
+	if err != nil {
+		return false
+	}
+	return bytes.Equal(aVariant, bVariant)
 }
 
 // verbRank orders declarations in the deterministic output order the seam

--- a/rulebooks/dnd5e/session/offers.go
+++ b/rulebooks/dnd5e/session/offers.go
@@ -96,10 +96,10 @@ type targetPreflight struct {
 // BUILD ORDER FOLLOWS THE BLOCKER MATRIX. EndTurn is built first from the
 // clock alone — it is governed solely by its clock/turn gate, so it stays
 // compiled through Downed and an unreadable character. Move and Attack both
-// need the sheet: Downed blocks both, an unreadable character (ErrBadCharacter)
-// blocks both, and a bad Attack compilation (ErrBadAttack) blocks Attack alone
-// while Move continues off the readied sheet. NotYourTurn is handled by the
-// caller, which returns all three verbs blocked without loading a sheet.
+// use the one strict actorSheet supplied by the caller: combat.IsDown on that
+// sheet blocks both, an unreadable character (ErrBadCharacter) blocks both, and
+// a bad Attack compilation (ErrBadAttack) blocks Attack alone while Move
+// continues off the readied sheet. NotYourTurn is handled before actor loading.
 //
 // Every compiled Attack, turn-clock Move, and EndTurn receives a selector ID
 // through [declarationID]; blockers carry an empty ID, no AttackRef, and an
@@ -112,15 +112,23 @@ func (m *Manager) compileOffers(
 	data *SessionData,
 	member string,
 	clock *encounter.ClockOfOutput,
-	downed bool,
+	actor actorSheet,
 ) ([]compiledOffer, error) {
 	endTurn, err := m.buildEndTurnOffer(data.ID, member)
 	if err != nil {
 		return nil, err
 	}
 
-	if downed {
-		why := Shortfall{Reason: ShortfallDowned, Text: "member is downed"}
+	// UNREADABLE CHARACTER: actor is the strict load Attack and Move execute
+	// from. The caller performs that load exactly once, so standing and offer
+	// compilation cannot observe different repository snapshots. ErrBadCharacter
+	// blocks Attack and Move while EndTurn, already built from the clock alone,
+	// continues.
+	if actor.err != nil {
+		why := Shortfall{
+			Reason: ShortfallUnreadable,
+			Text:   fmt.Errorf("member %q: %w: %v", member, ErrBadCharacter, actor.err).Error(),
+		}
 		return []compiledOffer{
 			blockedCompiledOffer(VerbAttack, TargetMember, why),
 			blockedCompiledOffer(VerbMove, TargetPath, why),
@@ -128,17 +136,21 @@ func (m *Manager) compileOffers(
 		}, nil
 	}
 
-	// UNREADABLE CHARACTER: the same load Attack's own door runs, so the two
-	// cannot disagree about whether a sheet exists to answer anything about.
-	// ErrBadCharacter (no sheet, or bytes that will not reconstitute) blocks
-	// Attack and Move — there is no sheet to read movement or compile a swing
-	// from — while EndTurn, already built from the clock alone, continues.
-	sheet, err := m.loadAttackSheet(ctx, member)
-	if err != nil {
+	sheet := actor.sheet
+	if sheet == nil {
 		why := Shortfall{
 			Reason: ShortfallUnreadable,
-			Text:   fmt.Errorf("member %q: %w: %v", member, ErrBadCharacter, err).Error(),
+			Text:   fmt.Errorf("member %q: %w", member, ErrBadCharacter).Error(),
 		}
+		return []compiledOffer{
+			blockedCompiledOffer(VerbAttack, TargetMember, why),
+			blockedCompiledOffer(VerbMove, TargetPath, why),
+			endTurn,
+		}, nil
+	}
+
+	if actor.downed {
+		why := Shortfall{Reason: ShortfallDowned, Text: "member is downed"}
 		return []compiledOffer{
 			blockedCompiledOffer(VerbAttack, TargetMember, why),
 			blockedCompiledOffer(VerbMove, TargetPath, why),
@@ -281,6 +293,28 @@ func (m *Manager) compileOffers(
 		return nil, err
 	}
 	return offers, nil
+}
+
+// actorSheet is one strict repository snapshot for Attack and turn-clock Move.
+// Its error is carried into compileOffers so Afford can project an Unreadable
+// blocker while execution can still select against exactly the same compiled
+// shape. A successful result always has a non-nil sheet.
+type actorSheet struct {
+	sheet  *character.Character
+	downed bool
+	err    error
+}
+
+// loadActorSheet performs the one strict actor load shared by the downed gate,
+// offer compilation, pricing, and execution. combat.IsDown is evaluated once
+// on that sheet so callers and compileOffers reuse one verdict as well as one
+// repository snapshot.
+func (m *Manager) loadActorSheet(ctx context.Context, member string) actorSheet {
+	sheet, err := m.loadAttackSheet(ctx, member)
+	if err != nil || sheet == nil {
+		return actorSheet{sheet: sheet, err: err}
+	}
+	return actorSheet{sheet: sheet, downed: combat.IsDown(sheet)}
 }
 
 // buildEndTurnOffer builds the compiled EndTurn declaration from the clock

--- a/rulebooks/dnd5e/session/offers.go
+++ b/rulebooks/dnd5e/session/offers.go
@@ -18,8 +18,8 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
-// compiledOffer is the internal, per-verb compiled declaration Task 6 builds
-// and Task 7 re-validates before execution. It never crosses the host
+// compiledOffer is the internal, per-verb declaration Afford builds and each
+// mutating verb regenerates before execution. It never crosses the host
 // boundary: only its [Declaration] projection does.
 //
 // ONE COMPILED OFFER PER VERB/ACTION/SPEND VARIANT. v1 has exactly one spend
@@ -29,7 +29,7 @@ import (
 // distinct slot, and the collision guard keys the two apart by selector
 // material.
 //
-// The [targets] map is the shared, target-specific gate result Task 7 enforces
+// The [targets] map is the shared, target-specific gate result Attack enforces
 // against a chosen target before executing: it carries each candidate's
 // reach verdict keyed by member ID, independent of the declaration's global
 // turn/economy gate. It is populated for VerbAttack only.
@@ -41,9 +41,17 @@ type compiledOffer struct {
 	// Non-nil for a compiled Attack, nil for Move/EndTurn and every blocker.
 	attack *combatActions.Definition
 	// targets is the per-candidate reach verdict for VerbAttack, keyed by
-	// candidate member ID. Empty for Move/EndTurn and every blocker. Task 7
-	// looks a chosen target up here to re-enforce reach before execution.
+	// candidate member ID. Empty for Move/EndTurn and every blocker. Execution
+	// looks a chosen target up here to re-enforce reach before resolving.
 	targets map[string]targetPreflight
+	// sheet is the already-loaded, turn-readied actor used to compile this
+	// offer. Attack and Move execution reuse it rather than selecting one
+	// definition and independently loading or pricing another. Nil for EndTurn
+	// and blockers.
+	sheet *character.Character
+	// price is the exact Attack price compiled into attack.Cost and handed to
+	// resolution. Nil for Move, EndTurn, and blockers.
+	price *swingPrice
 	// verb and slot are the selector material the declaration ID is derived
 	// from, kept here so the collision guard can compare offers by selector
 	// material rather than candidate state.
@@ -57,9 +65,17 @@ type compiledOffer struct {
 }
 
 // targetPreflight is the shared, target-specific gate result for one
-// candidate. Reused by Task 7's execution enforcement: the executor looks a
+// candidate. Reused by Attack's execution enforcement: the executor looks a
 // chosen target up by member ID and refuses when available is false, echoing
 // why verbatim. Never crosses the host boundary.
+type targetPreflightFunc func(
+	enc *encounter.Encounter,
+	positions map[string]spatial.Position,
+	holdings []intel.Holding,
+	member string,
+	maxRangeFeet int,
+) ([]targetPreflight, error)
+
 type targetPreflight struct {
 	// member is the candidate member ID.
 	member string
@@ -74,8 +90,8 @@ type targetPreflight struct {
 
 // compileOffers builds the full set of compiled offers for one member on the
 // turn clock, applying the per-verb blocker matrix. It is the single
-// producer [Manager.Afford] projects from, and the single source Task 7
-// re-validates against before execution.
+// producer [Manager.Afford] projects from, and the source execution regenerates
+// before selecting an echoed ID.
 //
 // BUILD ORDER FOLLOWS THE BLOCKER MATRIX. EndTurn is built first from the
 // clock alone — it is governed solely by its clock/turn gate, so it stays
@@ -143,11 +159,27 @@ func (m *Manager) compileOffers(
 		return nil, err
 	}
 
+	// Price BEFORE assembly. The complete Definition is selector material, so
+	// compiling a costless weapon and merely pricing beside it would let two
+	// different executable prices hash to the same offer. AssembleAttack clones
+	// this actual profile into Definition.Cost; the resolution Cost receives a
+	// second clone so selector material and execution data cannot alias.
+	price, err := m.priceSwing(ctx, enc, member, sheet)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %v", ErrBadCost, err)
+	}
+	// price.cost is never nil here: priceSwing returns a nil cost only on
+	// the world clock, already ruled out by the caller.
+	pricedProfile := combatActions.CloneSpendProfile(price.cost.Profile)
+
 	// BAD ATTACK COMPILATION: a sheet that loads fine but names a weapon
 	// this build cannot compile blocks Attack only — Move and EndTurn
 	// continue, because Move reads the readied sheet's movement capacity and
 	// EndTurn reads only the clock.
-	definition, err := character.AssembleAttack(sheet, &character.AssembleAttackInput{Slot: character.SlotMainHand})
+	definition, err := character.AssembleAttack(sheet, &character.AssembleAttackInput{
+		Slot: character.SlotMainHand,
+		Cost: pricedProfile,
+	})
 	if err != nil {
 		why := Shortfall{
 			Reason: ShortfallUnreadable,
@@ -159,28 +191,18 @@ func (m *Manager) compileOffers(
 			endTurn,
 		}, nil
 	}
-
-	// Price the swing for the budget gate and the slot. priceSwing is the
-	// SAME gate Attack's door pays through; a failure here is a hard error
-	// rather than a declaration, because the rulebook cannot compile this
-	// member's own price and [Manager.Attack] would refuse the same way.
-	price, err := m.priceSwing(ctx, enc, member, sheet)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrBadCost, err)
-	}
-	// price.cost is never nil here: priceSwing returns a nil cost only on
-	// the world clock, already ruled out by the caller.
-	slot := slotOf(price.cost.Profile)
+	price.cost.Profile = combatActions.CloneSpendProfile(definition.Cost)
+	slot := slotOf(definition.Cost)
 
 	// Budget gate, asked non-mutatingly through the SAME check combat.Pay
 	// runs to completion before touching anything. The sheet this call
 	// loaded is shared with Move above, so the gate must not spend from it;
 	// CanPay is exactly the check, and a failing check leaves the ledger
 	// untouched for the move declaration already built.
-	budgetOK := combat.CanPay(sheet, price.cost.Profile)
+	budgetOK := combat.CanPay(sheet, definition.Cost)
 	var budgetWhy *Shortfall
 	if !budgetOK {
-		sf := shortfallForPay(sheet, price.cost.Profile, slot)
+		sf := shortfallForPay(sheet, definition.Cost, slot)
 		budgetWhy = &sf
 	}
 
@@ -195,7 +217,7 @@ func (m *Manager) compileOffers(
 		return nil, fmt.Errorf("%w: %v", ErrBadCost, translate(err))
 	}
 
-	candidates, err := buildTargetPreflight(enc, positions, holdings, member, definition.Attack.Delivery.MaxRangeFeet())
+	candidates, err := m.targetPreflight(enc, positions, holdings, member, definition.Attack.Delivery.MaxRangeFeet())
 	if err != nil {
 		return nil, err
 	}
@@ -247,6 +269,8 @@ func (m *Manager) compileOffers(
 		},
 		attack:  &definition,
 		targets: targets,
+		sheet:   sheet,
+		price:   price,
 		verb:    VerbAttack,
 		slot:    slot,
 		variant: attackVariant,
@@ -304,7 +328,7 @@ func buildMoveOffer(session, member string, sheet *character.Character) (compile
 	}
 	if left >= 5 {
 		decl.Available = true
-		return compiledOffer{declaration: decl, verb: VerbMove, slot: SlotNone, variant: variant}, nil
+		return compiledOffer{declaration: decl, sheet: sheet, verb: VerbMove, slot: SlotNone, variant: variant}, nil
 	}
 	why := Shortfall{
 		Reason:   ShortfallNoBudget,
@@ -319,7 +343,7 @@ func buildMoveOffer(session, member string, sheet *character.Character) (compile
 		Text:   fmt.Sprintf("movement: %d ft left", left),
 	}
 	decl.Why = &why
-	return compiledOffer{declaration: decl, verb: VerbMove, slot: SlotNone, variant: variant}, nil
+	return compiledOffer{declaration: decl, sheet: sheet, verb: VerbMove, slot: SlotNone, variant: variant}, nil
 }
 
 // blockedCompiledOffer is the compiledOffer shape every early per-verb
@@ -333,7 +357,7 @@ func blockedCompiledOffer(verb Verb, kind TargetKind, why Shortfall) compiledOff
 	}
 }
 
-// buildTargetPrefflight enumerates the ruled candidate universe for one
+// buildTargetPreflight enumerates the ruled candidate universe for one
 // compiled Attack: every live CurrentVia-nonempty holding except the actor,
 // exactly once, sorted by member ID. Stale memories (empty CurrentVia) and
 // the actor are excluded. A live candidate whose position is missing from the
@@ -398,13 +422,43 @@ func buildTargetPreflight(
 func projectCandidates(candidates []targetPreflight) []TargetCandidate {
 	out := make([]TargetCandidate, 0, len(candidates))
 	for _, c := range candidates {
+		var why *Shortfall
+		if c.why != nil {
+			copied := *c.why
+			why = &copied
+		}
 		out = append(out, TargetCandidate{
 			Member:    c.member,
 			Available: c.available,
-			Why:       c.why,
+			Why:       why,
 		})
 	}
 	return out
+}
+
+// selectCompiledOffer returns the one current, available offer named by an
+// echoed selector. Empty IDs are invalid input; every other miss — unknown ID,
+// wrong verb, collision-shaped ambiguity, or an offer whose current global gate
+// is false — is stale current-world state.
+func selectCompiledOffer(offers []compiledOffer, verb Verb, id string) (compiledOffer, error) {
+	if id == "" {
+		return compiledOffer{}, ErrNoDeclarationID
+	}
+
+	var selected *compiledOffer
+	for i := range offers {
+		if offers[i].verb != verb || offers[i].declaration.ID != id {
+			continue
+		}
+		if selected != nil {
+			return compiledOffer{}, ErrStaleDeclaration
+		}
+		selected = &offers[i]
+	}
+	if selected == nil || !selected.declaration.Available {
+		return compiledOffer{}, ErrStaleDeclaration
+	}
+	return *selected, nil
 }
 
 // selectorIDFor computes both the declaration selector ID and the canonical

--- a/rulebooks/dnd5e/session/offers_test.go
+++ b/rulebooks/dnd5e/session/offers_test.go
@@ -1,0 +1,539 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// offers_test.go pins Task 6's compiled-offer projection: one Declaration
+// per compiled verb carrying a selector ID, a fixed target kind, and — for
+// Attack — the full candidate universe with per-candidate availability. The
+// four named helpers keep assertions off declaration ordering beyond the
+// documented deterministic verb sort.
+
+// candidateFight builds a turn-clock fight with alice active and two live
+// skeletons in sight: skeleton-near at (2,1), one cell from alice's longsword
+// reach, and skeleton-far at (7,1), six cells away and so out of reach but
+// still within encEveryoneSees' unbounded sight. The caller mutates the
+// persisted encounter data through the returned repositories to inject the
+// stale and self holdings runAffordCandidateFixture adds on top.
+func candidateFight(t *testing.T) (*session.Manager, *fakeSessions, *fakeEncounters, *fakeCharacters) {
+	t.Helper()
+	alice := armedFighter("alice")
+	sessions, encounters := newFakeSessions(), newFakeEncounters()
+	characters := newFakeCharacters(alice)
+
+	// Enough scripted rolls for the fight's initiative and nothing else:
+	// Afford is a read and rolls nothing.
+	mgr, err := session.NewManager(&session.Config{
+		Dice: &sequenceDice{rolls: []int{10, 1, 1, 1, 1, 1, 1, 1, 1, 1}}, TurnDriver: session.Pass{},
+		Sessions: sessions, Encounters: encounters, Characters: characters, Events: session.DiscardEvents{},
+	})
+	require.NoError(t, err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Striker: encounter.RefusingStriker{}, Sight: encEveryoneSees{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{},
+		Standing: encEveryoneStanding{},
+		Field:    encounter.FieldInput{Canvas: pointyCanvas(), Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 8, 8)}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	require.NoError(t, err)
+	data := enc.ToData()
+
+	ctx := context.Background()
+	_, err = mgr.StartSession(ctx, &session.StartSessionInput{Session: "sess", Encounter: "world", World: &data})
+	require.NoError(t, err)
+
+	// skeleton-near lands one cell from alice and forms the fight, putting
+	// alice on the turn clock as the active member.
+	spawned, err := mgr.Spawn(ctx, &session.SpawnInput{
+		Session: "sess", ID: "skeleton-near", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 2, Y: 1},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, spawned.Formed, "skeleton-near in plain sight of alice must start a fight")
+
+	// skeleton-far is well outside a longsword's one-cell reach but inside
+	// encEveryoneSees' unbounded sight, so it is a LIVE candidate that fails
+	// the reach gate rather than a stale memory.
+	_, err = mgr.Spawn(ctx, &session.SpawnInput{
+		Session: "sess", ID: "skeleton-far", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 7, Y: 1},
+	})
+	require.NoError(t, err)
+
+	turn, err := mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	require.Equal(t, session.ClockTurn, turn.Clock, "alice is on the turn clock")
+	require.Equal(t, 1, turn.Round)
+	return mgr, sessions, encounters, characters
+}
+
+// injectHolding adds one holding for alice as observer, with the given subject
+// and current-via channels. It round-trips the persisted encounter data
+// through the fake repository so the next Afford reloads the mutated intel.
+func injectHolding(
+	t *testing.T, encounters *fakeEncounters, subject string, currentVia []intel.Channel,
+) {
+	t.Helper()
+	stored, err := encounters.GetEncounter(context.Background(), "world")
+	require.NoError(t, err)
+	if stored.Intel.Holdings == nil {
+		stored.Intel.Holdings = map[core.EntityID]map[intel.Subject]intel.HoldingData{}
+	}
+	obs := core.EntityID("alice")
+	if stored.Intel.Holdings[obs] == nil {
+		stored.Intel.Holdings[obs] = map[intel.Subject]intel.HoldingData{}
+	}
+	stored.Intel.Holdings[obs][intel.Subject(subject)] = intel.HoldingData{
+		Channel:    intel.Sight,
+		CurrentVia: currentVia,
+		Payload:    nil,
+	}
+	require.NoError(t, encounters.SaveEncounter(context.Background(), "world", stored))
+}
+
+// runAffordCandidateFixture builds the candidate universe fixture: in-range
+// (skeleton-near), out-of-range (skeleton-far), a stale memory
+// (skeleton-stale, CurrentVia empty) and a self holding (alice observing
+// herself). Only the two live non-self candidates should survive the
+// projection, sorted by member ID.
+func runAffordCandidateFixture(t *testing.T) *session.AffordOutput {
+	t.Helper()
+	mgr, _, encounters, _ := candidateFight(t)
+	// A stale memory: a holding the intel log retains with no live channel.
+	// skeleton-stale is not a roster member, but the CurrentVia-empty filter
+	// excludes it before the position lookup, so the missing position is
+	// never an inconsistency this fixture raises.
+	injectHolding(t, encounters, "skeleton-stale", nil)
+	// A self holding: alice observing herself. The subject==member filter
+	// excludes the actor from the candidate universe even when a holding
+	// exists.
+	injectHolding(t, encounters, "alice", []intel.Channel{intel.Sight})
+
+	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	return out
+}
+
+// requireSingleAttackDeclaration returns the one Attack declaration in decls,
+// failing loudly if there is not exactly one. Declarations are sorted by the
+// seam's documented verb rank (Attack, Move, EndTurn), but this helper finds
+// the Attack by verb rather than by index so it never couples to ordering
+// beyond that sort.
+func requireSingleAttackDeclaration(t *testing.T, decls []session.Declaration) session.Declaration {
+	t.Helper()
+	var attack *session.Declaration
+	for i := range decls {
+		if decls[i].Verb == session.VerbAttack {
+			if attack != nil {
+				t.Fatalf("found more than one Attack declaration")
+			}
+			attack = &decls[i]
+		}
+	}
+	if attack == nil {
+		t.Fatalf("expected exactly one Attack declaration, got none")
+	}
+	return *attack
+}
+
+// requireSingleDeclaration returns the one declaration with the given verb.
+func requireSingleDeclaration(t *testing.T, decls []session.Declaration, verb session.Verb) session.Declaration {
+	t.Helper()
+	for i := range decls {
+		if decls[i].Verb == verb {
+			return decls[i]
+		}
+	}
+	t.Fatalf("expected a %s declaration, got none", verb)
+	return session.Declaration{}
+}
+
+// candidateIDs extracts the member IDs from a candidate slice in order, for
+// assertions that do not repeat each candidate's availability.
+func candidateIDs(candidates []session.TargetCandidate) []string {
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		out = append(out, c.Member)
+	}
+	return out
+}
+
+// TestAffordReturnsOneAttackOfferWithEveryLiveCandidate is the brief's
+// load-bearing pin: one Attack declaration carries the full candidate
+// universe — in-range and out-of-range live candidates, sorted by member ID
+// — and excludes stale memories and the actor. The out-of-range candidate
+// keeps its row with a target-specific ShortfallTargetOutOfReach; the
+// declaration-level Why stays nil because at least one candidate is in reach.
+func TestAffordReturnsOneAttackOfferWithEveryLiveCandidate(t *testing.T) {
+	out := runAffordCandidateFixture(t)
+	attack := requireSingleAttackDeclaration(t, out.Declarations)
+
+	require.Equal(t, "dnd5e:weapons:longsword", attack.Attack.Ref,
+		"the compiled Attack carries the full definition ref")
+	require.Equal(t, "Longsword", attack.Attack.Name)
+	require.Equal(t, session.TargetMember, attack.TargetKind)
+	require.Equal(t, []string{"skeleton-far", "skeleton-near"}, candidateIDs(attack.Candidates),
+		"candidates are the live non-self universe, sorted by member ID")
+
+	// skeleton-far sorts before skeleton-near lexicographically.
+	require.False(t, attack.Candidates[0].Available, "skeleton-far is out of reach")
+	require.NotNil(t, attack.Candidates[0].Why)
+	require.Equal(t, session.ShortfallTargetOutOfReach, attack.Candidates[0].Why.Reason)
+
+	require.True(t, attack.Candidates[1].Available, "skeleton-near is in reach")
+	require.Nil(t, attack.Candidates[1].Why)
+
+	require.True(t, attack.Available, "budget passes and one candidate is in reach")
+	require.Nil(t, attack.Why)
+	require.NotEmpty(t, attack.ID, "a compiled Attack carries a selector ID")
+	require.Equal(t, session.SlotAction, attack.Slot)
+}
+
+// TestAffordProjectsThreeCompiledDeclarationsOnTheTurnClock pins the shape
+// of a full compiled turn: Attack, Move and EndTurn each carry a selector
+// ID and the fixed target kind, Move carries Remaining, EndTurn carries no
+// candidates, and the declarations arrive in the documented verb order.
+func TestAffordProjectsThreeCompiledDeclarationsOnTheTurnClock(t *testing.T) {
+	mgr, _, _, _ := candidateFight(t)
+	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+
+	require.Equal(t, session.ClockTurn, out.Clock)
+	require.Len(t, out.Declarations, 3, "Attack, Move and EndTurn")
+
+	// Documented verb order: Attack, Move, EndTurn.
+	require.Equal(t, session.VerbAttack, out.Declarations[0].Verb)
+	require.Equal(t, session.VerbMove, out.Declarations[1].Verb)
+	require.Equal(t, session.VerbEndTurn, out.Declarations[2].Verb)
+
+	attack := out.Declarations[0]
+	require.NotEmpty(t, attack.ID, "compiled Attack has a selector ID")
+	require.NotNil(t, attack.Attack)
+	require.Equal(t, session.TargetMember, attack.TargetKind)
+	require.NotEmpty(t, attack.Candidates)
+
+	move := out.Declarations[1]
+	require.NotEmpty(t, move.ID, "compiled Move has a selector ID")
+	require.Nil(t, move.Attack)
+	require.Equal(t, session.TargetPath, move.TargetKind)
+	require.NotNil(t, move.Remaining, "Move carries remaining feet")
+	require.Empty(t, move.Candidates, "Move carries no candidates")
+
+	endTurn := out.Declarations[2]
+	require.NotEmpty(t, endTurn.ID, "compiled EndTurn has a selector ID")
+	require.Nil(t, endTurn.Attack)
+	require.Equal(t, session.TargetNone, endTurn.TargetKind)
+	require.True(t, endTurn.Available, "EndTurn follows the clock alone")
+	require.Empty(t, endTurn.Candidates)
+}
+
+// TestNotYourTurnBlocksAllThreeVerbs pins the cheap, sheet-free blocker:
+// every verb is blocked with the same NotYourTurn reason, an empty selector
+// ID, no AttackRef, an empty candidate slice, and the fixed target kind.
+func TestNotYourTurnBlocksAllThreeVerbs(t *testing.T) {
+	sessions, encounters := newFakeSessions(), newFakeEncounters()
+	characters := newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: sessions, Encounters: encounters,
+		Characters: characters, Events: session.DiscardEvents{},
+	})
+	require.NoError(t, err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Striker: encounter.RefusingStriker{}, Sight: encEveryoneSees{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{}, Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: pointyCanvas(), Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 8, 8)}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: encounter.KindPlayer, Position: spatial.Position{X: 5, Y: 5}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	require.NoError(t, err)
+	data := enc.ToData()
+
+	ctx := context.Background()
+	_, err = mgr.StartSession(ctx, &session.StartSessionInput{Session: "sess", Encounter: "world", World: &data})
+	require.NoError(t, err)
+
+	_, err = mgr.Spawn(ctx, &session.SpawnInput{
+		Session: "sess", ID: "skel-1", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 2, Y: 1},
+	})
+	require.NoError(t, err)
+
+	out, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "bob"})
+	require.NoError(t, err)
+	require.Equal(t, session.ClockTurn, out.Clock)
+	require.Len(t, out.Declarations, 3)
+
+	for _, d := range out.Declarations {
+		require.False(t, d.Available)
+		require.Empty(t, d.ID, "a blocker carries no selector ID")
+		require.Nil(t, d.Attack, "a blocker carries no AttackRef")
+		require.Empty(t, d.Candidates, "a blocker carries no candidates")
+		require.NotNil(t, d.Why)
+		require.Equal(t, session.ShortfallNotYourTurn, d.Why.Reason)
+	}
+	require.Equal(t, session.TargetMember, out.Declarations[0].TargetKind)
+	require.Equal(t, session.TargetPath, out.Declarations[1].TargetKind)
+	require.Equal(t, session.TargetNone, out.Declarations[2].TargetKind)
+}
+
+// TestDownedBlocksAttackAndMoveButNotEndTurn pins the per-verb blocker
+// matrix for Downed: Attack and Move are blocked with the Downed reason,
+// while EndTurn follows the clock alone and stays compiled with a selector
+// ID. A downed active member is an edge case — the standing seam splices a
+// downed member out of the turn order, so NotYourTurn already covers a
+// downed bystander. This fixture reproduces the edge case by forming the
+// fight first (alice active on the turn clock) and only then dropping her
+// stored sheet to zero hit points, so the encounter's clock still names her
+// active while the session's sheet-based standing seam reads her downed.
+func TestDownedBlocksAttackAndMoveButNotEndTurn(t *testing.T) {
+	alice := armedFighter("alice")
+	mgr, _, _, characters := aFight(t, alice, []int{1, 1})
+
+	// Drop alice's stored sheet to zero AFTER the fight formed, so the
+	// encounter's clock still names her active while the standing seam reads
+	// her downed.
+	characters.byID["alice"].HitPoints = 0
+
+	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	require.Equal(t, session.ClockTurn, out.Clock)
+	require.Len(t, out.Declarations, 3)
+
+	attack := requireSingleDeclaration(t, out.Declarations, session.VerbAttack)
+	require.False(t, attack.Available)
+	require.Empty(t, attack.ID)
+	require.Nil(t, attack.Attack)
+	require.Empty(t, attack.Candidates)
+	require.Equal(t, session.TargetMember, attack.TargetKind)
+	require.NotNil(t, attack.Why)
+	require.Equal(t, session.ShortfallDowned, attack.Why.Reason)
+
+	move := requireSingleDeclaration(t, out.Declarations, session.VerbMove)
+	require.False(t, move.Available)
+	require.Empty(t, move.ID)
+	require.Empty(t, move.Candidates)
+	require.Equal(t, session.TargetPath, move.TargetKind)
+	require.NotNil(t, move.Why)
+	require.Equal(t, session.ShortfallDowned, move.Why.Reason)
+
+	endTurn := requireSingleDeclaration(t, out.Declarations, session.VerbEndTurn)
+	require.True(t, endTurn.Available, "EndTurn follows the clock alone, even downed")
+	require.NotEmpty(t, endTurn.ID, "EndTurn is still compiled with a selector ID")
+	require.Equal(t, session.TargetNone, endTurn.TargetKind)
+	require.Empty(t, endTurn.Candidates)
+}
+
+// TestBadAttackCompilationBlocksAttackOnly pins the per-verb blocker matrix
+// for an unreadable Attack: a sheet that loads fine but names a weapon the
+// catalog cannot resolve blocks Attack alone, while Move and EndTurn
+// continue off the readied sheet and the clock.
+func TestBadAttackCompilationBlocksAttackOnly(t *testing.T) {
+	alice := armedFighter("alice")
+	// A shield is valid equipment (so the sheet loads) but not a weapon, so
+	// AssembleAttack fails with "holds no weapon" where Move and EndTurn do
+	// not — the per-verb blocker matrix for a bad Attack compilation.
+	alice.EquipmentSlots[character.SlotMainHand] = "shield"
+	alice.Inventory = []character.InventoryItemData{
+		{Type: shared.EquipmentTypeArmor, ID: "shield", Quantity: 1},
+	}
+
+	sessions, encounters := newFakeSessions(), newFakeEncounters()
+	characters := newFakeCharacters(alice)
+	mgr, err := session.NewManager(&session.Config{
+		Dice: &sequenceDice{rolls: []int{10, 1, 1, 1, 1, 1, 1, 1, 1, 1}}, TurnDriver: session.Pass{},
+		Sessions: sessions, Encounters: encounters, Characters: characters, Events: session.DiscardEvents{},
+	})
+	require.NoError(t, err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Striker: encounter.RefusingStriker{}, Sight: encEveryoneSees{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{}, Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: pointyCanvas(), Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 8, 8)}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	require.NoError(t, err)
+	data := enc.ToData()
+
+	ctx := context.Background()
+	_, err = mgr.StartSession(ctx, &session.StartSessionInput{Session: "sess", Encounter: "world", World: &data})
+	require.NoError(t, err)
+	_, err = mgr.Spawn(ctx, &session.SpawnInput{
+		Session: "sess", ID: "skeleton-near", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 2, Y: 1},
+	})
+	require.NoError(t, err)
+
+	out, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	require.Equal(t, session.ClockTurn, out.Clock)
+	require.Len(t, out.Declarations, 3)
+
+	attack := requireSingleDeclaration(t, out.Declarations, session.VerbAttack)
+	require.False(t, attack.Available)
+	require.Empty(t, attack.ID, "a blocked Attack carries no selector ID")
+	require.Nil(t, attack.Attack)
+	require.Empty(t, attack.Candidates)
+	require.Equal(t, session.TargetMember, attack.TargetKind)
+	require.NotNil(t, attack.Why)
+	require.Equal(t, session.ShortfallUnreadable, attack.Why.Reason)
+
+	move := requireSingleDeclaration(t, out.Declarations, session.VerbMove)
+	require.True(t, move.Available, "Move continues off the readied sheet")
+	require.NotEmpty(t, move.ID, "Move is still compiled with a selector ID")
+	require.Equal(t, session.TargetPath, move.TargetKind)
+	require.NotNil(t, move.Remaining)
+
+	endTurn := requireSingleDeclaration(t, out.Declarations, session.VerbEndTurn)
+	require.True(t, endTurn.Available)
+	require.NotEmpty(t, endTurn.ID)
+}
+
+// TestUnreadableCharacterBlocksAttackAndMoveButNotEndTurn pins the per-verb
+// blocker matrix for an unreadable character: a member whose sheet the
+// repository does not hold blocks Attack and Move — there is no sheet to
+// compile a swing or read movement from — while EndTurn, governed by the
+// clock alone, stays compiled with a selector ID.
+func TestUnreadableCharacterBlocksAttackAndMoveButNotEndTurn(t *testing.T) {
+	// alice is armed and in the repository; bob is a player member the
+	// repository does not hold, so loading bob's sheet fails with
+	// ErrNoCharacter once bob is the active member.
+	sessions, encounters := newFakeSessions(), newFakeEncounters()
+	characters := newFakeCharacters(armedFighter("alice"))
+
+	mgr, err := session.NewManager(&session.Config{
+		Dice: &sequenceDice{rolls: []int{10, 1, 1, 1, 1, 1, 1, 1, 1, 1}}, TurnDriver: session.Pass{},
+		Sessions: sessions, Encounters: encounters, Characters: characters, Events: session.DiscardEvents{},
+	})
+	require.NoError(t, err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Striker: encounter.RefusingStriker{}, Sight: encEveryoneSees{},
+		Initiative: encOrderAsGiven{}, TurnDriver: encPassDriver{}, Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{Canvas: pointyCanvas(), Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 8, 8)}},
+		Members: []encounter.MemberInput{
+			{ID: "alice", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: "bob", Kind: encounter.KindPlayer, Position: spatial.Position{X: 3, Y: 1}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	require.NoError(t, err)
+	data := enc.ToData()
+
+	ctx := context.Background()
+	_, err = mgr.StartSession(ctx, &session.StartSessionInput{Session: "sess", Encounter: "world", World: &data})
+	require.NoError(t, err)
+	_, err = mgr.Spawn(ctx, &session.SpawnInput{
+		Session: "sess", ID: "skeleton-near", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 2, Y: 1},
+	})
+	require.NoError(t, err)
+
+	// End alice's turn: the skeleton's turn is driven through (Pass driver)
+	// and bob — a player — becomes active.
+	_, err = mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+
+	out, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "bob"})
+	require.NoError(t, err)
+	require.Equal(t, session.ClockTurn, out.Clock)
+	require.Len(t, out.Declarations, 3)
+
+	attack := requireSingleDeclaration(t, out.Declarations, session.VerbAttack)
+	require.False(t, attack.Available)
+	require.Empty(t, attack.ID)
+	require.Nil(t, attack.Attack)
+	require.Empty(t, attack.Candidates)
+	require.Equal(t, session.TargetMember, attack.TargetKind)
+	require.NotNil(t, attack.Why)
+	require.Equal(t, session.ShortfallUnreadable, attack.Why.Reason)
+
+	move := requireSingleDeclaration(t, out.Declarations, session.VerbMove)
+	require.False(t, move.Available)
+	require.Empty(t, move.ID)
+	require.Empty(t, move.Candidates)
+	require.Equal(t, session.TargetPath, move.TargetKind)
+	require.NotNil(t, move.Why)
+	require.Equal(t, session.ShortfallUnreadable, move.Why.Reason)
+
+	endTurn := requireSingleDeclaration(t, out.Declarations, session.VerbEndTurn)
+	require.True(t, endTurn.Available, "EndTurn follows the clock alone")
+	require.NotEmpty(t, endTurn.ID, "EndTurn is still compiled with a selector ID")
+	require.Equal(t, session.TargetNone, endTurn.TargetKind)
+}
+
+// TestLiveCandidateMissingPositionFailsClosed pins the fail-closed law: a
+// live holding (CurrentVia non-empty) whose subject the roster no longer
+// places is an internal inconsistency Afford surfaces as an error rather
+// than silently omitting the candidate.
+func TestLiveCandidateMissingPositionFailsClosed(t *testing.T) {
+	mgr, _, encounters, _ := candidateFight(t)
+	// A live holding for a subject that is NOT in the roster: the CurrentVia
+	// filter keeps it in the candidate universe, but the roster has no
+	// position for it, so Afford must fail closed.
+	injectHolding(t, encounters, "ghost", []intel.Channel{intel.Sight})
+
+	_, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
+	require.Error(t, err, "a live candidate with no position must fail rather than be omitted")
+}
+
+// TestNoTargetInReachKeepsCandidateRowsWithNoTargetInReach pins the
+// declaration-level precedence: when the budget passes but no candidate is
+// in reach, the Attack declaration's Why is NoTargetInReach while the
+// candidate rows remain, each carrying its own target-specific verdict.
+func TestNoTargetInReachKeepsCandidateRowsWithNoTargetInReach(t *testing.T) {
+	alice := armedFighter("alice")
+	mgr, _, _, _ := aFight(t, alice, []int{1, 1})
+
+	// Walk alice five cells from her spawn (1,1), well past a longsword's
+	// one-cell reach from the skeleton at (2,1).
+	_, err := mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice",
+		Path: []spatial.Position{{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}, {X: 1, Y: 5}, {X: 1, Y: 6}},
+	})
+	require.NoError(t, err, "test fixture must be able to walk alice out of reach")
+
+	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+
+	attack := requireSingleAttackDeclaration(t, out.Declarations)
+	require.False(t, attack.Available)
+	require.NotNil(t, attack.Why)
+	require.Equal(t, session.ShortfallNoTargetInReach, attack.Why.Reason)
+	require.NotEmpty(t, attack.ID, "a compiled Attack keeps its selector ID even with no target in reach")
+	require.NotNil(t, attack.Attack, "a compiled Attack keeps its AttackRef even with no target in reach")
+	require.Len(t, attack.Candidates, 1, "the candidate row remains")
+	require.False(t, attack.Candidates[0].Available)
+	require.NotNil(t, attack.Candidates[0].Why)
+	require.Equal(t, session.ShortfallTargetOutOfReach, attack.Candidates[0].Why.Reason)
+}

--- a/rulebooks/dnd5e/session/offers_test.go
+++ b/rulebooks/dnd5e/session/offers_test.go
@@ -5,6 +5,7 @@ package session_test
 
 import (
 	"context"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -31,7 +32,7 @@ import (
 // still within encEveryoneSees' unbounded sight. The caller mutates the
 // persisted encounter data through the returned repositories to inject the
 // stale and self holdings runAffordCandidateFixture adds on top.
-func candidateFight(t *testing.T) (*session.Manager, *fakeSessions, *fakeEncounters, *fakeCharacters) {
+func candidateFight(t *testing.T) (*session.Manager, *fakeSessions, *fakeEncounters, *fakeCharacters, *sequenceDice) {
 	t.Helper()
 	alice := armedFighter("alice")
 	sessions, encounters := newFakeSessions(), newFakeEncounters()
@@ -39,8 +40,9 @@ func candidateFight(t *testing.T) (*session.Manager, *fakeSessions, *fakeEncount
 
 	// Enough scripted rolls for the fight's initiative and nothing else:
 	// Afford is a read and rolls nothing.
+	roller := &sequenceDice{rolls: []int{10, 1, 1, 1, 1, 1, 1, 1, 1, 1}}
 	mgr, err := session.NewManager(&session.Config{
-		Dice: &sequenceDice{rolls: []int{10, 1, 1, 1, 1, 1, 1, 1, 1, 1}}, TurnDriver: session.Pass{},
+		Dice: roller, TurnDriver: session.Pass{},
 		Sessions: sessions, Encounters: encounters, Characters: characters, Events: session.DiscardEvents{},
 	})
 	require.NoError(t, err)
@@ -85,7 +87,7 @@ func candidateFight(t *testing.T) (*session.Manager, *fakeSessions, *fakeEncount
 	require.NoError(t, err)
 	require.Equal(t, session.ClockTurn, turn.Clock, "alice is on the turn clock")
 	require.Equal(t, 1, turn.Round)
-	return mgr, sessions, encounters, characters
+	return mgr, sessions, encounters, characters, roller
 }
 
 // injectHolding adds one holding for alice as observer, with the given subject
@@ -119,7 +121,7 @@ func injectHolding(
 // projection, sorted by member ID.
 func runAffordCandidateFixture(t *testing.T) *session.AffordOutput {
 	t.Helper()
-	mgr, _, encounters, _ := candidateFight(t)
+	mgr, _, encounters, _, _ := candidateFight(t)
 	// A stale memory: a holding the intel log retains with no live channel.
 	// skeleton-stale is not a roster member, but the CurrentVia-empty filter
 	// excludes it before the position lookup, so the missing position is
@@ -215,7 +217,7 @@ func TestAffordReturnsOneAttackOfferWithEveryLiveCandidate(t *testing.T) {
 // ID and the fixed target kind, Move carries Remaining, EndTurn carries no
 // candidates, and the declarations arrive in the documented verb order.
 func TestAffordProjectsThreeCompiledDeclarationsOnTheTurnClock(t *testing.T) {
-	mgr, _, _, _ := candidateFight(t)
+	mgr, _, _, _, _ := candidateFight(t)
 	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
 	require.NoError(t, err)
 
@@ -461,7 +463,9 @@ func TestUnreadableCharacterBlocksAttackAndMoveButNotEndTurn(t *testing.T) {
 
 	// End alice's turn: the skeleton's turn is driven through (Pass driver)
 	// and bob — a player — becomes active.
-	_, err = mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	_, err = mgr.EndTurn(ctx, &session.EndTurnInput{
+		Session: "sess", Member: "alice", DeclarationID: currentEndTurnID(t, mgr, "sess", "alice"),
+	})
 	require.NoError(t, err)
 
 	out, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "bob"})
@@ -490,6 +494,12 @@ func TestUnreadableCharacterBlocksAttackAndMoveButNotEndTurn(t *testing.T) {
 	require.True(t, endTurn.Available, "EndTurn follows the clock alone")
 	require.NotEmpty(t, endTurn.ID, "EndTurn is still compiled with a selector ID")
 	require.Equal(t, session.TargetNone, endTurn.TargetKind)
+
+	ended, err := mgr.EndTurn(ctx, &session.EndTurnInput{
+		Session: "sess", Member: "bob", DeclarationID: endTurn.ID,
+	})
+	require.NoError(t, err, "EndTurn execution has no sheet, standing, or economy gate")
+	require.NotNil(t, ended)
 }
 
 // TestLiveCandidateMissingPositionFailsClosed pins the fail-closed law: a
@@ -497,7 +507,7 @@ func TestUnreadableCharacterBlocksAttackAndMoveButNotEndTurn(t *testing.T) {
 // places is an internal inconsistency Afford surfaces as an error rather
 // than silently omitting the candidate.
 func TestLiveCandidateMissingPositionFailsClosed(t *testing.T) {
-	mgr, _, encounters, _ := candidateFight(t)
+	mgr, _, encounters, _, _ := candidateFight(t)
 	// A live holding for a subject that is NOT in the roster: the CurrentVia
 	// filter keeps it in the candidate universe, but the roster has no
 	// position for it, so Afford must fail closed.
@@ -511,6 +521,110 @@ func TestLiveCandidateMissingPositionFailsClosed(t *testing.T) {
 // declaration-level precedence: when the budget passes but no candidate is
 // in reach, the Attack declaration's Why is NoTargetInReach while the
 // candidate rows remain, each carrying its own target-specific verdict.
+// TestAttackSelectorGatesFailBeforeDiceOrDurableMutation pins the execution
+// trust boundary: the client may echo only the current available Attack offer.
+// Unknown IDs, IDs belonging to another verb, and unavailable candidates all
+// fail as stale without rolling or changing a repository-backed fact.
+func TestAttackSelectorGatesFailBeforeDiceOrDurableMutation(t *testing.T) {
+	mgr, sessions, encounters, characters, roller := candidateFight(t)
+	ctx := context.Background()
+
+	afford, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	attack := requireSingleDeclaration(t, afford.Declarations, session.VerbAttack)
+	move := requireSingleDeclaration(t, afford.Declarations, session.VerbMove)
+
+	beforeRolls := roller.next
+	beforeSession, err := json.Marshal(sessions.byID["sess"])
+	require.NoError(t, err)
+	beforeEncounter, err := json.Marshal(encounters.byID["world"])
+	require.NoError(t, err)
+	beforeCharacter := cloneCharacter(characters.byID["alice"])
+	beforeStory, err := mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		selector string
+		target   string
+	}{
+		{name: "unknown selector", selector: "v1.stale", target: "skeleton-near"},
+		{name: "selector belongs to Move", selector: move.ID, target: "skeleton-near"},
+		{name: "candidate is currently unavailable", selector: attack.ID, target: "skeleton-far"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, attackErr := mgr.Attack(ctx, &session.AttackInput{
+				Session: "sess", Attacker: "alice", Target: tc.target, DeclarationID: tc.selector,
+			})
+			require.ErrorIs(t, attackErr, session.ErrStaleDeclaration)
+			require.Nil(t, out)
+		})
+	}
+
+	require.Equal(t, beforeRolls, roller.next, "selector refusals roll no dice")
+	afterSession, err := json.Marshal(sessions.byID["sess"])
+	require.NoError(t, err)
+	afterEncounter, err := json.Marshal(encounters.byID["world"])
+	require.NoError(t, err)
+	require.JSONEq(t, string(beforeSession), string(afterSession), "selector refusals write no session state")
+	require.JSONEq(t, string(beforeEncounter), string(afterEncounter), "selector refusals record no story")
+	require.Equal(t, beforeCharacter, characters.byID["alice"], "selector refusals spend nothing")
+	afterStory, err := mgr.Story(ctx, &session.StoryInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	require.Len(t, afterStory, len(beforeStory))
+}
+
+// TestAttackRequiresADeclarationID pins missing selector as invalid input,
+// distinct from a current-world stale selector.
+func TestAttackRequiresADeclarationID(t *testing.T) {
+	mgr, _, _, _, _ := candidateFight(t)
+	out, err := mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "skeleton-near",
+	})
+	require.ErrorIs(t, err, session.ErrNoDeclarationID)
+	require.Nil(t, out)
+}
+
+// TestCompiledAttackSelectorIncludesItsActualPrice proves the load-bearing
+// selector material is the priced definition, not the costless weapon profile.
+// Changing only the actor's level changes the first-swing SpendProfile while
+// keeping session/member/verb/slot/weapon fixed, and therefore changes the ID.
+// Executing the new selector then banks the priced level-5 second swing.
+func TestCompiledAttackSelectorIncludesItsActualPrice(t *testing.T) {
+	alice := armedFighter("alice")
+	alice.Level = 3
+	mgr, _, _, characters := aFight(t, alice, []int{1, 1, 1, 1})
+	ctx := context.Background()
+
+	before, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	level3 := requireSingleDeclaration(t, before.Declarations, session.VerbAttack)
+	require.Equal(t, session.SlotAction, level3.Slot)
+
+	characters.byID["alice"].Level = 5
+	after, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	level5 := requireSingleDeclaration(t, after.Declarations, session.VerbAttack)
+	require.Equal(t, session.SlotAction, level5.Slot, "slot stayed fixed; the price is what changed")
+	require.NotEqual(t, level3.ID, level5.ID, "the actual SpendProfile participates in selector identity")
+
+	_, err = mgr.Attack(ctx, &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "skeleton", DeclarationID: level5.ID,
+	})
+	require.NoError(t, err)
+
+	banked, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	second := requireSingleDeclaration(t, banked.Declarations, session.VerbAttack)
+	require.Equal(t, session.SlotNone, second.Slot, "the selected priced definition banked Extra Attack")
+	require.True(t, second.Available)
+	_, err = mgr.Attack(ctx, &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "skeleton", DeclarationID: second.ID,
+	})
+	require.NoError(t, err, "execution consumes the same priced variant Afford selected")
+}
+
 func TestNoTargetInReachKeepsCandidateRowsWithNoTargetInReach(t *testing.T) {
 	alice := armedFighter("alice")
 	mgr, _, _, _ := aFight(t, alice, []int{1, 1})
@@ -518,7 +632,7 @@ func TestNoTargetInReachKeepsCandidateRowsWithNoTargetInReach(t *testing.T) {
 	// Walk alice five cells from her spawn (1,1), well past a longsword's
 	// one-cell reach from the skeleton at (2,1).
 	_, err := mgr.Move(context.Background(), &session.MoveInput{
-		Session: "sess", Member: "alice",
+		Session: "sess", Member: "alice", DeclarationID: currentMoveID(t, mgr, "sess", "alice"),
 		Path: []spatial.Position{{X: 1, Y: 2}, {X: 1, Y: 3}, {X: 1, Y: 4}, {X: 1, Y: 5}, {X: 1, Y: 6}},
 	})
 	require.NoError(t, err, "test fixture must be able to walk alice out of reach")

--- a/rulebooks/dnd5e/session/read.go
+++ b/rulebooks/dnd5e/session/read.go
@@ -320,6 +320,10 @@ func (m *Manager) loadSessionData(ctx context.Context, sessionID string) (*Sessi
 		return nil, fmt.Errorf(
 			"%q: GetSession reported success with no data: %w", sessionID, ErrBadRepository)
 	}
+	if data.ID != sessionID {
+		return nil, fmt.Errorf(
+			"GetSession(%q) returned session %q: %w", sessionID, data.ID, ErrBadRepository)
+	}
 	return data, nil
 }
 

--- a/rulebooks/dnd5e/session/selector_no_mutation_test.go
+++ b/rulebooks/dnd5e/session/selector_no_mutation_test.go
@@ -191,6 +191,27 @@ func TestEndTurnNotYourTurnPrecedesSelectorAndMutatesNothing(t *testing.T) {
 	f.requireNoMutation(before)
 }
 
+func TestAffordThenEndTurnRejectsRepositorySessionIDMismatch(t *testing.T) {
+	f := newSelectorFixture(t, turnWorld(freeRoamDuelWorld(t), []string{"alice", "bob"}, 0))
+	id := currentEndTurnID(t, f.mgr, "sess", "alice")
+	f.sessions.byID["sess"].ID = "different-session"
+	f.resetMutationCounters()
+	before := f.state("alice")
+
+	afford, err := f.mgr.Afford(context.Background(), &session.AffordInput{
+		Session: "sess", Member: "alice",
+	})
+	require.ErrorIs(t, err, session.ErrBadRepository)
+	require.Nil(t, afford)
+
+	out, err := f.mgr.EndTurn(context.Background(), &session.EndTurnInput{
+		Session: "sess", Member: "alice", DeclarationID: id,
+	})
+	require.ErrorIs(t, err, session.ErrBadRepository)
+	require.Nil(t, out)
+	f.requireNoMutation(before)
+}
+
 // actorLoadCheckingDice observes the execution boundary: by the first attack
 // roll, the turn path must have loaded the actor exactly once. The resolution
 // may legitimately consult standing again after the roll and after damage.
@@ -205,6 +226,8 @@ func (d *actorLoadCheckingDice) Roll(_ context.Context, _ int) (int, error) {
 	if d.next == 0 {
 		require.Equal(d.t, 1, d.characters.asked["alice"],
 			"downed verdict and compiled offer must share one strict actor load before execution")
+		require.Equal(d.t, 1, d.characters.asked["bob"],
+			"compiled cast must snapshot each non-actor participant once and execution must not refetch it")
 	}
 	require.Less(d.t, d.next, len(d.rolls), "execution requested an unexpected die roll")
 	roll := d.rolls[d.next]
@@ -228,6 +251,7 @@ func TestSuccessfulTurnAttackLoadsActorOnceBeforeExecution(t *testing.T) {
 	require.NoError(t, err)
 	id := currentAttackID(t, mgr, "sess", "alice")
 	characters.asked["alice"] = 0
+	characters.asked["bob"] = 0
 	characters.loads = 0
 
 	out, err := mgr.Attack(context.Background(), &session.AttackInput{

--- a/rulebooks/dnd5e/session/selector_no_mutation_test.go
+++ b/rulebooks/dnd5e/session/selector_no_mutation_test.go
@@ -1,0 +1,238 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// selectorFixture gives every refusal case fresh repositories and independent
+// mutation counters. The counters are reset after setup (and after obtaining a
+// current selector), so zero means this attempted verb wrote and recorded
+// nothing rather than merely restoring an equal value.
+type selectorFixture struct {
+	t          *testing.T
+	mgr        *session.Manager
+	sessions   *fakeSessions
+	encounters *fakeEncounters
+	characters *fakeCharacters
+	stream     *fakeStream
+	roller     *sequenceDice
+}
+
+func newSelectorFixture(t *testing.T, world *encounter.EncounterData) *selectorFixture {
+	t.Helper()
+	f := &selectorFixture{
+		t:          t,
+		sessions:   newFakeSessions(),
+		encounters: newFakeEncounters(),
+		characters: newFakeCharacters(armedFighter("alice"), armedFighter("bob")),
+		stream:     &fakeStream{},
+		roller:     &sequenceDice{rolls: []int{15, 5}},
+	}
+	mgr, err := session.NewManager(&session.Config{
+		Dice: f.roller, TurnDriver: session.Pass{}, Sessions: f.sessions, Encounters: f.encounters,
+		Characters: f.characters, Events: f.stream,
+	})
+	require.NoError(t, err)
+	f.mgr = mgr
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: world,
+	})
+	require.NoError(t, err)
+	f.resetMutationCounters()
+	return f
+}
+
+func (f *selectorFixture) resetMutationCounters() {
+	f.sessions.saves = 0
+	f.encounters.saves = 0
+	f.encounters.records = 0
+	f.characters.saves = 0
+	f.stream.published = nil
+	f.roller.next = 0
+}
+
+type selectorState struct {
+	position spatial.Position
+	clock    string
+}
+
+func (f *selectorFixture) state(member string) selectorState {
+	f.t.Helper()
+	world := f.encounters.byID["world"]
+	var position spatial.Position
+	found := false
+	for _, candidate := range world.Members {
+		if string(candidate.ID) == member && candidate.Cell != nil {
+			position = spatial.Position{X: candidate.Cell.X, Y: candidate.Cell.Y}
+			found = true
+			break
+		}
+	}
+	require.True(f.t, found, "member %q must be in the stored world", member)
+	clock, err := json.Marshal(struct {
+		World   any `json:"world"`
+		Bubbles any `json:"bubbles"`
+	}{World: world.Clock, Bubbles: world.Bubbles})
+	require.NoError(f.t, err)
+	return selectorState{position: position, clock: string(clock)}
+}
+
+func (f *selectorFixture) requireNoMutation(before selectorState) {
+	f.t.Helper()
+	require.Zero(f.t, f.roller.next, "selector refusal must roll no dice")
+	require.Zero(f.t, f.characters.saves, "selector refusal must write no character")
+	require.Zero(f.t, f.sessions.saves, "selector refusal must write no session")
+	require.Zero(f.t, f.encounters.saves, "selector refusal must write no encounter")
+	require.Zero(f.t, f.encounters.records, "selector refusal must record no story beat")
+	require.Empty(f.t, f.stream.published, "selector refusal must publish no event")
+	require.Equal(f.t, before, f.state("alice"), "selector refusal must leave position and clock unchanged")
+}
+
+func TestAttackSelectorRefusalsMutateNothing(t *testing.T) {
+	tests := []struct {
+		name     string
+		world    func() *encounter.EncounterData
+		selector func(*selectorFixture) string
+	}{
+		{
+			name:     "stale selector",
+			world:    func() *encounter.EncounterData { return turnWorld(freeRoamDuelWorld(t), []string{"alice", "bob"}, 0) },
+			selector: func(*selectorFixture) string { return "v1.stale" },
+		},
+		{
+			name:  "wrong verb selector",
+			world: func() *encounter.EncounterData { return turnWorld(freeRoamDuelWorld(t), []string{"alice", "bob"}, 0) },
+			selector: func(f *selectorFixture) string {
+				return currentMoveID(t, f.mgr, "sess", "alice")
+			},
+		},
+		{
+			name:  "currently unavailable selector",
+			world: func() *encounter.EncounterData { return reachWorld(t, spatial.Position{X: 5, Y: 1}) },
+			selector: func(f *selectorFixture) string {
+				declaration := currentDeclaration(t, f.mgr, "sess", "alice", session.VerbAttack)
+				require.False(t, declaration.Available)
+				return declaration.ID
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f := newSelectorFixture(t, tc.world())
+			id := tc.selector(f)
+			f.resetMutationCounters()
+			before := f.state("alice")
+
+			out, err := f.mgr.Attack(context.Background(), &session.AttackInput{
+				Session: "sess", Attacker: "alice", Target: "bob", DeclarationID: id,
+			})
+			require.ErrorIs(t, err, session.ErrStaleDeclaration)
+			require.Nil(t, out)
+			f.requireNoMutation(before)
+		})
+	}
+}
+
+func TestStaleTurnMoveAfterWorldTransitionMutatesNothing(t *testing.T) {
+	f := newSelectorFixture(t, turnWorld(freeRoamDuelWorld(t), []string{"alice", "bob"}, 0))
+	id := currentMoveID(t, f.mgr, "sess", "alice")
+	_, err := f.mgr.Dissolve(context.Background(), &session.DissolveInput{
+		Session: "sess", Member: "alice", Cause: session.ByDecision(),
+	})
+	require.NoError(t, err)
+	f.resetMutationCounters()
+	before := f.state("alice")
+
+	out, err := f.mgr.Move(context.Background(), &session.MoveInput{
+		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 2}}, DeclarationID: id,
+	})
+	require.ErrorIs(t, err, session.ErrStaleDeclaration)
+	require.Nil(t, out)
+	f.requireNoMutation(before)
+}
+
+func TestStaleEndTurnMutatesNothingEvenWhenARealEndWouldWrapBack(t *testing.T) {
+	world := turnWorld(ambushWorld(t), []string{"alice", "ogre"}, 0)
+	f := newSelectorFixture(t, world)
+	f.resetMutationCounters()
+	before := f.state("alice")
+
+	out, err := f.mgr.EndTurn(context.Background(), &session.EndTurnInput{
+		Session: "sess", Member: "alice", DeclarationID: "v1.stale",
+	})
+	require.ErrorIs(t, err, session.ErrStaleDeclaration)
+	require.Nil(t, out)
+	f.requireNoMutation(before)
+}
+
+func TestEndTurnNotYourTurnPrecedesSelectorAndMutatesNothing(t *testing.T) {
+	f := newSelectorFixture(t, turnWorld(freeRoamDuelWorld(t), []string{"alice", "bob"}, 0))
+	f.resetMutationCounters()
+	before := f.state("alice")
+
+	out, err := f.mgr.EndTurn(context.Background(), &session.EndTurnInput{
+		Session: "sess", Member: "bob", DeclarationID: "v1.stale",
+	})
+	require.ErrorIs(t, err, session.ErrNotYourTurn)
+	require.NotErrorIs(t, err, session.ErrStaleDeclaration)
+	require.Nil(t, out)
+	f.requireNoMutation(before)
+}
+
+// actorLoadCheckingDice observes the execution boundary: by the first attack
+// roll, the turn path must have loaded the actor exactly once. The resolution
+// may legitimately consult standing again after the roll and after damage.
+type actorLoadCheckingDice struct {
+	t          *testing.T
+	characters *fakeCharacters
+	rolls      []int
+	next       int
+}
+
+func (d *actorLoadCheckingDice) Roll(_ context.Context, _ int) (int, error) {
+	if d.next == 0 {
+		require.Equal(d.t, 1, d.characters.asked["alice"],
+			"downed verdict and compiled offer must share one strict actor load before execution")
+	}
+	require.Less(d.t, d.next, len(d.rolls), "execution requested an unexpected die roll")
+	roll := d.rolls[d.next]
+	d.next++
+	return roll, nil
+}
+
+func TestSuccessfulTurnAttackLoadsActorOnceBeforeExecution(t *testing.T) {
+	sessions, encounters := newFakeSessions(), newFakeEncounters()
+	characters := newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
+	dice := &actorLoadCheckingDice{t: t, characters: characters, rolls: []int{15, 5}}
+	mgr, err := session.NewManager(&session.Config{
+		Dice: dice, TurnDriver: session.Pass{}, Sessions: sessions, Encounters: encounters,
+		Characters: characters, Events: session.DiscardEvents{},
+	})
+	require.NoError(t, err)
+	_, err = mgr.StartSession(context.Background(), &session.StartSessionInput{
+		Session: "sess", Encounter: "world",
+		World: turnWorld(freeRoamDuelWorld(t), []string{"alice", "bob"}, 0),
+	})
+	require.NoError(t, err)
+	id := currentAttackID(t, mgr, "sess", "alice")
+	characters.asked["alice"] = 0
+	characters.loads = 0
+
+	out, err := mgr.Attack(context.Background(), &session.AttackInput{
+		Session: "sess", Attacker: "alice", Target: "bob", DeclarationID: id,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, out)
+}

--- a/rulebooks/dnd5e/session/sentinels_test.go
+++ b/rulebooks/dnd5e/session/sentinels_test.go
@@ -33,6 +33,7 @@ package session_test
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -170,6 +171,24 @@ type SentinelSuite struct {
 
 func TestSentinelSuite(t *testing.T) { suite.Run(t, new(SentinelSuite)) }
 
+// TestDeclarationSentinelVocabulary pins the two selector-boundary additions
+// as distinct host remedies: omission is invalid input, while an echoed option
+// changing is current-world refusal. The explicit count makes future additions
+// a reviewed vocabulary change rather than silent accretion.
+func TestDeclarationSentinelVocabulary(t *testing.T) {
+	selectorSentinels := []error{session.ErrNoDeclarationID, session.ErrStaleDeclaration}
+	if len(selectorSentinels) != 2 {
+		t.Fatalf("selector sentinel count changed: got %d", len(selectorSentinels))
+	}
+	for i, left := range selectorSentinels {
+		for j, right := range selectorSentinels {
+			if i != j && errors.Is(left, right) {
+				t.Fatalf("selector sentinels %d and %d are not distinct", i, j)
+			}
+		}
+	}
+}
+
 func (s *SentinelSuite) SetupTest() {
 	s.sessions, s.encounters = newFakeSessions(), newFakeEncounters()
 	mgr, err := session.NewManager(&session.Config{
@@ -241,6 +260,7 @@ func (s *SentinelSuite) swing(mgr *session.Manager) error {
 	s.T().Helper()
 	_, err := mgr.Attack(context.Background(), &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "bob",
+		DeclarationID: currentAttackID(s.T(), mgr, "sess", "alice"),
 	})
 	return err
 }
@@ -440,7 +460,7 @@ func (s *SentinelSuite) TestASwingWithAnUnreadableSheet() {
 	mgr := s.armedDuel(newFakeCharacters(unreadableFighter("alice"), armedFighter("bob")))
 
 	err := s.swing(mgr)
-	s.refusedInOurVocabulary(err, session.ErrBadCharacter)
+	s.refusedInOurVocabulary(err, session.ErrNoDeclarationID)
 }
 
 // TestADownedActorIsRefusedInOurWords is the death lane's own refusal, and the
@@ -458,26 +478,29 @@ func (s *SentinelSuite) TestASwingWithAnUnreadableSheet() {
 // So the refusal is driven for real: bob puts alice at zero hit points, and
 // alice is then refused the verbs a downed member cannot drive.
 func (s *SentinelSuite) TestADownedActorIsRefusedInOurWords() {
-	mgr := s.armedDuel(newFakeCharacters(armedFighter("alice"), armedFighter("bob")))
+	alice := armedFighter("alice")
+	alice.Level = 5
+	mgr := s.armedDuel(newFakeCharacters(alice, armedFighter("bob")))
 	ctx := context.Background()
 
-	for i := 0; i < 4; i++ {
+	for i := 0; i < 2; i++ {
 		_, err := mgr.Attack(ctx, &session.AttackInput{
-			Session: "sess", Attacker: "bob", Target: "alice",
+			Session: "sess", Attacker: "alice", Target: "bob",
+			DeclarationID: currentAttackID(s.T(), mgr, "sess", "alice"),
 		})
 		s.Require().NoError(err)
 	}
 
 	_, moveErr := mgr.Move(ctx, &session.MoveInput{
-		Session: "sess", Member: "alice", Path: []spatial.Position{{X: 1, Y: 2}},
+		Session: "sess", Member: "bob", Path: []spatial.Position{{X: 2, Y: 2}},
 	})
 	s.refusedInOurVocabulary(moveErr, session.ErrDowned)
 
 	_, swingErr := mgr.Attack(ctx, &session.AttackInput{
-		Session: "sess", Attacker: "alice", Target: "bob",
+		Session: "sess", Attacker: "bob", Target: "alice",
 	})
 	s.refusedInOurVocabulary(swingErr, session.ErrDowned)
-	s.Contains(swingErr.Error(), "alice", "and the refusal still names who could not act")
+	s.Contains(swingErr.Error(), "bob", "and the refusal still names who could not act")
 }
 
 // TestASecondSwingInOneTurn is the economy's refusal, driven for real.
@@ -498,15 +521,15 @@ func (s *SentinelSuite) TestASecondSwingInOneTurn() {
 
 	_, err := mgr.Attack(ctx, &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "skeleton",
+		DeclarationID: currentAttackID(s.T(), mgr, "sess", "alice"),
 	})
 	s.Require().NoError(err, "the first swing is bought by the Attack action")
 
 	_, err = mgr.Attack(ctx, &session.AttackInput{
 		Session: "sess", Attacker: "alice", Target: "skeleton",
+		DeclarationID: currentAttackID(s.T(), mgr, "sess", "alice"),
 	})
-	s.refusedInOurVocabulary(err, session.ErrCannotAfford)
-	s.Contains(err.Error(), "action",
-		"and the refusal still names the currency that ran out")
+	s.refusedInOurVocabulary(err, session.ErrStaleDeclaration)
 }
 
 // TestASpawnNamingAMalformedRef is the third module and the second door.

--- a/rulebooks/dnd5e/session/sentinels_test.go
+++ b/rulebooks/dnd5e/session/sentinels_test.go
@@ -38,6 +38,8 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -213,26 +215,34 @@ var sessionSentinels = map[string]error{
 }
 
 // TestExportedSentinelAllowListIsComplete makes sessionSentinels an actual
-// allow-list rather than a list that can become incomplete unnoticed.
+// allow-list rather than a list that can become incomplete unnoticed. It scans
+// every Go file in the package, not just errors.go, so a stray exported Err*
+// sentinel beside its one caller cannot bypass review.
 func TestExportedSentinelAllowListIsComplete(t *testing.T) {
-	file, err := parser.ParseFile(token.NewFileSet(), "errors.go", nil, 0)
+	paths, err := filepath.Glob("*.go")
 	if err != nil {
-		t.Fatalf("parse errors.go: %v", err)
+		t.Fatalf("glob package Go files: %v", err)
 	}
 	found := map[string]bool{}
-	for _, declaration := range file.Decls {
-		gen, ok := declaration.(*ast.GenDecl)
-		if !ok || gen.Tok != token.VAR {
-			continue
+	for _, path := range paths {
+		file, parseErr := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if parseErr != nil {
+			t.Fatalf("parse %s: %v", path, parseErr)
 		}
-		for _, spec := range gen.Specs {
-			values, ok := spec.(*ast.ValueSpec)
-			if !ok {
+		for _, declaration := range file.Decls {
+			gen, ok := declaration.(*ast.GenDecl)
+			if !ok || gen.Tok != token.VAR {
 				continue
 			}
-			for _, name := range values.Names {
-				if name.IsExported() && len(name.Name) >= 3 && name.Name[:3] == "Err" {
-					found[name.Name] = true
+			for _, spec := range gen.Specs {
+				values, ok := spec.(*ast.ValueSpec)
+				if !ok {
+					continue
+				}
+				for _, name := range values.Names {
+					if name.IsExported() && strings.HasPrefix(name.Name, "Err") {
+						found[name.Name] = true
+					}
 				}
 			}
 		}
@@ -518,21 +528,16 @@ func (s *SentinelSuite) TestASwingWithAnEmptyHandIsNotRefused() {
 	s.NoError(err)
 }
 
-// TestOneSheetStoredUnderTwoNames drives the resolution module's own validation
-// — the arm translateResolution was written for.
-//
-// The roster holds two members and the repository answers both with the same
-// sheet, which is a seeding mistake rather than corruption: the bytes are
-// valid, and only their identity is wrong. Resolution refuses because two
-// sheets under one ID would attach twice and be written back once, and the host
-// is entitled to hear that in this package's vocabulary — its own character
-// data is what needs looking at.
+// TestOneSheetStoredUnderTwoNames pins dependency preflight ahead of
+// resolution. The roster holds two members and the repository answers both
+// with Alice's sheet; Afford marks the Attack Unreadable, and echoing that
+// unavailable selector is stale before resolution or mutation.
 func (s *SentinelSuite) TestOneSheetStoredUnderTwoNames() {
 	chars := newFakeCharacters(armedFighter("alice"))
 	chars.byID["bob"] = armedFighter("alice")
 
 	err := s.swing(s.armedDuel(chars))
-	s.refusedInOurVocabulary(err, session.ErrBadCharacter)
+	s.refusedInOurVocabulary(err, session.ErrStaleDeclaration)
 }
 
 // TestASwingWithAnUnreadableSheet is the loader's own refusal on the swing

--- a/rulebooks/dnd5e/session/sentinels_test.go
+++ b/rulebooks/dnd5e/session/sentinels_test.go
@@ -35,6 +35,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"testing"
 
 	"github.com/stretchr/testify/suite"
@@ -159,6 +162,91 @@ var refSentinels = map[string]error{
 // rpg-toolkit#1058.
 var innerSentinels = []map[string]error{compositionSentinels, resolutionSentinels, refSentinels}
 
+// sessionSentinels is the reviewed host-facing sentinel vocabulary. The AST
+// completeness test below compares this allow-list with every exported Err*
+// declaration in errors.go, so additions cannot silently escape review.
+var sessionSentinels = map[string]error{
+	"ErrNilInput":         session.ErrNilInput,
+	"ErrNilConfig":        session.ErrNilConfig,
+	"ErrIncompleteConfig": session.ErrIncompleteConfig,
+	"ErrNotFound":         session.ErrNotFound,
+	"ErrBadRepository":    session.ErrBadRepository,
+	"ErrNoSession":        session.ErrNoSession,
+	"ErrNoEncounter":      session.ErrNoEncounter,
+	"ErrNoCharacter":      session.ErrNoCharacter,
+	"ErrBadCharacter":     session.ErrBadCharacter,
+	"ErrNoRef":            session.ErrNoRef,
+	"ErrBadRef":           session.ErrBadRef,
+	"ErrNoLoader":         session.ErrNoLoader,
+	"ErrUnknownContent":   session.ErrUnknownContent,
+	"ErrNoMemberID":       session.ErrNoMemberID,
+	"ErrNoDeclarationID":  session.ErrNoDeclarationID,
+	"ErrStaleDeclaration": session.ErrStaleDeclaration,
+	"ErrNoMember":         session.ErrNoMember,
+	"ErrStoryTrimmed":     session.ErrStoryTrimmed,
+	"ErrClosed":           session.ErrClosed,
+	"ErrNoEnding":         session.ErrNoEnding,
+	"ErrEmptyPath":        session.ErrEmptyPath,
+	"ErrBrokenPath":       session.ErrBrokenPath,
+	"ErrLocked":           session.ErrLocked,
+	"ErrDoorShut":         session.ErrDoorShut,
+	"ErrNoConnection":     session.ErrNoConnection,
+	"ErrBadPosition":      session.ErrBadPosition,
+	"ErrNoSessionID":      session.ErrNoSessionID,
+	"ErrNoEncounterID":    session.ErrNoEncounterID,
+	"ErrSessionExists":    session.ErrSessionExists,
+	"ErrInvalidWorld":     session.ErrInvalidWorld,
+	"ErrInBubble":         session.ErrInBubble,
+	"ErrNotInFight":       session.ErrNotInFight,
+	"ErrNotYourTurn":      session.ErrNotYourTurn,
+	"ErrNoCause":          session.ErrNoCause,
+	"ErrNotACharacter":    session.ErrNotACharacter,
+	"ErrNoSheet":          session.ErrNoSheet,
+	"ErrDowned":           session.ErrDowned,
+	"ErrBadAttack":        session.ErrBadAttack,
+	"ErrOutOfReach":       session.ErrOutOfReach,
+	"ErrCannotAfford":     session.ErrCannotAfford,
+	"ErrBadCost":          session.ErrBadCost,
+	"ErrInvalidSession":   session.ErrInvalidSession,
+	"ErrSaveFailed":       session.ErrSaveFailed,
+	"ErrBadTurnOutcome":   session.ErrBadTurnOutcome,
+}
+
+// TestExportedSentinelAllowListIsComplete makes sessionSentinels an actual
+// allow-list rather than a list that can become incomplete unnoticed.
+func TestExportedSentinelAllowListIsComplete(t *testing.T) {
+	file, err := parser.ParseFile(token.NewFileSet(), "errors.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parse errors.go: %v", err)
+	}
+	found := map[string]bool{}
+	for _, declaration := range file.Decls {
+		gen, ok := declaration.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			values, ok := spec.(*ast.ValueSpec)
+			if !ok {
+				continue
+			}
+			for _, name := range values.Names {
+				if name.IsExported() && len(name.Name) >= 3 && name.Name[:3] == "Err" {
+					found[name.Name] = true
+				}
+			}
+		}
+	}
+	if len(found) != len(sessionSentinels) {
+		t.Fatalf("exported sentinel count changed: declarations=%d allow-list=%d", len(found), len(sessionSentinels))
+	}
+	for name := range found {
+		if _, ok := sessionSentinels[name]; !ok {
+			t.Errorf("exported sentinel %s is not reviewed in sessionSentinels", name)
+		}
+	}
+}
+
 // SentinelSuite drives each reachable refusal and checks what a host can match
 // on afterwards.
 type SentinelSuite struct {
@@ -171,14 +259,13 @@ type SentinelSuite struct {
 
 func TestSentinelSuite(t *testing.T) { suite.Run(t, new(SentinelSuite)) }
 
-// TestDeclarationSentinelVocabulary pins the two selector-boundary additions
-// as distinct host remedies: omission is invalid input, while an echoed option
-// changing is current-world refusal. The explicit count makes future additions
-// a reviewed vocabulary change rather than silent accretion.
+// TestDeclarationSentinelVocabulary pins the selector-boundary additions as
+// distinct host remedies. Completeness belongs to the exported allow-list/count
+// test above rather than a tautological local len-two assertion.
 func TestDeclarationSentinelVocabulary(t *testing.T) {
-	selectorSentinels := []error{session.ErrNoDeclarationID, session.ErrStaleDeclaration}
-	if len(selectorSentinels) != 2 {
-		t.Fatalf("selector sentinel count changed: got %d", len(selectorSentinels))
+	selectorSentinels := []error{
+		sessionSentinels["ErrNoDeclarationID"],
+		sessionSentinels["ErrStaleDeclaration"],
 	}
 	for i, left := range selectorSentinels {
 		for j, right := range selectorSentinels {

--- a/rulebooks/dnd5e/session/session.go
+++ b/rulebooks/dnd5e/session/session.go
@@ -103,6 +103,13 @@ type Manager struct {
 	initiative encounter.InitiativeRoller
 	turnDriver encounter.TurnDriver
 
+	// targetPreflight is the one shared target gate used by offer projection
+	// and regenerated Attack execution. It is a pure function seam rather than
+	// host configuration: production always installs buildTargetPreflight, while
+	// an internal mutation test can inject a refusal and prove both callers move
+	// together.
+	targetPreflight targetPreflightFunc
+
 	// dice is the host's randomness, kept as well as wrapped: the initiative
 	// seam needs it wrapped for the composition, and a resolution machine
 	// needs it wrapped for the rulebook. One source, two adapters.
@@ -145,12 +152,13 @@ func NewManager(cfg *Config) (*Manager, error) {
 	}
 
 	return &Manager{
-		sessions:   cfg.Sessions,
-		encounters: cfg.Encounters,
-		characters: cfg.Characters,
-		events:     cfg.Events,
-		initiative: initiativeSeam{dice: cfg.Dice},
-		dice:       cfg.Dice,
-		turnDriver: turnDriverSeam{driver: cfg.TurnDriver},
+		sessions:        cfg.Sessions,
+		encounters:      cfg.Encounters,
+		characters:      cfg.Characters,
+		events:          cfg.Events,
+		initiative:      initiativeSeam{dice: cfg.Dice},
+		dice:            cfg.Dice,
+		turnDriver:      turnDriverSeam{driver: cfg.TurnDriver},
+		targetPreflight: buildTargetPreflight,
 	}, nil
 }

--- a/rulebooks/dnd5e/session/stale_combat_economy_test.go
+++ b/rulebooks/dnd5e/session/stale_combat_economy_test.go
@@ -134,12 +134,18 @@ func (s *StaleCombatEconomySuite) afford(member string) *session.AffordOutput {
 	return out
 }
 
-// attackDecl finds the VerbAttack declaration for a specific target.
+// attackDecl finds the VerbAttack declaration whose candidate universe
+// includes the named target, failing loudly if Afford omits it.
 func (s *StaleCombatEconomySuite) attackDecl(out *session.AffordOutput, target string) session.Declaration {
 	s.T().Helper()
 	for _, d := range out.Declarations {
-		if d.Verb == session.VerbAttack && d.Target != nil && *d.Target == target {
-			return d
+		if d.Verb != session.VerbAttack {
+			continue
+		}
+		for _, c := range d.Candidates {
+			if c.Member == target {
+				return d
+			}
 		}
 	}
 	s.Require().Fail("no VerbAttack declaration for "+target, "declarations: %+v", out.Declarations)
@@ -179,6 +185,6 @@ func (s *StaleCombatEconomySuite) TestASecondFightsFirstTurnIsNotChargedForTheFi
 	// sees TurnNumber already matching this round and silently no-ops,
 	// leaving her with no action to swing at all.
 	decl := s.attackDecl(s.afford("alice"), "skel-2")
-	s.True(decl.Affordable,
+	s.True(decl.Available,
 		"alice's first swing in a NEW fight must be affordable — not refused for an action fight 1 already spent")
 }

--- a/rulebooks/dnd5e/session/stale_combat_economy_test.go
+++ b/rulebooks/dnd5e/session/stale_combat_economy_test.go
@@ -23,8 +23,8 @@ import (
 // Kirk (live, two browsers, 2026-08-24): a member recruited into a fight
 // already in progress started their own first turn with only 5 of 30 feet
 // of movement. The natural first read — "the free-roam approach spent it" —
-// does not hold: [Manager.priceWalk] decides free-roam-vs-turn-clock ONCE,
-// from the clock state at the top of the Move call, before any step runs, so
+// does not hold: Move decides free-roam-vs-turn-clock ONCE, from the clock
+// state at the top of the call, before any step runs, so
 // a walk that starts on the world clock is priced nothing for the whole
 // call regardless of what a mid-path step does. A genuinely first-ever
 // combat entrant seeds a full 30ft via [character.StartTurn] exactly as
@@ -121,6 +121,7 @@ func (s *StaleCombatEconomySuite) killAdjacentSkeleton(id string) {
 	for i := 0; i < runaway && s.storedHP(id) > 0; i++ {
 		_, err := s.mgr.Attack(context.Background(), &session.AttackInput{
 			Session: "sess", Attacker: "alice", Target: id,
+			DeclarationID: currentAttackID(s.T(), s.mgr, "sess", "alice"),
 		})
 		s.Require().NoError(err)
 	}

--- a/rulebooks/dnd5e/session/turn.go
+++ b/rulebooks/dnd5e/session/turn.go
@@ -280,7 +280,7 @@ func (m *Manager) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnOutput
 	if string(clock.Active) != in.Member {
 		return nil, fmt.Errorf("endturn: %w", ErrNotYourTurn)
 	}
-	current, err := m.buildEndTurnOffer(in.Session, in.Member)
+	current, err := m.buildEndTurnOffer(scope.session, in.Member)
 	if err != nil {
 		return nil, fmt.Errorf("endturn: %w", err)
 	}

--- a/rulebooks/dnd5e/session/turn.go
+++ b/rulebooks/dnd5e/session/turn.go
@@ -210,6 +210,10 @@ type EndTurnInput struct {
 
 	// Member is whose turn is ending. Required — and it must be THEIR turn.
 	Member string
+
+	// DeclarationID is the opaque current EndTurn selector returned by Afford.
+	// Required. The client echoes it and never parses it.
+	DeclarationID string
 }
 
 // EndTurnOutput reports what ending the turn produced.
@@ -242,9 +246,10 @@ type EndTurnOutput struct {
 // top-level question again wearing a verb's clothes: it could only mean
 // anything if one clock were privileged.
 //
-// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoSession,
-// ErrNoEncounter, ErrNoMember, ErrNotInFight, ErrNotYourTurn, ErrClosed, or
-// ErrSaveFailed with a populated report. Ending a turn that is not yours is
+// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoDeclarationID,
+// ErrNoSession, ErrNoEncounter, ErrNoMember, ErrNotInFight, ErrNotYourTurn,
+// ErrStaleDeclaration, ErrClosed, or ErrSaveFailed with a populated report.
+// Ending a turn that is not yours is
 // refused by the clock itself and translated to ErrNotYourTurn — the same
 // sentinel Move's own turn gate produces (rpg-toolkit#1169) — rather than
 // left unnamed; see translate.
@@ -258,6 +263,28 @@ func (m *Manager) EndTurn(ctx context.Context, in *EndTurnInput) (*EndTurnOutput
 
 	scope, err := m.openForWrite(ctx, in.Session)
 	if err != nil {
+		return nil, fmt.Errorf("endturn: %w", err)
+	}
+
+	// EndTurn's real gate is the clock alone. Keep it ahead of selection so a
+	// world-clock member and a member whose turn it is not retain the specific
+	// refusals this verb has always promised; unlike Attack and Move, no sheet,
+	// standing capability, or economy is consulted to compile this selector.
+	clock, err := scope.enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(in.Member)})
+	if err != nil {
+		return nil, fmt.Errorf("endturn: %w", translate(err))
+	}
+	if ClockKind(clock.Kind) != ClockTurn {
+		return nil, fmt.Errorf("endturn: %w", ErrNotInFight)
+	}
+	if string(clock.Active) != in.Member {
+		return nil, fmt.Errorf("endturn: %w", ErrNotYourTurn)
+	}
+	current, err := m.buildEndTurnOffer(in.Session, in.Member)
+	if err != nil {
+		return nil, fmt.Errorf("endturn: %w", err)
+	}
+	if _, err := selectCompiledOffer([]compiledOffer{current}, VerbEndTurn, in.DeclarationID); err != nil {
 		return nil, fmt.Errorf("endturn: %w", err)
 	}
 

--- a/rulebooks/dnd5e/session/turn_test.go
+++ b/rulebooks/dnd5e/session/turn_test.go
@@ -241,7 +241,9 @@ func (s *TurnTestSuite) TestEndingSomebodyElsesTurnIsRefused() {
 	_, err := s.mgr.EndTurn(context.Background(), &session.EndTurnInput{
 		Session: "sess", Member: "ogre",
 	})
-	s.Require().Error(err, "it is alice's turn, so the ogre cannot end one")
+	s.Require().ErrorIs(err, session.ErrNotYourTurn,
+		"the clock refusal must precede the missing-selector gate")
+	s.NotErrorIs(err, session.ErrNoDeclarationID)
 }
 
 // TestTheTurnEndingReachesClients pins the beat's event kind.

--- a/rulebooks/dnd5e/session/turn_test.go
+++ b/rulebooks/dnd5e/session/turn_test.go
@@ -111,6 +111,33 @@ func (s *TurnTestSuite) TestStatusNeverLearnsWhoseTurnItIs() {
 			"of a member")
 }
 
+// TestEndTurnRequiresItsCurrentSelector pins EndTurn's entire execution gate.
+// Its selector is compiled from the clock alone: omission is invalid input,
+// while the current echoed selector commits the turn normally.
+func (s *TurnTestSuite) TestEndTurnRequiresItsCurrentSelector() {
+	s.fight()
+	ctx := context.Background()
+
+	out, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	s.ErrorIs(err, session.ErrNoDeclarationID)
+	s.Nil(out)
+
+	out, err = s.mgr.EndTurn(ctx, &session.EndTurnInput{
+		Session: "sess", Member: "alice", DeclarationID: "v1.stale",
+	})
+	s.ErrorIs(err, session.ErrStaleDeclaration)
+	s.Nil(out)
+
+	afford, err := s.mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "alice"})
+	s.Require().NoError(err)
+	decl := requireSingleDeclaration(s.T(), afford.Declarations, session.VerbEndTurn)
+	out, err = s.mgr.EndTurn(ctx, &session.EndTurnInput{
+		Session: "sess", Member: "alice", DeclarationID: decl.ID,
+	})
+	s.Require().NoError(err)
+	s.Equal("alice", out.Next)
+}
+
 // TestEndingATurnHandsItOn is rpg-toolkit#1162's headline case at the seam:
 // alice ends her turn, the ogre has no player, and this single call must not
 // return with the clock parked on it. covers the write verb, including that
@@ -119,7 +146,10 @@ func (s *TurnTestSuite) TestEndingATurnHandsItOn() {
 	s.fight()
 	ctx := context.Background()
 
-	out, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	out, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{
+		Session: "sess", Member: "alice",
+		DeclarationID: currentEndTurnID(s.T(), s.mgr, "sess", "alice"),
+	})
 	s.Require().NoError(err)
 	s.Equal("alice", out.Next,
 		"the ogre has no player; TurnDriver passes its turn and the round wraps straight back to her")
@@ -178,7 +208,10 @@ func (s *TurnTestSuite) TestTheRoundComesRound() {
 	s.Require().NoError(err)
 	s.Equal(1, before.Round, "control: the fight opens in round 1")
 
-	last, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "alice"})
+	last, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{
+		Session: "sess", Member: "alice",
+		DeclarationID: currentEndTurnID(s.T(), s.mgr, "sess", "alice"),
+	})
 	s.Require().NoError(err)
 	s.True(last.RoundWrapped)
 
@@ -254,7 +287,10 @@ func (s *TurnTestSuite) TestAPointerPassDrivesThroughTheSameAsAValue() {
 	})
 	s.Require().NoError(err)
 
-	out, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "ptr", Member: "alice"})
+	out, err := mgr.EndTurn(ctx, &session.EndTurnInput{
+		Session: "ptr", Member: "alice",
+		DeclarationID: currentEndTurnID(s.T(), mgr, "ptr", "alice"),
+	})
 	s.Require().NoError(err, "&Pass{} must drive the ogre through exactly like Pass{} does")
 	s.Equal("alice", out.Next)
 	s.True(out.RoundWrapped)
@@ -272,6 +308,7 @@ func (s *TurnTestSuite) TestTheTurnEndingReachesClients() {
 
 	_, err = mgr.EndTurn(context.Background(), &session.EndTurnInput{
 		Session: "sess", Member: "alice",
+		DeclarationID: currentEndTurnID(s.T(), mgr, "sess", "alice"),
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/session/two_players_test.go
+++ b/rulebooks/dnd5e/session/two_players_test.go
@@ -202,7 +202,7 @@ func (s *TwoPlayersTestSuite) TestTwoPlayersOneSession() {
 	// Round 1, barbarian: passes her own turn (a player's turn needs no
 	// declared action before EndTurn — the same convention every prior
 	// suite's own driven-turn gates use).
-	out1, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "barbarian"})
+	out1, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "barbarian", DeclarationID: currentEndTurnID(s.T(), s.mgr, "sess", "barbarian")})
 	s.Require().NoError(err)
 	s.Equal("fighter", out1.Next)
 	s.False(out1.RoundWrapped)
@@ -213,7 +213,7 @@ func (s *TwoPlayersTestSuite) TestTwoPlayersOneSession() {
 	// back to barbarian, exactly as TestSkeletonAttacksFromRange's own
 	// single-player shape does with a second real player added.
 	beforeRound1Drive := len(s.stream.published)
-	out2, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter"})
+	out2, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter", DeclarationID: currentEndTurnID(s.T(), s.mgr, "sess", "fighter")})
 	s.Require().NoError(err)
 	s.Equal("barbarian", out2.Next)
 	s.True(out2.RoundWrapped, "skel-1 was last in the order — its own end wraps the round")
@@ -223,7 +223,7 @@ func (s *TwoPlayersTestSuite) TestTwoPlayersOneSession() {
 	s.Require().Len(fighterRound1, 3, "turn-ended(fighter), struck(skel-1), turn-ended(skel-1) — the shortbow needs no approach")
 
 	// Round 2, barbarian: same shape as round 1's own opening.
-	out3, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "barbarian"})
+	out3, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "barbarian", DeclarationID: currentEndTurnID(s.T(), s.mgr, "sess", "barbarian")})
 	s.Require().NoError(err)
 	s.Equal("fighter", out3.Next)
 	s.False(out3.RoundWrapped)
@@ -231,7 +231,7 @@ func (s *TwoPlayersTestSuite) TestTwoPlayersOneSession() {
 	// Round 2, fighter: skel-1 remains inside shortbow range, so this
 	// round's driven turn is again a bare strike with no move beat.
 	beforeRound2Drive := len(s.stream.published)
-	out4, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter"})
+	out4, err := s.mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter", DeclarationID: currentEndTurnID(s.T(), s.mgr, "sess", "fighter")})
 	s.Require().NoError(err)
 	s.Equal("barbarian", out4.Next)
 	s.True(out4.RoundWrapped)
@@ -355,14 +355,14 @@ func TestDrivenKillingBlowDissolvesCleanlyWithTwoPlayers(t *testing.T) {
 		"same tie-break as TestTwoPlayersOneSession's own — barbarian sorts first")
 
 	// Round 1: barbarian passes her own turn.
-	out1, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "barbarian"})
+	out1, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "barbarian", DeclarationID: currentEndTurnID(t, mgr, "sess", "barbarian")})
 	require.NoError(t, err)
 	require.Equal(t, "fighter", out1.Next)
 
 	// Round 1: fighter's own end drives skel-1's WHOLE turn — the fix under
 	// test is that this is exactly ONE attack, not two.
 	stream.published = nil
-	out2, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter"})
+	out2, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter", DeclarationID: currentEndTurnID(t, mgr, "sess", "fighter")})
 	require.NoError(t, err)
 	require.Equal(t, "fighter", out2.Next, "a two-member order (barbarian spliced) wraps skel-1's own end back to fighter")
 	require.True(t, out2.RoundWrapped)
@@ -408,7 +408,7 @@ func TestDrivenKillingBlowDissolvesCleanlyWithTwoPlayers(t *testing.T) {
 	// deciding the fight mid-drive: rpg-toolkit#1202's own case, now with
 	// two players in it.
 	stream.published = nil
-	out3, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter"})
+	out3, err := mgr.EndTurn(ctx, &session.EndTurnInput{Session: "sess", Member: "fighter", DeclarationID: currentEndTurnID(t, mgr, "sess", "fighter")})
 	require.NoError(t, err, "a driven turn that wins the fight must not abort the caller's own EndTurn")
 	require.Equal(t, "fighter", out3.Next,
 		"there is no bubble left to name a turn IN; EndTurnOutput.Next reports the caller instead (rpg-toolkit#1202)")

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -1077,10 +1077,11 @@ const (
 	// Attack, Move and EndTurn refuse as ErrNotYourTurn.
 	ShortfallNotYourTurn ShortfallReason = "not_your_turn"
 
-	// ShortfallNoTargetInReach is nothing to swing at within reach — what
-	// Attack refuses as ErrOutOfReach (rpg-toolkit#1010). The one shortfall
-	// that arrives on a declaration with no Target: when no candidate is
-	// in reach, Afford still says so, once, rather than saying nothing.
+	// ShortfallNoTargetInReach is nothing to swing at within reach. Echoing
+	// that unavailable offer is ErrStaleDeclaration; ErrOutOfReach remains the
+	// final defensive resolution validation (rpg-toolkit#1010). This is the one
+	// shortfall that arrives on a declaration with no Target: when no candidate
+	// is in reach, Afford still says so, once, rather than saying nothing.
 	ShortfallNoTargetInReach ShortfallReason = "no_target_in_reach"
 
 	// ShortfallDowned is the member being downed and unable to act — what

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -1092,6 +1092,13 @@ const (
 	// rpg-toolkit#1168). Afford reports it rather than failing the read,
 	// so the rest of the declarations still arrive.
 	ShortfallUnreadable ShortfallReason = "unreadable"
+
+	// ShortfallTargetOutOfReach is the named target failing the attack's
+	// reach gate — a CANDIDATE-level reason, never the declaration's. Each
+	// out-of-reach candidate row carries it while the declaration-level
+	// answer remains ShortfallNoTargetInReach when no candidate is in reach
+	// at all (rpg-toolkit#1010, rpg-project#249 §6).
+	ShortfallTargetOutOfReach ShortfallReason = "target_out_of_reach"
 )
 
 // Currency names which of a turn's budgets a NO_BUDGET shortfall ran out
@@ -1147,6 +1154,62 @@ type Shortfall struct {
 	// target in reach". The same text Declaration.Shortfall carries and the
 	// same text the verb's own refusal error would.
 	Text string `json:"text"`
+}
+
+// TargetKind tells a client which selector shape a Declaration accepts. A
+// closed set owned at the seam, mirroring the merged proto's TargetKind: the
+// three currently executable verbs fix their kind, and a new kind arrives the
+// day a proven executor for it lands — never in advance.
+//
+// FIXED FOR EVERY COMPILED OR BLOCKED DECLARATION: Attack -> TargetMember,
+// Move -> TargetPath, EndTurn -> TargetNone. A blocker keeps the fixed kind
+// even with empty candidates, so a client always knows which selector shape
+// the verb carries.
+type TargetKind string
+
+const (
+	// TargetNone is EndTurn's selector shape: no target. EndTurn is governed
+	// solely by its clock/turn gate and carries no candidate.
+	TargetNone TargetKind = "none"
+
+	// TargetMember is Attack's selector shape: one member from the compiled
+	// candidate universe. Every live CurrentVia-nonempty holding except the
+	// actor appears exactly once in the declaration's Candidates.
+	TargetMember TargetKind = "member"
+
+	// TargetPath is Move's selector shape: a walk along a path on the turn
+	// clock. Move declarations carry no candidates; the path is chosen at
+	// execution time and priced whole.
+	TargetPath TargetKind = "path"
+)
+
+// TargetCandidate is one member in a compiled Attack's complete candidate
+// universe: every current live-sight holding (CurrentVia non-empty) except the
+// actor appears exactly once, sorted by member ID. Stale memories, undisclosed
+// members, and the actor are excluded. A live holding whose position is
+// missing fails Afford rather than being silently omitted.
+//
+// The candidate's availability is the TARGET-SPECIFIC gate, independent of
+// the declaration's turn/economy gate: a declaration may be unavailable while
+// an in-reach candidate remains available, and an out-of-reach candidate
+// carries ShortfallTargetOutOfReach on itself while the declaration-level
+// reason stays ShortfallNoTargetInReach when no candidate is in reach at all.
+type TargetCandidate struct {
+	// Member is the candidate member ID, as it appears in the encounter
+	// roster and the observer's holdings.
+	Member string `json:"member"`
+
+	// Available is whether this candidate passes the attack's reach gate.
+	// PLAIN bool, not optional: false is an answer (out of reach), not an
+	// absence — the same false-vs-absent law every other bool at this seam
+	// keeps.
+	Available bool `json:"available"`
+
+	// Why is present if and only if Available is false. Carries a
+	// candidate-level reason (ShortfallTargetOutOfReach today); global
+	// turn/economy reasons are never copied here — they live on the
+	// declaration's Why.
+	Why *Shortfall `json:"why,omitempty"`
 }
 
 // Discovery is what changed in one observer's perception.

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -1037,13 +1037,13 @@ const (
 )
 
 // AttackRef identifies WHAT was swung — weapon identity, which this seam
-// dropped on the floor since the first swing (rpg-toolkit#866). Carried on
-// AttackOutput and on the Struck/Missed event bodies, so a beat line can say
-// "6 slashing" and "with a longsword" for every witness, not only the
-// attacker whose own verb response held the compiled profile.
+// dropped on the floor since the first swing (rpg-toolkit#866). Carried on a
+// compiled Declaration, AttackOutput, and the Struck/Missed event bodies, so
+// selection and outcome name the same authored attack for every witness.
 type AttackRef struct {
-	// Ref is the catalog ref the attack compiled from — "longsword",
-	// "unarmed-strike". An OPEN set, so a string: the client already maps
+	// Ref is the full catalog ref the attack compiled from —
+	// "dnd5e:weapons:longsword", "dnd5e:weapons:unarmed-strike". An OPEN set,
+	// so a string: the client already maps
 	// refs to models and icons, and the catalog grows without this type
 	// changing.
 	Ref string `json:"ref"`
@@ -1067,9 +1067,10 @@ type AttackRef struct {
 type ShortfallReason string
 
 const (
-	// ShortfallNoBudget is the currency running out — what Attack refuses
-	// as ErrCannotAfford ("action: 1 needed, 0 left"). Currency, Needed and
-	// Left are populated.
+	// ShortfallNoBudget is the currency running out. Attack exposes it before
+	// execution; echoing that unavailable offer is ErrStaleDeclaration. Move's
+	// path-specific overrun is ErrCannotAfford. Currency, Needed and Left are
+	// populated.
 	ShortfallNoBudget ShortfallReason = "no_budget"
 
 	// ShortfallNotYourTurn is it not being this member's turn — what
@@ -1151,7 +1152,7 @@ type Shortfall struct {
 
 	// Text is the refusal in the SDK's own words — "action: 1 needed, 0
 	// left", "movement: 20 ft needed, 15 ft left", "not your turn", "no
-	// target in reach". The same text Declaration.Shortfall carries and the
+	// target in reach". The same text Declaration.Why carries and the
 	// same text the verb's own refusal error would.
 	Text string `json:"text"`
 }


### PR DESCRIPTION
## Summary

Closes #1246.

Implements the toolkit provider half of the approved [session combat experience design](https://github.com/KirkDiggler/rpg-project/issues/270) against merged proto artifact **v0.1.142** (generated commit **9d75694**):

- `rulebooks/dnd5e`: canonical `ConditionBehavior.Ref`, immutable owner-private character status, and non-magical feature/resource descriptors;
- `rulebooks/dnd5e/session`: RFC 8785 selectors, compiled Attack/Move/EndTurn offers, nested target preflight, full-ref `AttackRef`, and echoed-selector execution gates;
- Attack selector identity includes the cloned actual `SpendProfile`, and execution reuses the selected definition, matching cost/readied sheet, and shared target preflight;
- missing IDs return `ErrNoDeclarationID`; unknown, mismatched, unavailable, or target-invalid selections return `ErrStaleDeclaration` before dice, movement, writes, or story;
- turn Move requires a current selector, world Move requires empty, and EndTurn remains clock-only under the per-verb blocker matrix.

## Boundary

This wave has **no magic system**. It does not add spells, spell slots, concentration, magical resources/items, magical targeting, or speculative future action executors. The only executable declarations are Attack, turn-clock Move, and EndTurn. No inner runtime or compiled-offer type crosses the session host seam.

## Verification

Rebased cleanly onto `origin/main` at `9ac727b` before Task 7 and reran both baselines.

```text
cd rulebooks/dnd5e/session && go test ./... -count=1
PASS

cd rulebooks/dnd5e/session && golangci-lint run ./...
0 issues

./scripts/verify.sh rulebooks/dnd5e/session
PASS: build, 454 tests, vet, gofmt, lint, verified transcripts

cd rulebooks/dnd5e && go test ./... -count=1
PASS

cd rulebooks/dnd5e && golangci-lint run ./...
0 issues

git diff --check
PASS

git grep '^replace ' -- '*/go.mod'
PASS: no matches

find . -name go.work -o -name go.work.sum
PASS: no residue
```

TDD selector gate:

```text
cd rulebooks/dnd5e/session && go test ./... -run 'Declaration|Selector|Stale|Preflight' -count=1
RED: inputs/sentinels absent
GREEN: PASS
```

Design: rpg-project#270 / PR #271  
Proto: v0.1.142 / generated 9d75694

— platform agent, on behalf of KirkDiggler