### PR TITLE
feat(resolution): install the cast, and prove Unarmored Defense in a real fight

### DIFF
--- a/rulebooks/dnd5e/resolution/cast.go
+++ b/rulebooks/dnd5e/resolution/cast.go
@@ -1,0 +1,135 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+)
+
+// castView answers [gamectx.Cast] over the participants this interaction
+// loaded.
+//
+// This is the only implementation there is, and this is the only package that
+// could hold it: an effect's questions are about the OTHER participants, and
+// R3 — pass everyone in — means resolution is the one place that has them all.
+// The registries this replaces lived in gamectx and in combat, one import
+// level below the data they described, which is why neither was ever installed
+// by anything (rpg-toolkit#1251).
+//
+// It is a view, not a copy. The sheets are the same objects the machine is
+// about to run against, so an effect asking about a participant mid-fold sees
+// that participant as it is right now rather than as it was when the
+// interaction opened. That matters for the questions worth asking — "is my
+// target still up", eventually "is my target still poisoned" — and it costs
+// nothing, because both die with the call.
+type castView struct {
+	cast *Participants
+}
+
+var _ gamectx.Cast = (*castView)(nil)
+
+// Member returns a participant's combat-facing sheet.
+//
+// Characters and monsters are the same thing here, which is the point:
+// [gamectx.CharacterRegistry] could name weapons and ability scores and action
+// economy and could not describe a wolf at all, so every predicate that wanted
+// to ask about "whoever is standing there" had nothing to ask.
+func (v *castView) Member(id string) (combat.Combatant, bool) {
+	if ch, ok := v.cast.Character(id); ok {
+		return ch, true
+	}
+	if m, ok := v.cast.Monster(id); ok {
+		return m, true
+	}
+
+	return nil, false
+}
+
+// Members returns every participant, in attach order.
+//
+// Attach order is sorted order (R4) — resolution attaches in sorted participant
+// order precisely so two resolutions over identical data produce identical
+// registration lists, which is what makes a suspension resumable into the world
+// it left. Handing that same order out here means an effect that iterates the
+// cast is deterministic for free rather than by remembering to sort.
+func (v *castView) Members() []string {
+	return v.cast.IDs()
+}
+
+// IsHostile answers whether b is an enemy of a.
+//
+// v1 answers "one of you is a character and the other is a monster", and that
+// is a LIE with a known expiry. Allegiance is a directed relation between
+// factions that quest events can change mid-run — the design case is a dungeon
+// holding two monster factions hostile to each other and to the party, and a
+// party that can shift one of them by returning something it wants
+// (rpg-project#286, ideas/session-combat/effect-context/brainstorm.md).
+//
+// The lie is confined HERE, to one function, on purpose. That is the whole
+// reason [gamectx.Cast] exposes questions instead of fields: when stance
+// arrives, this body reads a relation table and not one rule changes.
+// conditions/sneak_attack.go used to make the same guess for itself, inline,
+// and was wrong in both directions the moment a third faction existed.
+func (v *castView) IsHostile(a, b string) (hostile, known bool) {
+	sideA, ok := v.side(a)
+	if !ok {
+		return false, false
+	}
+	sideB, ok := v.side(b)
+	if !ok {
+		return false, false
+	}
+
+	return sideA != sideB, true
+}
+
+// IsAllied answers whether b is on a's side.
+//
+// Not the negation of [castView.IsHostile], even though today it computes as
+// one. Both derive from the same two-valued guess, so they are momentarily
+// complements; the moment a faction can be NEUTRAL toward another they stop
+// being, and a rule written against the wrong one starts counting bystanders.
+// Pack Tactics wants allies, Sneak Attack wants the target's enemies, and each
+// asks for what it means.
+func (v *castView) IsAllied(a, b string) (allied, known bool) {
+	sideA, ok := v.side(a)
+	if !ok {
+		return false, false
+	}
+	sideB, ok := v.side(b)
+	if !ok {
+		return false, false
+	}
+
+	return sideA == sideB, true
+}
+
+// castSide is v1's stand-in for allegiance: which map a participant loaded
+// into.
+type castSide int
+
+const (
+	sideCharacter castSide = iota
+	sideMonster
+)
+
+// side reports which side a participant is on, and whether it is in this
+// interaction at all.
+//
+// Not-in-the-cast is the "cannot answer" case rather than a default side. An
+// effect asking about somebody who is not here has to be able to tell that
+// apart from an answer, or it invents a rule out of missing data — the
+// distinction conditions/prone.go draws between "not within reach" and "nobody
+// knows where these two are standing".
+func (v *castView) side(id string) (castSide, bool) {
+	if _, ok := v.cast.Character(id); ok {
+		return sideCharacter, true
+	}
+	if _, ok := v.cast.Monster(id); ok {
+		return sideMonster, true
+	}
+
+	return 0, false
+}

