### PR TITLE
feat(events): a turn belongs to its subject, not to a character

### DIFF
--- a/rulebooks/dnd5e/character/conditions_test.go
+++ b/rulebooks/dnd5e/character/conditions_test.go
@@ -283,8 +283,8 @@ func (s *CharacterConditionsTestSuite) TestCharacterRemovesExpiredCondition() {
 	// Simulate rage expiring by publishing turn end event without combat activity
 	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
 	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-		CharacterID: "char-1",
-		Round:       1,
+		SubjectID: "char-1",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/combat/turn_manager.go
+++ b/rulebooks/dnd5e/combat/turn_manager.go
@@ -153,7 +153,7 @@ func (tm *TurnManager) StartTurn(ctx context.Context) (*StartTurnResult, error) 
 	// Publish turn start event
 	topic := dnd5eEvents.TurnStartTopic.On(tm.bus)
 	if err := topic.Publish(ctx, dnd5eEvents.TurnStartEvent{
-		CharacterID: tm.character.GetID(),
+		SubjectID: tm.character.GetID(),
 	}); err != nil {
 		return nil, fmt.Errorf("failed to publish turn start event: %w", err)
 	}
@@ -176,7 +176,7 @@ func (tm *TurnManager) EndTurn(ctx context.Context) (*EndTurnResult, error) {
 	// Publish turn end event
 	topic := dnd5eEvents.TurnEndTopic.On(tm.bus)
 	if err := topic.Publish(ctx, dnd5eEvents.TurnEndEvent{
-		CharacterID: tm.character.GetID(),
+		SubjectID: tm.character.GetID(),
 	}); err != nil {
 		return nil, fmt.Errorf("failed to publish turn end event: %w", err)
 	}

--- a/rulebooks/dnd5e/conditions/disengaging.go
+++ b/rulebooks/dnd5e/conditions/disengaging.go
@@ -163,7 +163,7 @@ func (d *DisengagingCondition) onMovementChain(
 // onTurnEnd handles turn end events to remove this condition when the character's turn ends.
 func (d *DisengagingCondition) onTurnEnd(ctx context.Context, event dnd5eEvents.TurnEndEvent) error {
 	// Only remove on this character's turn end
-	if event.CharacterID != d.CharacterID {
+	if event.SubjectID != d.CharacterID {
 		return nil
 	}
 

--- a/rulebooks/dnd5e/conditions/disengaging_test.go
+++ b/rulebooks/dnd5e/conditions/disengaging_test.go
@@ -142,8 +142,8 @@ func (s *DisengagingConditionTestSuite) TestRemovedOnTurnEnd() {
 	// Publish turn end for the disengaging character
 	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
 	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-		CharacterID: "rogue-1",
-		Round:       1,
+		SubjectID: "rogue-1",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 
@@ -165,8 +165,8 @@ func (s *DisengagingConditionTestSuite) TestNotRemovedOnOtherCharactersTurnEnd()
 	// Publish turn end for a DIFFERENT character
 	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
 	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-		CharacterID: "fighter-1", // Not the disengaging character
-		Round:       1,
+		SubjectID: "fighter-1", // Not the disengaging character
+		Round:     1,
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/conditions/dodging.go
+++ b/rulebooks/dnd5e/conditions/dodging.go
@@ -205,7 +205,7 @@ func (d *DodgingCondition) onSavingThrowChain(
 // onTurnStart handles turn start events to remove this condition at the start of the character's next turn.
 func (d *DodgingCondition) onTurnStart(ctx context.Context, event dnd5eEvents.TurnStartEvent) error {
 	// Only remove on this character's turn start
-	if event.CharacterID != d.CharacterID {
+	if event.SubjectID != d.CharacterID {
 		return nil
 	}
 

--- a/rulebooks/dnd5e/conditions/dodging_test.go
+++ b/rulebooks/dnd5e/conditions/dodging_test.go
@@ -232,8 +232,8 @@ func (s *DodgingConditionTestSuite) TestTurnStartRemoval() {
 
 		// Publish turn start for this character
 		err = dnd5eEvents.TurnStartTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-			CharacterID: s.characterID,
-			Round:       1,
+			SubjectID: s.characterID,
+			Round:     1,
 		})
 		s.Require().NoError(err)
 
@@ -252,8 +252,8 @@ func (s *DodgingConditionTestSuite) TestTurnStartRemoval() {
 
 		// Publish turn start for different character
 		err = dnd5eEvents.TurnStartTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-			CharacterID: "other-character",
-			Round:       1,
+			SubjectID: "other-character",
+			Round:     1,
 		})
 		s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/conditions/helped.go
+++ b/rulebooks/dnd5e/conditions/helped.go
@@ -187,7 +187,7 @@ func (h *HelpedCondition) onAttackChain(
 // is removed at the start of the HELPER's next turn (not the ally's —
 // PHB p.192: "before the start of your [the helper's] next turn").
 func (h *HelpedCondition) onTurnStart(ctx context.Context, event dnd5eEvents.TurnStartEvent) error {
-	if event.CharacterID != h.HelperID {
+	if event.SubjectID != h.HelperID {
 		return nil
 	}
 

--- a/rulebooks/dnd5e/conditions/helped_test.go
+++ b/rulebooks/dnd5e/conditions/helped_test.go
@@ -151,8 +151,8 @@ func (s *HelpedConditionTestSuite) TestTurnStartRemoval_SafetyNetAtHelpersTurn()
 
 	s.Run("does not remove on the ally's own turn start", func() {
 		err = dnd5eEvents.TurnStartTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-			CharacterID: s.characterID,
-			Round:       1,
+			SubjectID: s.characterID,
+			Round:     1,
 		})
 		s.Require().NoError(err)
 		s.True(condition.IsApplied(), "the trigger is the HELPER's turn, not the ally's")
@@ -160,8 +160,8 @@ func (s *HelpedConditionTestSuite) TestTurnStartRemoval_SafetyNetAtHelpersTurn()
 
 	s.Run("removes on the helper's turn start", func() {
 		err = dnd5eEvents.TurnStartTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-			CharacterID: s.helperID,
-			Round:       1,
+			SubjectID: s.helperID,
+			Round:     1,
 		})
 		s.Require().NoError(err)
 		s.False(condition.IsApplied())

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -265,7 +265,7 @@ func (r *RagingCondition) onDamageReceived(_ context.Context, event dnd5eEvents.
 
 // onTurnEnd handles turn end events to check if rage continues
 func (r *RagingCondition) onTurnEnd(ctx context.Context, event dnd5eEvents.TurnEndEvent) error {
-	if event.CharacterID != r.CharacterID {
+	if event.SubjectID != r.CharacterID {
 		return nil
 	}
 

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -147,8 +147,8 @@ func (s *RagingConditionTestSuite) TestRagingConditionSustainsOnMissedAttack() {
 	// End the barbarian's turn.
 	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
 	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-		CharacterID: "barbarian-1",
-		Round:       1,
+		SubjectID: "barbarian-1",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 
@@ -212,8 +212,8 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsWithoutCombatActivity(
 	// Publish turn end event without any combat activity
 	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
 	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-		CharacterID: "barbarian-1",
-		Round:       1,
+		SubjectID: "barbarian-1",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 
@@ -254,8 +254,8 @@ func (s *RagingConditionTestSuite) TestRagingConditionContinuesWithCombatActivit
 	// Publish turn end event
 	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
 	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-		CharacterID: "barbarian-1",
-		Round:       1,
+		SubjectID: "barbarian-1",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 
@@ -301,8 +301,8 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsAfter10Rounds() {
 
 		// End turn
 		err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-			CharacterID: "barbarian-1",
-			Round:       round,
+			SubjectID: "barbarian-1",
+			Round:     round,
 		})
 		s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/conditions/reckless_attack.go
+++ b/rulebooks/dnd5e/conditions/reckless_attack.go
@@ -183,7 +183,7 @@ func (r *RecklessAttackCondition) onAttackChain(
 
 // onTurnStart removes the condition when the barbarian's turn starts.
 func (r *RecklessAttackCondition) onTurnStart(ctx context.Context, event dnd5eEvents.TurnStartEvent) error {
-	if event.CharacterID != r.CharacterID {
+	if event.SubjectID != r.CharacterID {
 		return nil
 	}
 

--- a/rulebooks/dnd5e/conditions/reckless_attack_test.go
+++ b/rulebooks/dnd5e/conditions/reckless_attack_test.go
@@ -254,8 +254,8 @@ func (s *RecklessAttackTestSuite) TestRemovedOnTurnStart() {
 	// Publish turn start for the barbarian
 	turnStartTopic := dnd5eEvents.TurnStartTopic.On(s.bus)
 	err = turnStartTopic.Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-		CharacterID: "barbarian-1",
-		Round:       2,
+		SubjectID: "barbarian-1",
+		Round:     2,
 	})
 	s.Require().NoError(err)
 
@@ -276,8 +276,8 @@ func (s *RecklessAttackTestSuite) TestNotRemovedOnOtherTurnStart() {
 	// Publish turn start for a different character
 	turnStartTopic := dnd5eEvents.TurnStartTopic.On(s.bus)
 	err = turnStartTopic.Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-		CharacterID: "goblin-1",
-		Round:       2,
+		SubjectID: "goblin-1",
+		Round:     2,
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/conditions/sneak_attack.go
+++ b/rulebooks/dnd5e/conditions/sneak_attack.go
@@ -163,7 +163,7 @@ func (s *SneakAttackCondition) onTurnEnd(_ context.Context, event dnd5eEvents.Tu
 	// flag every rogue dirty at the end of every turn they did not sneak
 	// attack, and a turn boundary is about to become an interaction that
 	// runs for every participant.
-	if event.CharacterID == s.CharacterID && s.UsedThisTurn {
+	if event.SubjectID == s.CharacterID && s.UsedThisTurn {
 		s.UsedThisTurn = false
 		s.markDirty()
 	}

--- a/rulebooks/dnd5e/conditions/sneak_attack_test.go
+++ b/rulebooks/dnd5e/conditions/sneak_attack_test.go
@@ -292,8 +292,8 @@ func (s *SneakAttackTestSuite) TestSneakAttackResetsOnTurnEnd() {
 	// End turn
 	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
 	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-		CharacterID: "rogue-1",
-		Round:       1,
+		SubjectID: "rogue-1",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/conditions/unconscious.go
+++ b/rulebooks/dnd5e/conditions/unconscious.go
@@ -159,7 +159,7 @@ func (c *UnconsciousCondition) loadJSON(data json.RawMessage) error {
 
 // onTurnStart handles turn start events to auto-roll death saves
 func (c *UnconsciousCondition) onTurnStart(ctx context.Context, event dnd5eEvents.TurnStartEvent) error {
-	if event.CharacterID != c.CharacterID {
+	if event.SubjectID != c.CharacterID {
 		return nil
 	}
 	if c.deathSaveState.Stabilized || c.deathSaveState.Dead {

--- a/rulebooks/dnd5e/conditions/unconscious_test.go
+++ b/rulebooks/dnd5e/conditions/unconscious_test.go
@@ -103,8 +103,8 @@ func (s *UnconsciousConditionTestSuite) TestOnTurnStart_RollsDeathSave() {
 	// Publish turn start
 	turnStartTopic := dnd5eEvents.TurnStartTopic.On(s.bus)
 	err = turnStartTopic.Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-		CharacterID: "char-1",
-		Round:       1,
+		SubjectID: "char-1",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 
@@ -133,8 +133,8 @@ func (s *UnconsciousConditionTestSuite) TestOnTurnStart_IgnoresOtherCharacters()
 	// Publish turn start for a different character - no roller mock expected
 	turnStartTopic := dnd5eEvents.TurnStartTopic.On(s.bus)
 	err = turnStartTopic.Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-		CharacterID: "char-2",
-		Round:       1,
+		SubjectID: "char-2",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 
@@ -159,8 +159,8 @@ func (s *UnconsciousConditionTestSuite) TestOnTurnStart_CriticalFail_TwoFailures
 
 	turnStartTopic := dnd5eEvents.TurnStartTopic.On(s.bus)
 	err = turnStartTopic.Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-		CharacterID: "char-1",
-		Round:       1,
+		SubjectID: "char-1",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 
@@ -206,8 +206,8 @@ func (s *UnconsciousConditionTestSuite) TestOnTurnStart_CriticalSuccess_RegainsC
 
 	turnStartTopic := dnd5eEvents.TurnStartTopic.On(s.bus)
 	err = turnStartTopic.Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-		CharacterID: "char-1",
-		Round:       1,
+		SubjectID: "char-1",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 
@@ -252,8 +252,8 @@ func (s *UnconsciousConditionTestSuite) TestOnTurnStart_ThreeFailures_Dies() {
 
 	turnStartTopic := dnd5eEvents.TurnStartTopic.On(s.bus)
 	err = turnStartTopic.Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-		CharacterID: "char-1",
-		Round:       1,
+		SubjectID: "char-1",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 
@@ -282,8 +282,8 @@ func (s *UnconsciousConditionTestSuite) TestOnTurnStart_ThreeSuccesses_Stabilize
 
 	turnStartTopic := dnd5eEvents.TurnStartTopic.On(s.bus)
 	err = turnStartTopic.Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-		CharacterID: "char-1",
-		Round:       1,
+		SubjectID: "char-1",
+		Round:     1,
 	})
 	s.Require().NoError(err)
 
@@ -520,8 +520,8 @@ func (s *UnconsciousConditionTestSuite) TestReload_NoRollerAfterReload_StillRoll
 
 	s.Require().NotPanics(func() {
 		err = dnd5eEvents.TurnStartTopic.On(freshBus).Publish(s.ctx, dnd5eEvents.TurnStartEvent{
-			CharacterID: "char-reload",
-			Round:       1,
+			SubjectID: "char-reload",
+			Round:     1,
 		})
 	}, "a nil Roller after reload must not panic")
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -580,16 +580,31 @@ func (p Position) Equals(other Position) bool {
 // Simple Events (pub/sub notifications)
 // =============================================================================
 
-// TurnStartEvent is published when a character's turn begins
+// TurnStartEvent is published when a turn begins.
+//
+// SubjectID is whoever is taking that turn — a player's character or a monster
+// the composition drove. It is named for what it denotes rather than for what
+// happens to be plugged into it today: monsters take turns, and a fight's
+// unplayed members have their turns ended several at a time inside a single
+// EndTurn (rpg-toolkit#1162), so a field called CharacterID here would be the
+// same character-shaped mistake that got gamectx.CharacterRegistry deleted —
+// "character-shaped, so it could not describe a monster at all".
+//
+// Round is which round of the fight this turn belongs to. It is a COORDINATE,
+// not a trigger: 5e measures durations in rounds but resolves every one of them
+// on a turn ("until the start of your next turn", "at the end of its turn"),
+// which is why there is no round topic beside this one and no publisher wanting
+// one. See rpg-project's ideas/session-combat/clock/design.md §3.1.
 type TurnStartEvent struct {
-	CharacterID string // ID of the character whose turn is starting
-	Round       int    // Current round number
+	SubjectID string // whoever is taking the turn that is starting
+	Round     int    // which round of the fight it belongs to
 }
 
-// TurnEndEvent is published when a character's turn ends
+// TurnEndEvent is published when a turn ends. See [TurnStartEvent] for what
+// SubjectID and Round mean and why they are named that way.
 type TurnEndEvent struct {
-	CharacterID string // ID of the character whose turn is ending
-	Round       int    // Current round number
+	SubjectID string // whoever is taking the turn that is ending
+	Round     int    // which round of the fight it belongs to
 }
 
 // DamageReceivedEvent is published when a character takes damage

--- a/rulebooks/dnd5e/integration/barbarian_encounter_test.go
+++ b/rulebooks/dnd5e/integration/barbarian_encounter_test.go
@@ -256,8 +256,8 @@ func (s *BarbarianEncounterSuite) TestRage_EndsAfter10Turns() {
 
 			// End turn
 			err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-				CharacterID: s.barbarian.GetID(),
-				Round:       round,
+				SubjectID: s.barbarian.GetID(),
+				Round:     round,
 			})
 			s.Require().NoError(err)
 
@@ -473,8 +473,8 @@ func (s *BarbarianEncounterSuite) TestEncounter_MultiTurnCombat() {
 
 		// End round 1
 		_ = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-			CharacterID: s.barbarian.GetID(),
-			Round:       1,
+			SubjectID: s.barbarian.GetID(),
+			Round:     1,
 		})
 
 		s.True(rageActive, "Rage should continue (attacked this turn)")
@@ -496,8 +496,8 @@ func (s *BarbarianEncounterSuite) TestEncounter_MultiTurnCombat() {
 		s.T().Log("─── After combat ───")
 		s.T().Log("→ With no enemies left, Grog doesn't attack")
 		_ = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-			CharacterID: s.barbarian.GetID(),
-			Round:       2,
+			SubjectID: s.barbarian.GetID(),
+			Round:     2,
 		})
 		s.False(rageActive, "Rage should end with no combat activity")
 		s.Equal("no_combat_activity", rageEndReason)

--- a/rulebooks/dnd5e/integration/rogue_encounter_test.go
+++ b/rulebooks/dnd5e/integration/rogue_encounter_test.go
@@ -427,7 +427,7 @@ func (s *RogueEncounterSuite) TestSneakAttack_ResetsOnTurnEnd() {
 
 		// End the turn
 		turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
-		err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{CharacterID: s.rogue.GetID()})
+		err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{SubjectID: s.rogue.GetID()})
 		s.Require().NoError(err)
 
 		// Next turn - sneak attack should work again


### PR DESCRIPTION
**PR 1 of 5** for rpg-project#294 — *a boundary is an interaction*. Design: KirkDiggler/rpg-project#293.

## A turn belongs to its subject

`TurnStartEvent` and `TurnEndEvent` named their subject **`CharacterID`**. Monsters take turns — `driveMonsterTurns` ends several of them inside a single `EndTurn` (#1162) — so the moment anything publishes these events, that field carries monster ids.

> *"we should be naming things for what they represent not what we currently have plugged in."* — Kirk

This is the same character-shaped defect that got `gamectx.CharacterRegistry` deleted last slice, and resolution's own doc already wrote the epitaph: *"character-shaped, so it could not describe a monster at all."* Caught this time before it bites rather than after.

## What changed

`SubjectID`, renamed with `gopls` so it is type-aware:

- Each condition's **own** `CharacterID` is untouched — a condition on a character's sheet really is a character's. Only the event's subject moves.
- `helped.go` still keys on `HelperID`, which was always the odd one and stays odd.
- The `Round` doc now says what it actually is: **a coordinate, not a trigger.** 5e measures durations in rounds and resolves every one of them on a turn (*"until the start of your next turn"*, *"at the end of its turn"*), which is why there is no round topic beside these two and nothing asking for one. Kirk ruled that explicitly — see design §3.1.

## Why this is worth a PR of its own

**No behaviour change — nothing publishes these events at all.** That is the bug the remaining four PRs fix: `TurnStartTopic`/`TurnEndTopic` are published only by `combat.TurnManager`, whose constructor has **zero call sites in the entire toolkit, tests included.** Seven conditions subscribe to them in `Apply` and none has ever fired.

Renaming first means the four PRs that follow publish into a vocabulary that already describes what it carries, instead of adding a rename to a PR that is also adding a capability.

## Evidence

`go build`, `go vet`, `go test ./...` and `golangci-lint run ./...` all clean — **0 issues**, 19 files touched.

No `Closes` keyword: #294 spans five PRs and only the last one carries it.

— platform agent, on behalf of KirkDiggler