### PR TITLE
feat(conditions): Sneak Attack and Pack Tactics ask who people are to each other

### DIFF
--- a/rulebooks/dnd5e/combat/capacity.go
+++ b/rulebooks/dnd5e/combat/capacity.go
@@ -78,16 +78,22 @@ func IsCapacity(key CapacityType) bool {
 // AdjacentCells is "within 5 feet" expressed in the units a grid answers in:
 // one cell.
 //
-// Every grid in tools/spatial reports distance in cells — Chebyshev on a square
-// grid (SquareGrid.Distance is max(|dx|,|dy|), so a diagonal neighbour is 1),
-// hex distance on a hex grid, Euclidean cell-widths when gridless — and a cell
-// is 5 feet. Comparing against 1 is therefore the correct reading of the rule
-// rather than an approximation of it.
+// Every grid in tools/spatial reports distance in cells and a cell is 5 feet.
+// The product runs on hex — encounter/compilefield.go compiles an AxialHexGrid
+// and nothing else — where distance is the cube formula and comes back
+// integral. Square (Chebyshev: max(|dx|,|dy|), so a diagonal neighbour is 1)
+// and gridless (Euclidean) remain supported by tools/spatial but nothing in
+// the game builds them.
+//
+// So comparing against 1 is the correct reading of the rule rather than an
+// approximation of it.
 //
 // It lives here because three rules had independently written it down and one
 // of them had it wrong: prone said 1.0, while sneak attack said 1.5 "to include
-// diagonals" — a correction the square grid does not need and which reads as
-// 7.5 feet on a gridless room. Two copies that agree are a coincidence waiting
-// to end; this is the constant they should all have been reading
+// diagonals" — a correction no integral-distance grid needs. On hex and square
+// the two are indistinguishable, since no distance falls between 1 and 1.5,
+// which is why it survived. On a gridless room 1.5 cells is 7.5 feet and it
+// was a live over-inclusion. Two copies that agree are a coincidence waiting to
+// end; this is the constant they should all have been reading
 // (rpg-toolkit#1255 review).
 const AdjacentCells = 1.0

--- a/rulebooks/dnd5e/combat/capacity.go
+++ b/rulebooks/dnd5e/combat/capacity.go
@@ -74,3 +74,20 @@ func IsCapacity(key CapacityType) bool {
 	_, ok := capacities[key]
 	return ok
 }
+
+// AdjacentCells is "within 5 feet" expressed in the units a grid answers in:
+// one cell.
+//
+// Every grid in tools/spatial reports distance in cells — Chebyshev on a square
+// grid (SquareGrid.Distance is max(|dx|,|dy|), so a diagonal neighbour is 1),
+// hex distance on a hex grid, Euclidean cell-widths when gridless — and a cell
+// is 5 feet. Comparing against 1 is therefore the correct reading of the rule
+// rather than an approximation of it.
+//
+// It lives here because three rules had independently written it down and one
+// of them had it wrong: prone said 1.0, while sneak attack said 1.5 "to include
+// diagonals" — a correction the square grid does not need and which reads as
+// 7.5 feet on a gridless room. Two copies that agree are a coincidence waiting
+// to end; this is the constant they should all have been reading
+// (rpg-toolkit#1255 review).
+const AdjacentCells = 1.0

--- a/rulebooks/dnd5e/conditions/fake_cast_test.go
+++ b/rulebooks/dnd5e/conditions/fake_cast_test.go
@@ -1,0 +1,50 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions
+
+import (
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// fakeCast answers gamectx.Cast from a plain member -> side map.
+//
+// Sides rather than a party/monster flag on purpose: the rules being tested
+// here are the ones that were wrong precisely because they assumed two sides,
+// and a fake that can only express two would keep them looking right. Give a
+// member its own side and it is everyone's enemy; that is the three-faction
+// dungeon these predicates have to survive.
+type fakeCast struct {
+	side map[string]string
+}
+
+func (f *fakeCast) Member(string) (combat.Combatant, bool) { return nil, false }
+
+func (f *fakeCast) Members() []string {
+	ids := make([]string, 0, len(f.side))
+	for id := range f.side {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (f *fakeCast) IsHostile(a, b string) (hostile, known bool) {
+	sa, oka := f.side[a]
+	sb, okb := f.side[b]
+	if !oka || !okb {
+		return false, false
+	}
+	return sa != sb, true
+}
+
+func (f *fakeCast) IsAllied(a, b string) (allied, known bool) {
+	sa, oka := f.side[a]
+	sb, okb := f.side[b]
+	if !oka || !okb {
+		return false, false
+	}
+	return sa == sb, true
+}

--- a/rulebooks/dnd5e/conditions/prone.go
+++ b/rulebooks/dnd5e/conditions/prone.go
@@ -21,13 +21,12 @@ import (
 
 // proneReachCells is "within 5 feet" in the units a grid answers in: one cell.
 //
-// Every grid in tools/spatial reports distance in cells — Chebyshev on a square
-// grid, hex distance on a hex grid, Euclidean cell-widths when gridless — and a
-// cell is 5 feet. Comparing against 1 rather than 5 is therefore the correct
-// reading of the rule, not an approximation of it; the same conversion is
-// spelled out in FightingStyleProtectionCondition ("adjacent on grid = distance
-// 1") and in SneakAttackCondition ("1 square = 5ft").
-const proneReachCells = 1.0
+// This comment used to explain the conversion here, and note that
+// FightingStyleProtectionCondition and SneakAttackCondition spelled out the
+// same one. They did — and sneak attack's copy nonetheless used 1.5. The
+// rationale now lives once, on [combat.AdjacentCells], and this is an alias so
+// the two cannot drift apart again (rpg-toolkit#1255 review).
+const proneReachCells = combat.AdjacentCells
 
 // ProneConditionData is the serializable form of the prone condition.
 // This is stored by the game server as an opaque JSON blob.

--- a/rulebooks/dnd5e/conditions/sneak_attack.go
+++ b/rulebooks/dnd5e/conditions/sneak_attack.go
@@ -193,12 +193,8 @@ func (s *SneakAttackCondition) onDamageChain(
 		return c, nil
 	}
 
-	// Check sneak attack conditions: advantage OR ally within 5ft of target
-	meetsConditions, err := s.checkSneakAttackConditions(ctx, event)
-	if err != nil {
-		return c, err
-	}
-	if !meetsConditions {
+	// Advantage, OR another enemy of the target adjacent to it.
+	if !s.sneakAttackApplies(ctx, event) {
 		return c, nil
 	}
 
@@ -244,7 +240,7 @@ func (s *SneakAttackCondition) onDamageChain(
 	s.UsedThisTurn = true
 	s.markDirty()
 
-	err = c.Add(combat.StageFeatures, "sneak_attack", modifyDamage)
+	err := c.Add(combat.StageFeatures, "sneak_attack", modifyDamage)
 	if err != nil {
 		return c, rpgerr.Wrap(err, "failed to add sneak attack modifier")
 	}
@@ -252,57 +248,62 @@ func (s *SneakAttackCondition) onDamageChain(
 	return c, nil
 }
 
-// checkSneakAttackConditions checks if sneak attack conditions are met.
-// Returns true if:
-// - Attacker has advantage on the attack roll, OR
-// - An ally (another "character" type entity) is within 5ft of the target
-// Returns an error if room context is required but not available.
-func (s *SneakAttackCondition) checkSneakAttackConditions(
+// sneakAttackReachCells is 5 feet in grid cells, widened to 1.5 so the four
+// diagonals count as adjacent.
+const sneakAttackReachCells = 1.5
+
+// sneakAttackApplies reports whether sneak attack's positional requirement is
+// met: the attacker has advantage, or another enemy OF THE TARGET is within
+// five feet of it.
+//
+// Note whose enemy. RAW is "another enemy of the target is within 5 feet of
+// it" — the relation is measured from the TARGET's point of view, not the
+// attacker's. With two factions those coincide and nobody notices. With three
+// they come apart: a hobgoblin standing beside the duergar you are stabbing is
+// an enemy of your target and enables this, and it is nobody's ally.
+//
+// This used to ask whether the adjacent entity's type was "character", which
+// baked a two-sided world into the rule and got it wrong in both directions —
+// a fellow player counted even when fighting you, and a rival monster never
+// counted at all.
+//
+// Returns a plain bool. A question this cannot answer is not an error: the
+// caller folds this into the damage chain, and an errored fold discards every
+// other damage component along with this one, exactly as an errored AC fold
+// discarded every other AC contributor (rpg-toolkit#1254).
+func (s *SneakAttackCondition) sneakAttackApplies(
 	ctx context.Context,
 	event *dnd5eEvents.DamageChainEvent,
-) (bool, error) {
-	// Condition 1: Has advantage
+) bool {
 	if event.HasAdvantage {
-		return true, nil
+		return true
 	}
 
-	// Condition 2: Ally within 5ft of target
-	// Need Room context to check positions
-	room, err := gamectx.RequireRoom(ctx)
-	if err != nil {
-		return false, err
+	room, ok := gamectx.Room(ctx)
+	if !ok {
+		return false
+	}
+	cast, ok := gamectx.CastOf(ctx)
+	if !ok {
+		return false
 	}
 
-	// Get target position
 	targetPos, found := room.GetEntityPosition(event.TargetID)
 	if !found {
-		return false, nil
+		return false
 	}
 
-	// Query entities within 5ft (1 square = 5ft, use radius 1.5 to include diagonals)
-	entitiesNearTarget := room.GetEntitiesInRange(targetPos, 1.5)
-
-	// Check if any "character" type entity (ally) is near the target
-	for _, entity := range entitiesNearTarget {
-		entityID := entity.GetID()
-
-		// Skip the target itself
-		if entityID == event.TargetID {
+	for _, entity := range room.GetEntitiesInRange(targetPos, sneakAttackReachCells) {
+		id := entity.GetID()
+		if id == event.TargetID || id == event.AttackerID {
 			continue
 		}
-
-		// Skip the attacker (they might be adjacent but don't count as "ally")
-		if entityID == event.AttackerID {
-			continue
-		}
-
-		// Allies are "character" type entities (players/NPCs, not monsters)
-		if entity.GetType() == "character" {
-			return true, nil
+		if hostile, known := cast.IsHostile(event.TargetID, id); known && hostile {
+			return true
 		}
 	}
 
-	return false, nil
+	return false
 }
 
 // ToJSON converts the condition to JSON for persistence

--- a/rulebooks/dnd5e/conditions/sneak_attack.go
+++ b/rulebooks/dnd5e/conditions/sneak_attack.go
@@ -248,10 +248,6 @@ func (s *SneakAttackCondition) onDamageChain(
 	return c, nil
 }
 
-// sneakAttackReachCells is 5 feet in grid cells, widened to 1.5 so the four
-// diagonals count as adjacent.
-const sneakAttackReachCells = 1.5
-
 // sneakAttackApplies reports whether sneak attack's positional requirement is
 // met: the attacker has advantage, or another enemy OF THE TARGET is within
 // five feet of it.
@@ -293,7 +289,7 @@ func (s *SneakAttackCondition) sneakAttackApplies(
 		return false
 	}
 
-	for _, entity := range room.GetEntitiesInRange(targetPos, sneakAttackReachCells) {
+	for _, entity := range room.GetEntitiesInRange(targetPos, combat.AdjacentCells) {
 		id := entity.GetID()
 		if id == event.TargetID || id == event.AttackerID {
 			continue

--- a/rulebooks/dnd5e/conditions/sneak_attack_test.go
+++ b/rulebooks/dnd5e/conditions/sneak_attack_test.go
@@ -47,11 +47,11 @@ func (s *SneakAttackTestSuite) SetupTest() {
 	s.bus = events.NewEventBus()
 	s.roller = mock_dice.NewMockRoller(s.ctrl)
 
-	// Set up room for spatial tests
-	grid := spatial.NewSquareGrid(spatial.SquareGridConfig{
-		Width:  20,
-		Height: 20,
-	})
+	// The grid the game actually compiles. encounter/compilefield.go builds an
+	// AxialHexGrid and nothing else; square and gridless remain supported by
+	// tools/spatial but nothing in the product uses them. A positional rule
+	// proven only on a square grid is proven on a configuration we do not ship.
+	grid := spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 1e6, SpanHeight: 1e6})
 	s.room = spatial.NewBasicRoom(spatial.BasicRoomConfig{
 		ID:   "test-room",
 		Type: "dungeon",

--- a/rulebooks/dnd5e/conditions/sneak_attack_test.go
+++ b/rulebooks/dnd5e/conditions/sneak_attack_test.go
@@ -473,13 +473,18 @@ func (s *SneakAttackTestSuite) TestSneakAttackTriggersWithAllyAdjacent() {
 	err = s.room.PlaceEntity(goblin, spatial.Position{X: 5, Y: 5})
 	s.Require().NoError(err)
 
-	// Fighter (ally) at (5, 6) - adjacent to goblin, character type = ally
+	// Fighter at (5, 6) - adjacent to the goblin. What qualifies it is not
+	// that it is a "character": it is that it is an enemy OF THE TARGET.
 	fighter := &mockEntity{id: "fighter-1", entityType: "character"}
 	err = s.room.PlaceEntity(fighter, spatial.Position{X: 5, Y: 6})
 	s.Require().NoError(err)
 
-	// Create context with room
 	ctx := gamectx.WithRoom(s.ctx, s.room)
+	ctx = gamectx.WithCast(ctx, &fakeCast{side: map[string]string{
+		"rogue-1":   "party",
+		"fighter-1": "party",
+		"goblin-1":  "goblins",
+	}})
 
 	sneak := NewSneakAttackCondition(SneakAttackInput{
 		CharacterID: "rogue-1",
@@ -525,6 +530,111 @@ func (s *SneakAttackTestSuite) TestSneakAttackTriggersWithAllyAdjacent() {
 
 	// Should have sneak attack due to ally adjacent
 	s.Require().Len(finalEvent.Components, 2, "Should have sneak attack with ally adjacent")
+}
+
+// TestSneakAttackDoesNotTriggerWhenAdjacentCreatureIsTheTargetsAlly pins the
+// half of the rule the old entity-type proxy could not express at all.
+//
+// RAW is "another ENEMY OF THE TARGET is within 5 feet of it". A second goblin
+// standing beside the first is the target's ally, and grants the rogue nothing.
+// The old code asked whether the adjacent entity's type was "character", so it
+// answered this correctly by luck rather than by rule — and answered the
+// three-faction case below incorrectly for the same reason.
+func (s *SneakAttackTestSuite) TestSneakAttackDoesNotTriggerWhenAdjacentCreatureIsTheTargetsAlly() {
+	rogue := &mockEntity{id: "rogue-1", entityType: "character"}
+	err := s.room.PlaceEntity(rogue, spatial.Position{X: 1, Y: 1})
+	s.Require().NoError(err)
+
+	goblin := &mockEntity{id: "goblin-1", entityType: "monster"}
+	err = s.room.PlaceEntity(goblin, spatial.Position{X: 5, Y: 5})
+	s.Require().NoError(err)
+
+	// Another goblin, adjacent to the target and on the target's own side.
+	goblinFriend := &mockEntity{id: "goblin-2", entityType: "monster"}
+	err = s.room.PlaceEntity(goblinFriend, spatial.Position{X: 5, Y: 6})
+	s.Require().NoError(err)
+
+	ctx := gamectx.WithRoom(s.ctx, s.room)
+	ctx = gamectx.WithCast(ctx, &fakeCast{side: map[string]string{
+		"rogue-1":  "party",
+		"goblin-1": "goblins",
+		"goblin-2": "goblins",
+	}})
+
+	sneak := NewSneakAttackCondition(SneakAttackInput{CharacterID: "rogue-1", Level: 1, Roller: s.roller})
+	s.Require().NoError(sneak.Apply(ctx, s.bus))
+
+	finalEvent := s.runDamageChain(ctx, "rogue-1", "goblin-1")
+	s.Require().Len(finalEvent.Components, 1, "the target's own ally must not enable sneak attack")
+}
+
+// TestSneakAttackTriggersWhenAThirdFactionIsAdjacentToTheTarget is the case the
+// old rule could not reach and the new one gets for free.
+//
+// The rogue stabs a duergar. A hobgoblin — hostile to the party AND hostile to
+// the duergar — is standing next to it. That hobgoblin is an enemy of the
+// target, so RAW the rogue sneak attacks. The old code asked "is it a
+// character?", the hobgoblin is not, and the rogue lost the bonus.
+//
+// This is the emergent bit of a dungeon with two monster factions in it: the
+// party benefits from their infighting without anybody scripting it.
+func (s *SneakAttackTestSuite) TestSneakAttackTriggersWhenAThirdFactionIsAdjacentToTheTarget() {
+	rogue := &mockEntity{id: "rogue-1", entityType: "character"}
+	err := s.room.PlaceEntity(rogue, spatial.Position{X: 1, Y: 1})
+	s.Require().NoError(err)
+
+	duergar := &mockEntity{id: "duergar-1", entityType: "monster"}
+	err = s.room.PlaceEntity(duergar, spatial.Position{X: 5, Y: 5})
+	s.Require().NoError(err)
+
+	hobgoblin := &mockEntity{id: "hobgoblin-1", entityType: "monster"}
+	err = s.room.PlaceEntity(hobgoblin, spatial.Position{X: 5, Y: 6})
+	s.Require().NoError(err)
+
+	ctx := gamectx.WithRoom(s.ctx, s.room)
+	ctx = gamectx.WithCast(ctx, &fakeCast{side: map[string]string{
+		"rogue-1":     "party",
+		"duergar-1":   "duergar",
+		"hobgoblin-1": "hobgoblins",
+	}})
+
+	sneak := NewSneakAttackCondition(SneakAttackInput{CharacterID: "rogue-1", Level: 1, Roller: s.roller})
+	s.Require().NoError(sneak.Apply(ctx, s.bus))
+
+	s.roller.EXPECT().RollN(gomock.Any(), 1, 6).Return([]int{5}, nil)
+
+	finalEvent := s.runDamageChain(ctx, "rogue-1", "duergar-1")
+	s.Require().Len(finalEvent.Components, 2,
+		"an enemy of the target enables sneak attack even when it is nobody's ally")
+}
+
+// runDamageChain folds one no-advantage DEX weapon hit and returns the result.
+func (s *SneakAttackTestSuite) runDamageChain(
+	ctx context.Context, attackerID, targetID string,
+) *dnd5eEvents.DamageChainEvent {
+	s.T().Helper()
+
+	damageEvent := &dnd5eEvents.DamageChainEvent{
+		AttackerID: attackerID,
+		TargetID:   targetID,
+		Components: []dnd5eEvents.DamageComponent{{
+			Source:            dnd5eEvents.DamageSourceWeapon,
+			Properties:        []damage.Property{damage.AddsAttackAbilityModifier},
+			OriginalDiceRolls: []int{5},
+			FinalDiceRolls:    []int{5},
+			DamageType:        damage.Piercing,
+		}},
+		HasAdvantage: false,
+		AbilityUsed:  abilities.DEX,
+	}
+
+	c := events.NewStagedChain[*dnd5eEvents.DamageChainEvent](combat.ModifierStages)
+	modifiedChain, err := dnd5eEvents.DamageChain.On(s.bus).PublishWithChain(ctx, damageEvent, c)
+	s.Require().NoError(err)
+
+	finalEvent, err := modifiedChain.Execute(ctx, damageEvent)
+	s.Require().NoError(err)
+	return finalEvent
 }
 
 func (s *SneakAttackTestSuite) TestSneakAttackDoesNotTriggerWithoutConditions() {

--- a/rulebooks/dnd5e/gamectx/cast.go
+++ b/rulebooks/dnd5e/gamectx/cast.go
@@ -74,6 +74,22 @@ type Cast interface {
 	//
 	// known is false when the question cannot be answered at all.
 	IsHostile(a, b string) (hostile, known bool)
+
+	// IsAllied answers whether b is on a's side, right now.
+	//
+	// NOT the negation of IsHostile, and the difference is the whole reason
+	// both exist. Once a third faction can be neutral toward you, "not my
+	// enemy" and "my ally" stop being the same set, and a rule that assumed
+	// they were would silently start counting bystanders. Sneak Attack asks
+	// the first question ("another enemy OF THE TARGET is within 5 feet of
+	// it"); Pack Tactics asks the second ("one of the attacker's ALLIES").
+	//
+	// Both are answered as "same MemberKind" today, so they are momentarily
+	// each other's complement. They are not the same question, and the rules
+	// must not be written as though they are.
+	//
+	// known is false when the question cannot be answered at all.
+	IsAllied(a, b string) (allied, known bool)
 }
 
 // castContextKey is the key type for storing a Cast in context.Context.

--- a/rulebooks/dnd5e/integration/fake_cast_test.go
+++ b/rulebooks/dnd5e/integration/fake_cast_test.go
@@ -1,0 +1,48 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package integration
+
+import (
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// fakeCast answers gamectx.Cast from a plain member -> side map, standing in
+// for the implementation resolution installs (rpg-toolkit#1252).
+//
+// Sides rather than a party/monster flag, because the rules under test here
+// are exactly the ones that used to decide allegiance from entity type.
+type fakeCast struct {
+	side map[string]string
+}
+
+func (f *fakeCast) Member(string) (combat.Combatant, bool) { return nil, false }
+
+func (f *fakeCast) Members() []string {
+	ids := make([]string, 0, len(f.side))
+	for id := range f.side {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (f *fakeCast) IsHostile(a, b string) (hostile, known bool) {
+	sa, oka := f.side[a]
+	sb, okb := f.side[b]
+	if !oka || !okb {
+		return false, false
+	}
+	return sa != sb, true
+}
+
+func (f *fakeCast) IsAllied(a, b string) (allied, known bool) {
+	sa, oka := f.side[a]
+	sb, okb := f.side[b]
+	if !oka || !okb {
+		return false, false
+	}
+	return sa == sb, true
+}

--- a/rulebooks/dnd5e/integration/rogue_encounter_test.go
+++ b/rulebooks/dnd5e/integration/rogue_encounter_test.go
@@ -134,6 +134,11 @@ func (s *RogueEncounterSuite) SetupSubTest() {
 
 	s.ctx = context.Background()
 	s.ctx = gamectx.WithRoom(s.ctx, s.room)
+	s.ctx = gamectx.WithCast(s.ctx, &fakeCast{side: map[string]string{
+		s.rogue.GetID():  "party",
+		s.ally.GetID():   "party",
+		s.goblin.GetID(): "goblins",
+	}})
 
 	_ = s.room.PlaceEntity(s.rogue, spatial.Position{X: 2, Y: 2})
 	_ = s.room.PlaceEntity(s.goblin, spatial.Position{X: 3, Y: 2})

--- a/rulebooks/dnd5e/integration/rogue_encounter_test.go
+++ b/rulebooks/dnd5e/integration/rogue_encounter_test.go
@@ -116,7 +116,11 @@ func (s *RogueEncounterSuite) SetupTest() {
 	s.lookup = newIntegrationLookup()
 	s.ctx = context.Background()
 
-	grid := spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 10, Height: 10})
+	// The grid the game actually compiles. encounter/compilefield.go builds an
+	// AxialHexGrid and nothing else; square and gridless remain supported by
+	// tools/spatial but nothing in the product uses them. A positional rule
+	// proven only on a square grid is proven on a configuration we do not ship.
+	grid := spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 1e6, SpanHeight: 1e6})
 	s.room = spatial.NewBasicRoom(spatial.BasicRoomConfig{ID: "combat-room", Type: "combat", Grid: grid})
 }
 

--- a/rulebooks/dnd5e/monstertraits/fake_cast_test.go
+++ b/rulebooks/dnd5e/monstertraits/fake_cast_test.go
@@ -1,0 +1,58 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monstertraits
+
+import (
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// fakeCast answers gamectx.Cast from a plain member -> side map.
+//
+// Sides rather than a monster/party flag: Pack Tactics belongs to a monster,
+// and the case it has to get right is a dungeon holding two monster factions
+// that hate each other as much as they hate the party. A fake that could only
+// express "monsters" and "characters" would hide exactly that.
+type fakeCast struct {
+	side map[string]string
+}
+
+func (f *fakeCast) Member(string) (combat.Combatant, bool) { return nil, false }
+
+func (f *fakeCast) Members() []string {
+	ids := make([]string, 0, len(f.side))
+	for id := range f.side {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (f *fakeCast) IsHostile(a, b string) (hostile, known bool) {
+	sa, oka := f.side[a]
+	sb, okb := f.side[b]
+	if !oka || !okb {
+		return false, false
+	}
+	return sa != sb, true
+}
+
+func (f *fakeCast) IsAllied(a, b string) (allied, known bool) {
+	sa, oka := f.side[a]
+	sb, okb := f.side[b]
+	if !oka || !okb {
+		return false, false
+	}
+	return sa == sb, true
+}
+
+// fakeEntity is a placeable body with an ID.
+type fakeEntity struct {
+	id string
+}
+
+func (f *fakeEntity) GetID() string            { return f.id }
+func (f *fakeEntity) GetType() core.EntityType { return "monster" }

--- a/rulebooks/dnd5e/monstertraits/pack_tactics.go
+++ b/rulebooks/dnd5e/monstertraits/pack_tactics.go
@@ -11,7 +11,9 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/core/chain"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
@@ -25,9 +27,11 @@ type PackTacticsData struct {
 // Pack Tactics grants advantage on attack rolls against a creature if at least
 // one of the attacker's allies is within 5 feet of the target and not incapacitated.
 //
-// Note: This is a simplified implementation. The full logic of determining if an ally
-// is adjacent to the target would be handled by the game server using spatial/perception
-// data. This trait simply provides the advantage bonus when applicable.
+// This was a stub until rpg-toolkit#1251. It could not be written before,
+// because a trait had no way to ask who anybody was to anybody else — the
+// registry that would have answered was never installed, and the only other
+// signal available was entity type, which cannot tell one monster faction from
+// another. gamectx.Cast answers it now.
 type packTacticsCondition struct {
 	ownerID string
 	bus     events.EventBus
@@ -110,43 +114,85 @@ func (p *packTacticsCondition) loadJSON(data json.RawMessage) error {
 	return nil
 }
 
-// onAttackChain grants advantage on attacks when ally is adjacent to target.
+// packTacticsReachCells is 5 feet in grid cells, widened to 1.5 so the four
+// diagonals count as adjacent.
+const packTacticsReachCells = 1.5
+
+// onAttackChain grants advantage when an ally of the attacker is within five
+// feet of the target.
 //
-// Note: This is a placeholder implementation. The full Pack Tactics logic requires:
-// 1. Access to spatial/perception data to know where allies are
-// 2. Checking if any ally (same faction, not incapacitated) is within 5 feet of target
+// Asks IsAllied rather than IsHostile. Those are momentarily each other's
+// complement — both answer "same MemberKind" today — but they are different
+// questions and the rule has to ask the one it means. The moment a third
+// faction can be neutral, "not my enemy" would start counting bystanders as
+// pack-mates.
 //
-// For now, this demonstrates the chain pattern. The actual ally-checking logic
-// would be implemented by the game server before publishing attack events, or this
-// function would need access to a perception/spatial service.
+// A question that cannot be answered leaves the chain untouched. Never an
+// error: this folds into the attack chain, and an errored fold discards every
+// other contribution to that roll along with this one (rpg-toolkit#1254).
 func (p *packTacticsCondition) onAttackChain(
-	_ context.Context,
+	ctx context.Context,
 	event dnd5eEvents.AttackChainEvent,
 	c chain.Chain[dnd5eEvents.AttackChainEvent],
 ) (chain.Chain[dnd5eEvents.AttackChainEvent], error) {
-	// Only process if we're the attacker
 	if event.AttackerID != p.ownerID {
 		return c, nil
 	}
+	if !p.allyAdjacentToTarget(ctx, event) {
+		return c, nil
+	}
 
-	// TODO: In full implementation, check if ally is adjacent to target
-	// For now, this is a no-op that preserves the chain pattern
-	// The game server would determine if Pack Tactics applies before creating the attack
+	modifyAttack := func(_ context.Context, e dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
+		e.AdvantageSources = append(e.AdvantageSources, dnd5eEvents.AttackModifierSource{
+			SourceRef: refs.MonsterTraits.PackTactics(),
+			SourceID:  p.ownerID,
+			Reason:    "Pack Tactics - ally adjacent to target",
+		})
+		return e, nil
+	}
 
-	// Example of how advantage would be granted:
-	// modifyAttack := func(_ context.Context, e dnd5eEvents.AttackChainEvent) (dnd5eEvents.AttackChainEvent, error) {
-	// 	e.AdvantageSources = append(e.AdvantageSources, dnd5eEvents.AttackModifierSource{
-	// 		SourceRef: refs.MonsterTraits.PackTactics(),
-	// 		SourceID:  p.ownerID,
-	// 		Reason:    "Pack Tactics - ally adjacent to target",
-	// 	})
-	// 	return e, nil
-	// }
-	//
-	// err := c.Add(combat.StageFeatures, "pack_tactics", modifyAttack)
-	// if err != nil {
-	// 	return c, rpgerr.Wrapf(err, "error applying pack tactics for owner %s", p.ownerID)
-	// }
+	if err := c.Add(combat.StageFeatures, "pack_tactics", modifyAttack); err != nil {
+		return c, rpgerr.Wrapf(err, "error applying pack tactics for owner %s", p.ownerID)
+	}
 
 	return c, nil
+}
+
+// allyAdjacentToTarget reports whether any ally of this creature stands within
+// five feet of the target.
+//
+// TODO(rpg-toolkit): RAW adds "and isn't incapacitated". That clause cannot be
+// written yet — Incapacitated is one of thirteen standard conditions with no
+// implementation, so there is nothing truthful to test. Deliberately left
+// unenforced rather than approximated by something that happens to be nearby
+// (downed, say), which would be a different rule wearing this one's name.
+func (p *packTacticsCondition) allyAdjacentToTarget(
+	ctx context.Context,
+	event dnd5eEvents.AttackChainEvent,
+) bool {
+	room, ok := gamectx.Room(ctx)
+	if !ok {
+		return false
+	}
+	cast, ok := gamectx.CastOf(ctx)
+	if !ok {
+		return false
+	}
+
+	targetPos, found := room.GetEntityPosition(event.TargetID)
+	if !found {
+		return false
+	}
+
+	for _, entity := range room.GetEntitiesInRange(targetPos, packTacticsReachCells) {
+		id := entity.GetID()
+		if id == event.TargetID || id == p.ownerID {
+			continue
+		}
+		if allied, known := cast.IsAllied(p.ownerID, id); known && allied {
+			return true
+		}
+	}
+
+	return false
 }

--- a/rulebooks/dnd5e/monstertraits/pack_tactics.go
+++ b/rulebooks/dnd5e/monstertraits/pack_tactics.go
@@ -114,10 +114,6 @@ func (p *packTacticsCondition) loadJSON(data json.RawMessage) error {
 	return nil
 }
 
-// packTacticsReachCells is 5 feet in grid cells, widened to 1.5 so the four
-// diagonals count as adjacent.
-const packTacticsReachCells = 1.5
-
 // onAttackChain grants advantage when an ally of the attacker is within five
 // feet of the target.
 //
@@ -184,7 +180,7 @@ func (p *packTacticsCondition) allyAdjacentToTarget(
 		return false
 	}
 
-	for _, entity := range room.GetEntitiesInRange(targetPos, packTacticsReachCells) {
+	for _, entity := range room.GetEntitiesInRange(targetPos, combat.AdjacentCells) {
 		id := entity.GetID()
 		if id == event.TargetID || id == p.ownerID {
 			continue

--- a/rulebooks/dnd5e/monstertraits/pack_tactics_test.go
+++ b/rulebooks/dnd5e/monstertraits/pack_tactics_test.go
@@ -39,7 +39,8 @@ func (s *PackTacticsTestSuite) SetupTest() {
 	s.packTactics = nil // Will be created in each test
 }
 
-// place puts a body on the grid and registers which side it is on.
+// place puts a body on the grid. Which side it is on is a separate matter,
+// declared to the fakeCast in each test.
 func (s *PackTacticsTestSuite) place(id string, x, y float64) *fakeEntity {
 	s.T().Helper()
 	e := &fakeEntity{id: id}
@@ -148,6 +149,46 @@ func (s *PackTacticsTestSuite) TestPackTacticsWithoutACastLeavesTheChainAlone() 
 	result := s.swing(ctx, "pc-1")
 	s.Empty(result.AdvantageSources)
 	s.Equal(4, result.AttackBonus, "the rest of the attack must survive an unanswerable question")
+}
+
+// TestPackTacticsReachIsFiveFeetOnAGridlessRoom pins the bug the #1255 review
+// caught: the radius used to be 1.5 cells "to include diagonals".
+//
+// A square grid does not need that correction — SquareGrid.Distance is
+// max(|dx|,|dy|), so a diagonal neighbour is already 1 — and nothing on a
+// square grid ever lands between 1 and 1.5, which is why it looked harmless.
+// A gridless room measures Euclidean, where 1.5 cells is 7.5 feet, and a
+// packmate standing seven feet away would have granted advantage.
+func (s *PackTacticsTestSuite) TestPackTacticsReachIsFiveFeetOnAGridlessRoom() {
+	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
+		ID:   "open-field",
+		Type: "wilderness",
+		Grid: spatial.NewGridlessRoom(spatial.GridlessConfig{Width: 20, Height: 20}),
+	})
+	for id, pos := range map[string]spatial.Position{
+		"wolf-1": {X: 1, Y: 1},
+		"pc-1":   {X: 5, Y: 5},
+		"wolf-2": {X: 5, Y: 6.4}, // 1.4 cells from the target — seven feet
+	} {
+		s.Require().NoError(room.PlaceEntity(&fakeEntity{id: id}, pos))
+	}
+
+	ctx := gamectx.WithRoom(s.ctx, room)
+	ctx = gamectx.WithCast(ctx, &fakeCast{side: map[string]string{
+		"wolf-1": "wolves", "wolf-2": "wolves", "pc-1": "party",
+	}})
+
+	s.packTactics = PackTactics("wolf-1").(*packTacticsCondition)
+	s.Require().NoError(s.packTactics.Apply(ctx, s.bus))
+
+	result := s.swing(ctx, "pc-1")
+	s.Empty(result.AdvantageSources, "a packmate seven feet away is not within five feet")
+
+	// And one that genuinely is adjacent still counts, so this is a boundary
+	// fix rather than the rule being switched off.
+	s.Require().NoError(room.RemoveEntity("wolf-2"))
+	s.Require().NoError(room.PlaceEntity(&fakeEntity{id: "wolf-2"}, spatial.Position{X: 5, Y: 6}))
+	s.Require().Len(s.swing(ctx, "pc-1").AdvantageSources, 1)
 }
 
 func (s *PackTacticsTestSuite) TestPackTacticsIgnoresOtherAttackers() {

--- a/rulebooks/dnd5e/monstertraits/pack_tactics_test.go
+++ b/rulebooks/dnd5e/monstertraits/pack_tactics_test.go
@@ -31,10 +31,14 @@ func TestPackTacticsTestSuite(t *testing.T) {
 func (s *PackTacticsTestSuite) SetupTest() {
 	s.bus = events.NewEventBus()
 	s.ctx = context.Background()
+	// The grid the game actually compiles. encounter/compilefield.go builds an
+	// AxialHexGrid and nothing else; square and gridless remain supported by
+	// tools/spatial but nothing in the product uses them. A positional rule
+	// proven only on a square grid is proven on a configuration we do not ship.
 	s.room = spatial.NewBasicRoom(spatial.BasicRoomConfig{
 		ID:   "test-room",
 		Type: "dungeon",
-		Grid: spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 20, Height: 20}),
+		Grid: spatial.NewAxialHexGrid(spatial.AxialHexGridConfig{SpanWidth: 1e6, SpanHeight: 1e6}),
 	})
 	s.packTactics = nil // Will be created in each test
 }

--- a/rulebooks/dnd5e/monstertraits/pack_tactics_test.go
+++ b/rulebooks/dnd5e/monstertraits/pack_tactics_test.go
@@ -10,6 +10,9 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 	"github.com/stretchr/testify/suite"
 )
 
@@ -17,6 +20,7 @@ type PackTacticsTestSuite struct {
 	suite.Suite
 	bus         events.EventBus
 	ctx         context.Context
+	room        spatial.Room
 	packTactics *packTacticsCondition
 }
 
@@ -27,46 +31,123 @@ func TestPackTacticsTestSuite(t *testing.T) {
 func (s *PackTacticsTestSuite) SetupTest() {
 	s.bus = events.NewEventBus()
 	s.ctx = context.Background()
+	s.room = spatial.NewBasicRoom(spatial.BasicRoomConfig{
+		ID:   "test-room",
+		Type: "dungeon",
+		Grid: spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 20, Height: 20}),
+	})
 	s.packTactics = nil // Will be created in each test
 }
 
-func (s *PackTacticsTestSuite) TestPackTacticsGrantsAdvantage() {
-	// Create Pack Tactics trait
-	// Note: This is a simplified implementation. The actual Pack Tactics logic
-	// (checking if ally is adjacent to target) would be handled by the game server
-	// before publishing the attack event. This trait just grants advantage when
-	// triggered.
-	s.packTactics = PackTactics("wolf-1").(*packTacticsCondition)
+// place puts a body on the grid and registers which side it is on.
+func (s *PackTacticsTestSuite) place(id string, x, y float64) *fakeEntity {
+	s.T().Helper()
+	e := &fakeEntity{id: id}
+	s.Require().NoError(s.room.PlaceEntity(e, spatial.Position{X: x, Y: y}))
+	return e
+}
 
-	// Apply to bus
-	err := s.packTactics.Apply(s.ctx, s.bus)
-	s.Require().NoError(err)
-
-	// Create attack event
+// swing folds one attack by wolf-1 against the named target and returns it.
+func (s *PackTacticsTestSuite) swing(ctx context.Context, targetID string) dnd5eEvents.AttackChainEvent {
+	s.T().Helper()
 	event := dnd5eEvents.AttackChainEvent{
 		AttackerID:  "wolf-1",
-		TargetID:    "pc-1",
+		TargetID:    targetID,
 		IsMelee:     true,
 		AttackBonus: 4,
 		TargetAC:    15,
 	}
-
-	// Publish attack chain event
-	chain := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
-	attackTopic := dnd5eEvents.AttackChain.On(s.bus)
-
-	modifiedChain, err := attackTopic.PublishWithChain(s.ctx, event, chain)
+	c := events.NewStagedChain[dnd5eEvents.AttackChainEvent](combat.ModifierStages)
+	modifiedChain, err := dnd5eEvents.AttackChain.On(s.bus).PublishWithChain(ctx, event, c)
 	s.Require().NoError(err)
-
-	// Execute chain to get modified event
-	result, err := modifiedChain.Execute(s.ctx, event)
+	result, err := modifiedChain.Execute(ctx, event)
 	s.Require().NoError(err)
+	return result
+}
 
-	// In the full implementation, this would check if an ally is adjacent
-	// For now, we verify the chain executes successfully
-	// The advantage would be added by checking AdvantageSources
-	s.Assert().Equal("wolf-1", result.AttackerID)
-	s.Assert().Equal("pc-1", result.TargetID)
+// TestPackTacticsGrantsAdvantage now actually tests advantage.
+//
+// It used to assert only that the attacker and target IDs survived the fold,
+// with a comment saying the real ally check "would be handled by the game
+// server before publishing the attack event". No game server ever did, and
+// nothing could have: the trait's whole body was commented out because there
+// was no way for it to ask who anybody was to anybody else.
+func (s *PackTacticsTestSuite) TestPackTacticsGrantsAdvantage() {
+	s.place("wolf-1", 1, 1)
+	s.place("wolf-2", 5, 6) // packmate, adjacent to the target
+	s.place("pc-1", 5, 5)
+
+	ctx := gamectx.WithRoom(s.ctx, s.room)
+	ctx = gamectx.WithCast(ctx, &fakeCast{side: map[string]string{
+		"wolf-1": "wolves", "wolf-2": "wolves", "pc-1": "party",
+	}})
+
+	s.packTactics = PackTactics("wolf-1").(*packTacticsCondition)
+	s.Require().NoError(s.packTactics.Apply(ctx, s.bus))
+
+	result := s.swing(ctx, "pc-1")
+
+	s.Require().Len(result.AdvantageSources, 1, "a packmate beside the target grants advantage")
+	s.Equal(refs.MonsterTraits.PackTactics().String(), result.AdvantageSources[0].SourceRef.String())
+	s.Equal("wolf-1", result.AdvantageSources[0].SourceID)
+}
+
+// TestPackTacticsWithoutAnAllyAdjacent — a lone wolf gets nothing.
+func (s *PackTacticsTestSuite) TestPackTacticsWithoutAnAllyAdjacent() {
+	s.place("wolf-1", 1, 1)
+	s.place("pc-1", 5, 5)
+	s.place("pc-2", 5, 6) // adjacent to the target, but not the wolf's ally
+
+	ctx := gamectx.WithRoom(s.ctx, s.room)
+	ctx = gamectx.WithCast(ctx, &fakeCast{side: map[string]string{
+		"wolf-1": "wolves", "pc-1": "party", "pc-2": "party",
+	}})
+
+	s.packTactics = PackTactics("wolf-1").(*packTacticsCondition)
+	s.Require().NoError(s.packTactics.Apply(ctx, s.bus))
+
+	result := s.swing(ctx, "pc-1")
+	s.Empty(result.AdvantageSources, "the target's own ally is not the wolf's packmate")
+}
+
+// TestPackTacticsDoesNotCountARivalFaction is the case a two-sided model gets
+// wrong, and the reason this asks IsAllied instead of !IsHostile.
+//
+// A hobgoblin stands beside the wolf's target. It is not the party, so any
+// "is it a character?" or "is it not my enemy?" test would count it as a
+// packmate. It is a rival faction and grants the wolf nothing.
+func (s *PackTacticsTestSuite) TestPackTacticsDoesNotCountARivalFaction() {
+	s.place("wolf-1", 1, 1)
+	s.place("pc-1", 5, 5)
+	s.place("hobgoblin-1", 5, 6)
+
+	ctx := gamectx.WithRoom(s.ctx, s.room)
+	ctx = gamectx.WithCast(ctx, &fakeCast{side: map[string]string{
+		"wolf-1": "wolves", "pc-1": "party", "hobgoblin-1": "hobgoblins",
+	}})
+
+	s.packTactics = PackTactics("wolf-1").(*packTacticsCondition)
+	s.Require().NoError(s.packTactics.Apply(ctx, s.bus))
+
+	result := s.swing(ctx, "pc-1")
+	s.Empty(result.AdvantageSources, "a rival faction beside the target is not a packmate")
+}
+
+// TestPackTacticsWithoutACastLeavesTheChainAlone — a question it cannot answer
+// is not an error, and must not poison the fold.
+func (s *PackTacticsTestSuite) TestPackTacticsWithoutACastLeavesTheChainAlone() {
+	s.place("wolf-1", 1, 1)
+	s.place("wolf-2", 5, 6)
+	s.place("pc-1", 5, 5)
+
+	ctx := gamectx.WithRoom(s.ctx, s.room) // room, but no cast
+
+	s.packTactics = PackTactics("wolf-1").(*packTacticsCondition)
+	s.Require().NoError(s.packTactics.Apply(ctx, s.bus))
+
+	result := s.swing(ctx, "pc-1")
+	s.Empty(result.AdvantageSources)
+	s.Equal(4, result.AttackBonus, "the rest of the attack must survive an unanswerable question")
 }
 
 func (s *PackTacticsTestSuite) TestPackTacticsIgnoresOtherAttackers() {


### PR DESCRIPTION
Closes #1251 · Follows #1254 · Design: KirkDiggler/rpg-project#286

Two rules that could not be written correctly before, because nothing could answer *"who is this to that"*.

## Sneak Attack was asking the wrong question

`sneak_attack.go` decided allyness like this:

```go
// Check if any "character" type entity (ally) is near the target
if entity.GetType() == "character" {
```

RAW is *"another **enemy of the target** is within 5 feet of it"* — measured from the **target's** point of view, not the attacker's. With two factions those coincide and nobody notices. With three they come apart **in both directions**: a fellow player counted as an ally even while fighting you, and a rival monster beside your target never counted at all.

It now asks `IsHostile(targetID, other)`.

## Pack Tactics was a stub

Its entire body was commented out behind `// TODO: In full implementation, check if ally is adjacent to target`, with a note saying the check *"would be handled by the game server before publishing the attack event."* Nothing ever did, and nothing could have — the trait had no way to ask. **The wolf already ships, and Pack Tactics is its signature trait.**

It now asks `IsAllied(attackerID, other)`.

Its *"and isn't incapacitated"* clause is deliberately **left unenforced**, with a note saying why: Incapacitated is one of thirteen standard conditions with no implementation, and approximating it with something nearby (downed, say) would be a different rule wearing this one's name.

## `Cast` gains `IsAllied`

Brought by the consumer that needs it, which is the rule `resolution/doc.go` states about not building registries ahead of readers.

**It is not the negation of `IsHostile`**, and that distinction is the whole reason both exist. Both answer "same `MemberKind`" today, so they are momentarily each other's complement — but the moment a third faction can be *neutral*, "not my enemy" starts counting bystanders as packmates. Sneak Attack asks the first question, Pack Tactics the second, and each asks the one it means.

## Also: another fold-poisoning error

`checkSneakAttackConditions` returned an error when it couldn't read the room, and its caller folded that into the damage chain — the same shape as the AC bug #1254 fixed, where an errored fold discards *every other contribution* along with the one that failed. Both predicates now return plain bools.

## Evidence

`go build`, `go vet`, `go test ./...` (27 packages), `golangci-lint` — all green.

The tests carry the three-faction case in both directions:

- **The rogue sneak attacks a duergar because a hobgoblin is standing beside it.** The hobgoblin is an enemy of the target and nobody's ally. That is RAW, it is emergent from two monster factions fighting each other, and the old rule could not produce it.
- **The wolf gets nothing from a hobgoblin beside its target** — a rival faction is not a packmate. A `!IsHostile` shortcut would have got this wrong.
- Plus: the target's own ally doesn't enable sneak attack, a lone wolf gets no advantage, and an unanswerable question leaves the rest of the attack intact.

`TestPackTacticsGrantsAdvantage` now asserts advantage. It previously asserted that the attacker and target IDs survived the fold, under a comment conceding the real check was somebody else's job — the second test in this slice found to be promising something it never checked.

— platform agent, on behalf of KirkDiggler