--- a/rulebooks/dnd5e/resolution/cast_test.go
+++ b/rulebooks/dnd5e/resolution/cast_test.go
@@ -1,0 +1,66 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoCodePathProducesACastlessInteraction is the STRUCTURAL half, and it is
+// deliberately not a behavioural one. It is the same pin as
+// TestNoCodePathProducesARoomlessInteraction and for a sharper reason.
+//
+// A behavioural test can only show that the interactions it happened to run got
+// a cast. The claim rpg-toolkit#1251 needs is that no input CAN produce one
+// without — and an optional ambient dependency is EXACTLY the defect being
+// removed. gamectx had five installers and one install; three conditions read
+// one of the four empty ones and returned its error into a chain fold that
+// swallows errors, so a barbarian fought at base AC in every real fight and
+// nothing was logged. Every test of those rules passed, because every test
+// installed a registry by hand.
+//
+// That is the failure mode a behavioural suite is structurally unable to catch:
+// the tests supply what production does not. So the source is the assertion.
+// The install is one statement at the top level of resolveOn's body, and a
+// condition wrapped around it is the defect by construction — whatever the
+// condition said, there would be inputs it answered no for.
+func TestNoCodePathProducesACastlessInteraction(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "resolve.go", nil, 0)
+	require.NoError(t, err)
+
+	fn := funcDecl(t, file, "resolveOn")
+
+	var installs []token.Pos
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "WithCast" {
+			installs = append(installs, call.Pos())
+		}
+
+		return true
+	})
+	require.Len(t, installs, 1, "the cast is installed in exactly one place")
+
+	ast.Inspect(fn, func(n ast.Node) bool {
+		branch, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		require.False(t, branch.Pos() <= installs[0] && installs[0] < branch.End(),
+			"resolve.go:%d installs the cast inside a condition — some input answers no, "+
+				"and an ambient dependency that is sometimes absent is rpg-toolkit#1251",
+			fset.Position(installs[0]).Line)
+
+		return true
+	})
+}

--- a/rulebooks/dnd5e/resolution/dirty_test.go
+++ b/rulebooks/dnd5e/resolution/dirty_test.go
@@ -192,9 +192,18 @@ func (s *DirtyTestSuite) TestAnUntouchedParticipantIsNotReturned() {
 	})
 	s.Require().NoError(err)
 
+	// Assert the positive first. A loop that only says "none of these is the
+	// bystander" passes when the list is EMPTY, which is the state where the
+	// writeback guarantee has actually collapsed — the test would go green on
+	// the worst outcome it could see.
+	returned := make([]string, 0, len(out.DirtyMonsters))
 	for _, m := range out.DirtyMonsters {
-		s.Require().NotEqual(secondWolfID, m.ID,
-			"a participant nothing happened to must not be written back (R3 says pass "+
-				"everyone in; it does not say charge for everyone)")
+		returned = append(returned, m.ID)
 	}
+	s.Require().Contains(returned, wolfID,
+		"the wolf that was hit must come back to be stored — without this the "+
+			"bystander check below proves nothing")
+	s.Require().NotContains(returned, secondWolfID,
+		"a participant nothing happened to must not be written back (R3 says pass "+
+			"everyone in; it does not say charge for everyone)")
 }

--- a/rulebooks/dnd5e/resolution/dirty_test.go
+++ b/rulebooks/dnd5e/resolution/dirty_test.go
@@ -1,0 +1,200 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// DirtyTestSuite proves the write half of an effect's owner handle: a condition
+// that changes its OWN persisted state comes back from Resolve to be stored.
+//
+// Resolve returns only participants reporting IsDirty, and until
+// rpg-toolkit#1251 nothing a condition did set that flag. It survived on
+// coincidence — a rogue who spent a sneak attack also paid an action, and
+// paying an action marks the sheet; a raging barbarian who was hit also took
+// damage, and damage marks the sheet. The state change rode along with
+// something else that happened to mark it.
+//
+// That coincidence runs out exactly where it is most needed. A turn boundary
+// becomes an interaction whose ENTIRE purpose is condition state, with no
+// damage and no economy to ride on, so every expiry would fire correctly and
+// then be discarded. This is the prerequisite for that clock, which is why it
+// gets an isolating test rather than an incidental one.
+type DirtyTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func TestDirtySuite(t *testing.T) {
+	suite.Run(t, new(DirtyTestSuite))
+}
+
+func (s *DirtyTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// ragingHero is a barbarian who is already raging and is about to swing.
+//
+// The swing is what makes this test isolating. A raging character records
+// DidAttackThisTurn when their attack resolves — and an ATTACKER takes no
+// damage, so nothing touches their hit points, and this interaction carries no
+// Cost, so nothing touches their action economy. Those are the two accidents
+// that were marking sheets dirty on the condition's behalf. With both gone,
+// RagingCondition.markDirty is the only thing left that can put this sheet in
+// the output.
+func (s *DirtyTestSuite) ragingHero() *character.Data {
+	raging, err := (&conditions.RagingCondition{
+		CharacterID: heroID,
+		DamageBonus: 2,
+		Level:       1,
+		Source:      "dnd5e:features:rage",
+	}).ToJSON()
+	s.Require().NoError(err)
+
+	return &character.Data{
+		ID:       heroID,
+		PlayerID: "player-1",
+		Name:     "Standre",
+		Level:    1,
+		ClassID:  classes.Barbarian,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, abilities.DEX: 14, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 8,
+		},
+		HitPoints:        20,
+		MaxHitPoints:     20,
+		ArmorClass:       12,
+		ProficiencyBonus: 2,
+		Conditions:       []json.RawMessage{raging},
+	}
+}
+
+func (s *DirtyTestSuite) world() encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{},
+		Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc.ToData()
+}
+
+// TestAConditionThatChangesItselfComesBackToBeStored is the isolating test.
+//
+// The hero swings, so takes no damage; the interaction has no Cost, so pays no
+// economy. If markDirty were removed, DidAttackThisTurn would still be set on
+// the live object and the sheet would simply not be returned — the update
+// applied, then silently thrown away. That is the failure this guards, and it
+// is invisible to any test whose subject also took damage or paid an action.
+func (s *DirtyTestSuite) TestAConditionThatChangesItselfComesBackToBeStored() {
+	hero := s.ragingHero()
+	bite := monsters.NewWolf(wolfID).ToData().Actions[0]
+
+	out, err := Resolve(s.ctx, &Input{
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
+		Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		World:        s.world(),
+		Participants: []Participant{{Character: hero}, {Monster: monsters.NewWolf(wolfID).ToData()}},
+		Machine: NewStrike(&StrikeInput{
+			AttackerID: heroID,
+			TargetID:   wolfID,
+			Definition: bite,
+			Roller:     &sequenceRoller{singles: []int{18, 18}, pair: []int{3, 4}},
+		}),
+		// No Cost. A free action, which is what every Resolve was before the
+		// door existed — and the point: nothing here debits an economy.
+	})
+	s.Require().NoError(err)
+
+	s.Require().Len(out.DirtyCharacters, 1,
+		"the attacker took no damage and paid no economy: if this sheet came back, "+
+			"a condition asked for it")
+	s.Require().Equal(heroID, out.DirtyCharacters[0].ID)
+
+	s.Require().Len(out.DirtyCharacters[0].Conditions, 1)
+	var stored map[string]any
+	s.Require().NoError(json.Unmarshal(out.DirtyCharacters[0].Conditions[0], &stored))
+	s.Require().Equal(true, stored["did_attack_this_turn"],
+		"and the change is IN the blob that gets stored, not only on the live object")
+}
+
+// TestAnUntouchedParticipantIsNotReturned is the other half: marking is not
+// indiscriminate.
+//
+// The wolf is attacked and misses nothing — it is the target, so it takes the
+// damage and legitimately comes back. What must NOT happen is every
+// participant coming back on every interaction, which would make the dirty set
+// meaningless and hand the host a write per sheet per swing.
+func (s *DirtyTestSuite) TestAnUntouchedParticipantIsNotReturned() {
+	hero := s.ragingHero()
+	bystander := monsters.NewWolf(secondWolfID).ToData()
+	bite := monsters.NewWolf(wolfID).ToData().Actions[0]
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{},
+		Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Field: encounter.FieldInput{
+			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
+			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+			{ID: secondWolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	out, err := Resolve(s.ctx, &Input{
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Standing: everyoneStanding{},
+		Sight: everyoneSeesTheWholeMap{}, Roller: dice.NewRoller(),
+		World: enc.ToData(),
+		Participants: []Participant{
+			{Character: hero},
+			{Monster: monsters.NewWolf(wolfID).ToData()},
+			{Monster: bystander},
+		},
+		Machine: NewStrike(&StrikeInput{
+			AttackerID: heroID,
+			TargetID:   wolfID,
+			Definition: bite,
+			Roller:     &sequenceRoller{singles: []int{18, 18}, pair: []int{3, 4}},
+		}),
+	})
+	s.Require().NoError(err)
+
+	for _, m := range out.DirtyMonsters {
+		s.Require().NotEqual(secondWolfID, m.ID,
+			"a participant nothing happened to must not be written back (R3 says pass "+
+				"everyone in; it does not say charge for everyone)")
+	}
+}

--- a/rulebooks/dnd5e/resolution/doc.go
+++ b/rulebooks/dnd5e/resolution/doc.go
@@ -168,28 +168,51 @@
 // outcome), so the case where the answer comes from outside the process is a
 // new step rather than a redesign of this one.
 //
-// No game context is installed. Effect predicates read world state through
-// five separate installers in the gamectx package, and neither a saving throw's
-// predicates nor a contest's read any of them — [conditions.RagingCondition]
-// decides on the event alone. Resolution is where they will be populated,
-// because it is the one place that holds both the world and the effects; the
-// first predicate that needs one brings its installer with it. Populating a
-// registry nothing reads would be building the wrong thing convincingly.
+// Two game-context installers are populated, both unconditionally.
 //
-// One installer is now populated, by the machine that forced it. The strike
-// folds the attack chain, and prone's predicate reads positions off that chain —
-// advantage from within five feet, disadvantage beyond — so [Resolve] installs
-// the world the interaction happens on.
+// This paragraph used to say "No game context is installed", and describe five
+// gamectx registries waiting for a predicate to force them: the first predicate
+// that needs one brings its installer with it, and populating a registry
+// nothing reads would be building the wrong thing convincingly. The policy was
+// right. It was not enforced, and the failure was invisible in exactly the
+// direction nobody was looking.
 //
-// ONE world, installed EVERY time, and it is THE world rather than a copy of
-// it. The composition compiles the authored chambers into a single canvas in a
-// single absolute frame and hands that room over to be read
-// (rpg-toolkit#1105, rpg-toolkit#1114), so "which room describes this
-// interaction" stopped being a question anybody has to answer. It used to be
-// one, and the answer this package gave when the cast spanned two rooms —
-// install nothing — silently switched off every predicate that reads positions
-// the moment a party member wandered off, which in a dungeon is most of the
-// time (rpg-toolkit#1090).
+// FOUR predicates arrived without their installer. UnarmoredDefense,
+// MartialArts twice, and UnarmoredMovement all read
+// gamectx.RequireCharacters — a registry with zero non-test call sites in the
+// whole toolkit — and returned its "no game context" error into a chain fold.
+// [character.Character.EffectiveAC] swallows fold errors, so a barbarian with
+// Unarmored Defense attached was struck at 10+DEX in every real fight, every
+// other contributor to that AC was discarded along with the one that failed,
+// and nothing was logged. Every test of those rules passed throughout, because
+// every one of them installed a registry by hand that production never
+// installed (rpg-toolkit#1251).
+//
+// So the mirror of the warning above is the one that actually bit: defining
+// registries nothing populates is the same mistake as populating registries
+// nothing reads, and it fails silently instead of loudly.
+//
+// What is installed now, on every path and inside no condition:
+//
+//   - [gamectx.WithRoom] — the world the interaction happens on. ONE world,
+//     installed EVERY time, and it is THE world rather than a copy of it. The
+//     composition compiles the authored chambers into a single canvas in a
+//     single absolute frame and hands that room over to be read
+//     (rpg-toolkit#1105, rpg-toolkit#1114), so "which room describes this
+//     interaction" stopped being a question anybody has to answer. It used to
+//     be one, and the answer this package gave when the cast spanned two rooms
+//     — install nothing — silently switched off every predicate that reads
+//     positions the moment a party member wandered off, which in a dungeon is
+//     most of the time (rpg-toolkit#1090).
+//   - [gamectx.WithCast] — who the participants are to each other. This
+//     package is the only one that can answer it: R3 passes everyone in, so
+//     this is the only place that holds them all. See [castView].
+//
+// TestNoCodePathProducesARoomlessInteraction and
+// TestNoCodePathProducesACastlessInteraction hold both structurally rather than
+// by example, by reading this file's source. A behavioural suite cannot make
+// the claim: the defect is that tests supply what production does not, so the
+// tests are the last place it shows up.
 //
 // This package builds no geometry of its own. It held a room it assembled out
 // of the encounter's persisted description, carrying a second copy of grid
@@ -197,8 +220,13 @@
 // composition enforces are now the same object, which is a stronger guarantee
 // than any test over two of them could be.
 //
-// Nothing else is installed. The other four registries stay empty until a
-// predicate that reads one arrives with its own consumer.
+// The registries that were never populated are gone rather than waiting:
+// CharacterRegistry (character-shaped, so it could not describe a monster at
+// all), CombatantRegistry, CombatState, and combat.CombatantLookup, a sixth
+// mechanism answering the same question from another package with its own
+// context key. gamectx.ReactionReadiness stays — it has two live readers and
+// its absent value is correct on purpose, which is a different thing from an
+// installer nobody wired.
 //
 // The machine for a saving throw lives here rather than in the rules package
 // that owns saves, because `rulebooks/dnd5e` cannot import this module — this

--- a/rulebooks/dnd5e/resolution/effective_ac_test.go
+++ b/rulebooks/dnd5e/resolution/effective_ac_test.go
@@ -138,6 +138,89 @@ func (s *EffectiveACTestSuite) biteAt(hero *character.Data, roll int) StrikeOutc
 	return outcome
 }
 
+// unarmoredBarbarian wears nothing at all.
+//
+// No armor on purpose: Unarmored Defense only applies when unarmored, so the
+// whole number has to come from the sheet's own ability scores through the AC
+// chain. DEX 14 (+2) and CON 14 (+2) put the answer at 10+2+2 = 14, and the
+// flat ArmorClass is 10 so that reading the sheet reports a number that says
+// so.
+func (s *EffectiveACTestSuite) unarmoredBarbarian(conds ...json.RawMessage) *character.Data {
+	return &character.Data{
+		ID:       heroID,
+		PlayerID: "player-1",
+		Name:     "Standre",
+		Level:    1,
+		ClassID:  classes.Barbarian,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14, // +2
+			abilities.CON: 14, // +2
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:        14,
+		MaxHitPoints:     14,
+		ArmorClass:       10,
+		ProficiencyBonus: 2,
+		Conditions:       conds,
+	}
+}
+
+func (s *EffectiveACTestSuite) unarmoredDefense() json.RawMessage {
+	raw, err := (&conditions.UnarmoredDefenseCondition{
+		CharacterID: heroID,
+		Type:        conditions.UnarmoredDefenseBarbarian,
+		Source:      "dnd5e:classes:barbarian",
+	}).ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// THE TEST THIS WHOLE SLICE EXISTS FOR. Unarmored Defense reaches the strike.
+//
+// It did not, in any real fight, for as long as the rule has existed. The
+// condition read gamectx.RequireCharacters — a registry with zero non-test
+// install sites — and returned its error into the AC fold, which
+// Character.EffectiveAC swallows. So a barbarian with Unarmored Defense
+// attached was struck at 10+DEX, every other AC contributor was discarded with
+// it, and nothing was logged. Kirk found it by playing: his barbarian fought
+// the tomb at 11 instead of 14 (rpg-api#842, rpg-toolkit#1251).
+//
+// Every test of the rule passed throughout, because every one of them
+// installed a registry by hand that production never installed. Which is why
+// this one lives HERE and goes through Resolve: the condition now reads its own
+// sheet, handed over by the same Attach the interaction performs, and there is
+// nothing in this test for a bug to hide behind.
+func (s *EffectiveACTestSuite) TestUnarmoredDefenseReachesTheStrike() {
+	bare := s.biteAt(s.unarmoredBarbarian(), 12)
+	defended := s.biteAt(s.unarmoredBarbarian(s.unarmoredDefense()), 12)
+
+	s.Require().Equal(12, bare.TargetAC,
+		"unarmored and without the feature: 10 + DEX(+2)")
+	s.Require().Equal(14, defended.TargetAC,
+		"Unarmored Defense adds CON(+2) through the AC chain: 10 + DEX + CON")
+	s.Require().Equal(2, defended.TargetAC-bare.TargetAC,
+		"exactly the feature's contribution, folded on this interaction's bus")
+}
+
+// And it decides the hit, which is the part that was costing hit points.
+//
+// The wolf's +4 against 12 needs an 8; against 14 it needs a 10. The same 8
+// must therefore land on the barbarian who lost the feature and miss the one
+// who has it — one roll, two points of Constitution between them.
+func (s *EffectiveACTestSuite) TestUnarmoredDefenseDecidesTheHit() {
+	bare := s.biteAt(s.unarmoredBarbarian(), 8)
+	s.Require().True(bare.Hit, "8 + 4 = 12 meets AC 12")
+
+	defended := s.biteAt(s.unarmoredBarbarian(s.unarmoredDefense()), 8)
+	s.Require().False(defended.Hit, "the same 12 falls short of AC 14")
+	s.Require().Zero(defended.Damage, "and a miss deals nothing")
+}
+
 // THE PROVING TEST. Worn armor reaches the strike.
 //
 // Chain mail is AC 16 with no DEX contribution. The sheet's flat ArmorClass

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.102.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.6
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0 h1:8c/xoqxgXqRO3LxoEXRFBd6gNgvOBc1JWXddKNvArzc=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.99.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.102.0 h1:ODT3LGh2tMXvNUNytmvfPlzf2gdGqYeUjU7SVfTbwNg=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.102.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.6 h1:O4YgK5tjVmeAY2L+Oj9IIuRh3SCFFRvODemW42u5Zyw=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.6/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -343,6 +343,24 @@ func resolveOn(ctx context.Context, in *Input, surf *surface) (*Output, error) {
 		return nil, err
 	}
 
+	// The other half of the read channel: the room says where everyone is
+	// standing, and this says who they are to each other.
+	//
+	// EVERY TIME, for the same reason and with the same pin. Five registries
+	// in gamectx and a sixth in combat tried to answer pieces of this and
+	// between them were installed zero times, so three conditions read a
+	// registry nobody supplied and returned its error into a chain fold that
+	// swallows errors — a barbarian fought at base AC in every real fight and
+	// nothing was logged (rpg-toolkit#1251). An ambient dependency that is
+	// SOMETIMES present is the defect; being always present is the fix, and
+	// TestNoCodePathProducesACastlessInteraction holds that structurally
+	// rather than by example.
+	//
+	// It goes in after attachAll because that is the call that loads the
+	// sheets. Nothing reads it before then: effects subscribe during Apply and
+	// ask their questions at fold time, which is after this line.
+	ctx = gamectx.WithCast(ctx, &castView{cast: cast})
+
 	// Start is pure preflight and runs before payment. Invalid participant,
 	// delivery, or condition declarations therefore consume nothing.
 	first, startErr := start(ctx, in.Machine, cast)


### PR DESCRIPTION
Closes #1252 · Follows #1254, #1255 · Design: KirkDiggler/rpg-project#286

Resolution answers `gamectx.Cast` now, over the participants it already loads, and installs it beside the room **on every path with no condition wrapped around it**.

That is the whole fix. R3 passes everyone in, so this is the only package that holds them all — and the registries that tried to answer this lived in `gamectx` and `combat`, a layer below the data they described, which is exactly why nothing ever installed them.

## The proving test

`effective_ac_test.go` — **a barbarian with Unarmored Defense is struck at 14 through a real `Resolve`.** 10 + DEX(+2) + CON(+2), against 12 for the same barbarian without the feature. And it decides the hit, not just the report: the wolf's +4 on an 8 lands on the one who lost the feature and misses the one who has it.

It did not work in any real fight for as long as the rule has existed. The condition read `gamectx.RequireCharacters` — zero non-test call sites in the toolkit — and returned its error into a fold that `Character.EffectiveAC` swallows. Kirk found it by playing the tomb at AC 11 instead of 14 (rpg-api#842).

**This lands a module earlier than the plan said.** The plan put the end-to-end proof in `session`, on the reasoning that nothing below could drive `Resolve`. But this package *is* resolution, and `effective_ac_test.go` was already proving the Defense fighting style end to end right here. Session's remaining job shrinks to the session verbs.

## Structural, not behavioural

`TestNoCodePathProducesACastlessInteraction` reads `resolve.go`'s AST and asserts exactly one `WithCast`, not inside an `if` — mirroring the roomless pin.

A behavioural suite structurally cannot make this claim. The defect being removed is *tests supplying what production does not*, so the tests are the last place it would ever surface. Every test of the three broken conditions passed for months.

## The dirty test isolates rather than demonstrates

A raging hero who **swings** takes no damage and pays no economy — both of the accidents that were marking sheets dirty on a condition's behalf are absent by construction. If `markDirty` were removed, `DidAttackThisTurn` would still be set on the live object and the sheet simply would not be returned: the update applied, then silently discarded. The assertion reads `did_attack_this_turn` out of the blob that gets **stored**, not off the live object.

A turn boundary — the next slice — will have neither accident, which is why this is its prerequisite.

## `doc.go` is rewritten, not patched

Its "No game context is installed" paragraph stated a policy that was right and unenforced: *the first predicate that needs an installer brings it with it*. Four predicates arrived without theirs and failed silently. Leaving that paragraph standing is how the drift went unnoticed — so it now says what is true, names both installers, and records that defining registries nothing populates is the same mistake as populating registries nothing reads, except that it fails quietly.

## `IsHostile` is still a lie, and confined

v1 answers "one of you is a character and the other is a monster", in **one function**, documented as such. When allegiance arrives — a directed relation between factions that quest events can change mid-run — that body reads a stance table and not one rule changes. `IsAllied` is deliberately not its negation; they only compute as complements while the answer is two-valued.

## Evidence

`go build`, `go vet`, `go test ./...`, `golangci-lint` — all green. Bumped to `rulebooks/dnd5e v0.102.0`.

— platform agent, on behalf of KirkDiggler
