### PR TITLE
feat(encounter): announce the boundaries the clock already crossed

### DIFF
--- a/rulebooks/dnd5e/encounter/arrival_test.go
+++ b/rulebooks/dnd5e/encounter/arrival_test.go
@@ -95,7 +95,7 @@ func (s *ArrivalSuite) arrivalEncounter(filter encounter.MemberID, walker encoun
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   arrivalField(),
 		Members: members,
 		Endings: []encounter.EndingInput{

--- a/rulebooks/dnd5e/encounter/atlas_regions_test.go
+++ b/rulebooks/dnd5e/encounter/atlas_regions_test.go
@@ -47,7 +47,7 @@ func atlasField() encounter.FieldInput {
 
 func (s *AtlasRegionsSuite) open(field encounter.FieldInput) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   field,
 		Members: []encounter.MemberInput{{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 6, Y: 4}}},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -59,7 +59,7 @@ func (s *AtlasRegionsSuite) open(field encounter.FieldInput) *encounter.Encounte
 func (s *AtlasRegionsSuite) reload(enc *encounter.Encounter) *encounter.Encounter {
 	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: enc.ToData(), Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().NoError(err)
 	return back
@@ -261,7 +261,7 @@ func (s *AtlasRegionsSuite) TestAPropMustStandOnTheFloor() {
 	field := atlasField()
 	field.Props = append(field.Props, rubble(12, 7))
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   field,
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/encounter/audience_internal_test.go
+++ b/rulebooks/dnd5e/encounter/audience_internal_test.go
@@ -27,7 +27,7 @@ import (
 // audienceFor's own contract, not any one call site's.
 func TestAudienceForPolicy(t *testing.T) {
 	enc, err := NewEncounter(&SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: FieldInput{Canvas: CanvasInput{Void: VoidIsOpaque(), Orientation: HexesArePointyTop()}, Regions: []RegionInput{rectRegion("hall", 0, 0, 6, 6)}},
 		Members: []MemberInput{
 			{ID: "zebra", Kind: KindPlayer, Position: spatial.Position{X: 0, Y: 0}},
@@ -115,7 +115,7 @@ func TestCallSiteClassification(t *testing.T) {
 	standing := &oneDown{}
 
 	enc, err := NewEncounter(&SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: standing, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: standing, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Retention: RetentionUnbounded,
 		Field: FieldInput{
 			Canvas: CanvasInput{Void: VoidIsOpaque(), Orientation: HexesArePointyTop()},

--- a/rulebooks/dnd5e/encounter/beatorder_test.go
+++ b/rulebooks/dnd5e/encounter/beatorder_test.go
@@ -81,7 +81,7 @@ func (s *BeatOrderTestSuite) beatKinds(enc *encounter.Encounter, audience encoun
 // that has not opened yet.
 func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: wallRoom(),
 		Members: []encounter.MemberInput{
 			// Both clear of the wall's span: they see each other at first light.
@@ -103,7 +103,7 @@ func (s *BeatOrderTestSuite) TestSetupOpensBeforeItFights() {
 // and the story cannot tell this step apart from any other (rpg-toolkit#1106).
 func (s *BeatOrderTestSuite) TestAStepThroughADoorwayBeforeItFights() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomWall(),
@@ -191,7 +191,7 @@ func (s *BeatOrderTestSuite) TestOpenDoorOpensBeforeItFights() {
 	const shutDoor = "shut-door"
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("near", 0, 0, 3, 3), rectRegion("far", 3, 0, 3, 3)}, Walls: seamWallExcept(2, 3, 1),
@@ -230,7 +230,7 @@ func (s *BeatOrderTestSuite) blockedScene(decider ...encounter.Decider) *encount
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: wallRoom(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 6, Y: 2}},

--- a/rulebooks/dnd5e/encounter/boundary_test.go
+++ b/rulebooks/dnd5e/encounter/boundary_test.go
@@ -1,0 +1,212 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+	"github.com/stretchr/testify/suite"
+)
+
+// journal is ONE ordered list of everything this composition did to its
+// capabilities, written by both the Announcer and the Striker.
+//
+// Two separate recorders could each be correct about their own calls and say
+// nothing about the order the two happened in — which is the only thing the
+// tests below are actually about.
+type journal struct{ entries []string }
+
+func (j *journal) add(entry string) { j.entries = append(j.entries, entry) }
+
+func (j *journal) indexOf(entry string) int {
+	for i, e := range j.entries {
+		if e == entry {
+			return i
+		}
+	}
+	return -1
+}
+
+type journalAnnouncer struct {
+	j    *journal
+	fail error
+}
+
+func (a journalAnnouncer) Announce(
+	_ context.Context, _ *encounter.Encounter, crossed []encounter.Boundary,
+) error {
+	for _, b := range crossed {
+		a.j.add(fmt.Sprintf("%s:%s:r%d", b.Kind, b.Subject, b.Round))
+	}
+	return a.fail
+}
+
+type journalStriker struct {
+	j     *journal
+	inner *scriptedStriker
+}
+
+func (s journalStriker) Strike(
+	ctx context.Context, enc *encounter.Encounter, attacker, target encounter.MemberID, action core.Ref,
+) error {
+	s.j.add("strike:" + string(attacker))
+	return s.inner.Strike(ctx, enc, attacker, target, action)
+}
+
+type BoundaryTestSuite struct {
+	suite.Suite
+}
+
+func TestBoundarySuite(t *testing.T) { suite.Run(t, new(BoundaryTestSuite)) }
+
+// adjacentFight is monsterturn_test's adjacentSkeletonEncounter with the
+// Announcer opened up, since that is what these tests are about.
+func (s *BoundaryTestSuite) adjacentFight(
+	driver encounter.TurnDriver, striker encounter.Striker, announcer encounter.Announcer,
+) (*encounter.Encounter, error) {
+	return encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
+		TurnDriver: driver, Striker: striker, Announcer: announcer,
+		Field: encounter.FieldInput{
+			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
+			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
+		},
+		Members: []encounter.MemberInput{
+			{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 2}},
+			{
+				ID: goblin, Kind: encounter.KindMonster, Position: spatial.Position{X: 3, Y: 2},
+				SpeedFeet: 30, Targeting: "closest",
+				Actions: []encounter.ActionView{
+					{Ref: testMeleeAction, Name: "Shortsword", RangeFeet: 5, Kind: "melee"},
+				},
+			},
+		},
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+}
+
+// TestADrivenMemberHearsItsTurnStartBeforeItSwings is the whole reason
+// Announcer is a capability instead of another field on EndTurnOutput.
+//
+// EndTurn drives every consecutive unplayed member forward INSIDE ONE CALL
+// (rpg-toolkit#1162), and those members attack during the drive. Boundaries
+// merely returned and published by the caller afterwards would put this
+// monster's turn-start after the swing it had already made.
+//
+// Nothing on a monster's sheet subscribes to a turn boundary today, so this
+// ordering is currently invisible in behaviour — which is exactly why it is
+// asserted directly rather than through an effect.
+func (s *BoundaryTestSuite) TestADrivenMemberHearsItsTurnStartBeforeItSwings() {
+	j := &journal{}
+	driver := &scriptedDriver{intents: []encounter.TurnIntent{
+		encounter.Attack{Target: alice, Action: testMeleeAction},
+	}}
+	striker := journalStriker{j: j, inner: &scriptedStriker{kind: encounter.OutcomeMissed}}
+	enc, err := s.adjacentFight(driver, striker, journalAnnouncer{j: j})
+	s.Require().NoError(err)
+
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	started := j.indexOf("turn_started:goblin:r1")
+	swung := j.indexOf("strike:goblin")
+	s.Require().NotEqual(-1, started, "the goblin's turn-start was never announced: %v", j.entries)
+	s.Require().NotEqual(-1, swung, "the goblin never swung: %v", j.entries)
+	s.Less(started, swung,
+		"a driven member must hear its turn start BEFORE it acts, not after: %v", j.entries)
+}
+
+// TestAFightsFirstTurnIsAnnounced closes a gap that existed for as long as
+// this composition has: SetOrder has always returned TurnStarted for whoever
+// won initiative, and form has always dropped it. Every fight's first turn
+// began with nothing said.
+func (s *BoundaryTestSuite) TestAFightsFirstTurnIsAnnounced() {
+	j := &journal{}
+	_, err := s.adjacentFight(
+		passDriver{}, &scriptedStriker{kind: encounter.OutcomeMissed}, journalAnnouncer{j: j})
+	s.Require().NoError(err)
+
+	s.Contains(j.entries, "turn_started:alice:r1",
+		"forming a fight must announce its first turn: %v", j.entries)
+}
+
+// TestTheRoundAdvancesWithoutARoundBoundary pins Kirk's 2026-08-27 ruling
+// structurally rather than by absence: no round boundary is published, AND the
+// round advancing is still visible — on the next turn boundary, which is where
+// the information already lived.
+func (s *BoundaryTestSuite) TestTheRoundAdvancesWithoutARoundBoundary() {
+	j := &journal{}
+	enc, err := s.adjacentFight(
+		passDriver{}, &scriptedStriker{kind: encounter.OutcomeMissed}, journalAnnouncer{j: j})
+	s.Require().NoError(err)
+
+	// alice ends; the goblin is driven and passes; the order wraps back.
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	for _, e := range j.entries {
+		s.NotContains(e, "round_", "no round boundary is published: %v", j.entries)
+	}
+	s.Contains(j.entries, "turn_started:alice:r2",
+		"the wrap must still be visible, as a changed Round on the next turn boundary: %v", j.entries)
+}
+
+// TestAnnouncerIsRequiredAtBothConstructors — supplied, never defaulted
+// (rpg-toolkit#1033). A nil one is not "boundaries are off"; it is every
+// turn-scoped condition living forever, silently, which is the defect this
+// capability was introduced to end.
+func (s *BoundaryTestSuite) TestAnnouncerIsRequiredAtBothConstructors() {
+	_, err := s.adjacentFight(passDriver{}, passStriker{}, nil)
+	s.Require().ErrorIs(err, encounter.ErrNoAnnouncer)
+
+	enc, err := s.adjacentFight(passDriver{}, passStriker{}, quietAnnouncer{})
+	s.Require().NoError(err)
+
+	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data: enc.ToData(), Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+	})
+	s.Require().ErrorIs(err, encounter.ErrNoAnnouncer,
+		"a blob that comes back without one is as unusable as a Setup without one")
+}
+
+// TestRefusingAnnouncerNamesTheHostBug — the twin of RefusingStriker, and
+// deliberately NOT a no-op: a silently-succeeding default is indistinguishable
+// from a boundary nobody published, which is the thing being fixed.
+func (s *BoundaryTestSuite) TestRefusingAnnouncerNamesTheHostBug() {
+	err := encounter.RefusingAnnouncer{}.Announce(context.Background(), nil, []encounter.Boundary{
+		{Kind: encounter.TurnEnded, Subject: alice, Round: 1},
+	})
+	s.Require().ErrorIs(err, encounter.ErrRefusingAnnouncer)
+}
+
+// TestAnnouncerFailureAbortsTheVerb — an announcer malfunction is a
+// TurnDriver/Striker-class failure: the caller's whole verb fails, and since
+// nothing is saved until the caller's own commit, it costs the retry and
+// nothing else.
+func (s *BoundaryTestSuite) TestAnnouncerFailureAbortsTheVerb() {
+	boom := errors.New("announcer exploded")
+	j := &journal{}
+	enc, err := s.adjacentFight(
+		passDriver{}, &scriptedStriker{kind: encounter.OutcomeMissed}, quietAnnouncer{})
+	s.Require().NoError(err)
+
+	// Reload the same world with an announcer that fails, so construction
+	// itself is not the thing under test.
+	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
+		Data: enc.ToData(), Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Announcer: journalAnnouncer{j: j, fail: boom},
+	})
+	s.Require().NoError(err)
+
+	_, err = reloaded.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().ErrorIs(err, boom, "an announcer malfunction aborts the caller's verb")
+}

--- a/rulebooks/dnd5e/encounter/boundary_test.go
+++ b/rulebooks/dnd5e/encounter/boundary_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/core"
@@ -71,6 +72,30 @@ func TestBoundarySuite(t *testing.T) { suite.Run(t, new(BoundaryTestSuite)) }
 func (s *BoundaryTestSuite) adjacentFight(
 	driver encounter.TurnDriver, striker encounter.Striker, announcer encounter.Announcer,
 ) (*encounter.Encounter, error) {
+	return s.fightWithMonsters(driver, striker, announcer, goblin)
+}
+
+// fightWithMonsters puts alice and every named monster shoulder to shoulder in
+// one room, in the order given — so TWO monsters after alice really are driven
+// back to back inside a single EndTurn, which is the case
+// driveOneMonsterTurn's own announce exists for.
+func (s *BoundaryTestSuite) fightWithMonsters(
+	driver encounter.TurnDriver, striker encounter.Striker, announcer encounter.Announcer,
+	monsters ...core.EntityID,
+) (*encounter.Encounter, error) {
+	members := []encounter.MemberInput{
+		{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 2}},
+	}
+	for i, id := range monsters {
+		members = append(members, encounter.MemberInput{
+			ID: id, Kind: encounter.KindMonster,
+			Position:  spatial.Position{X: float64(3 + i), Y: 2},
+			SpeedFeet: 30, Targeting: "closest",
+			Actions: []encounter.ActionView{
+				{Ref: testMeleeAction, Name: "Shortsword", RangeFeet: 5, Kind: "melee"},
+			},
+		})
+	}
 	return encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
 		TurnDriver: driver, Striker: striker, Announcer: announcer,
@@ -78,16 +103,7 @@ func (s *BoundaryTestSuite) adjacentFight(
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
 		},
-		Members: []encounter.MemberInput{
-			{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 2}},
-			{
-				ID: goblin, Kind: encounter.KindMonster, Position: spatial.Position{X: 3, Y: 2},
-				SpeedFeet: 30, Targeting: "closest",
-				Actions: []encounter.ActionView{
-					{Ref: testMeleeAction, Name: "Shortsword", RangeFeet: 5, Kind: "melee"},
-				},
-			},
-		},
+		Members: members,
 		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
 	})
 }
@@ -121,6 +137,67 @@ func (s *BoundaryTestSuite) TestADrivenMemberHearsItsTurnStartBeforeItSwings() {
 	s.Require().NotEqual(-1, swung, "the goblin never swung: %v", j.entries)
 	s.Less(started, swung,
 		"a driven member must hear its turn start BEFORE it acts, not after: %v", j.entries)
+}
+
+// TestTheSECONDDrivenMemberAlsoHearsItsTurnStartFirst is the test the one
+// above could not be.
+//
+// With a single monster after alice, that monster's turn-start is announced by
+// ALICE's EndTurn — driveOneMonsterTurn's own announce never enters into it. A
+// mutant that deleted the announce from the drive loop entirely left the test
+// above passing, which is the whole reason this one exists.
+//
+// Two consecutive unplayed members is the real case: gob1's turn ends and
+// gob2's begins INSIDE the drive loop, with nobody's EndTurn in between. If
+// that crossing is not announced where it happens, gob2 swings before anything
+// says its turn started.
+func (s *BoundaryTestSuite) TestTheSECONDDrivenMemberAlsoHearsItsTurnStartFirst() {
+	j := &journal{}
+	striker := journalStriker{j: j, inner: &scriptedStriker{kind: encounter.OutcomeMissed}}
+	enc, err := s.fightWithMonsters(
+		killEveryoneStandingDriver{action: testMeleeAction}, striker, journalAnnouncer{j: j},
+		goblin, bob)
+	s.Require().NoError(err)
+
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	// WHO is driven second is initiative's business, not this test's, so it
+	// is derived rather than assumed — the observed order here is
+	// [alice, bob, goblin], and hardcoding that would make this test about
+	// orderAsGiven instead of about announcement.
+	var drivenOrder []string
+	for _, e := range j.entries {
+		if id, ok := strings.CutPrefix(e, "turn_started:"); ok {
+			id = strings.Split(id, ":")[0]
+			if id != string(alice) {
+				drivenOrder = append(drivenOrder, id)
+			}
+		}
+	}
+	s.Require().Len(drivenOrder, 2, "both monsters must have had a turn announced: %v", j.entries)
+	first, second := drivenOrder[0], drivenOrder[1]
+
+	// The crossing INSIDE the drive loop: the first driven member's turn ends
+	// and the second's begins with nobody's EndTurn in between. This is the
+	// pair that driveOneMonsterTurn's own announce is responsible for, and the
+	// pair a mutant that deletes it destroys.
+	s.Less(j.indexOf("turn_ended:"+first+":r1"), j.indexOf("turn_started:"+second+":r1"),
+		"boundaries arrive in causal order: %v", j.entries)
+	s.Less(j.indexOf("turn_started:"+second+":r1"), j.indexOf("strike:"+second),
+		"the second driven member must hear its turn start BEFORE it acts: %v", j.entries)
+
+	// And the invariant in general: nobody swings before their turn is
+	// announced, whoever they are.
+	for i, e := range j.entries {
+		id, ok := strings.CutPrefix(e, "strike:")
+		if !ok {
+			continue
+		}
+		started := j.indexOf("turn_started:" + id + ":r1")
+		s.Require().NotEqual(-1, started, "%s swung with no turn-start at all: %v", id, j.entries)
+		s.Less(started, i, "%s swung before its turn was announced: %v", id, j.entries)
+	}
 }
 
 // TestAFightsFirstTurnIsAnnounced closes a gap that existed for as long as

--- a/rulebooks/dnd5e/encounter/canvas_test.go
+++ b/rulebooks/dnd5e/encounter/canvas_test.go
@@ -153,7 +153,7 @@ func tombProp(origin spatial.Position, x, y int) encounter.PropInput {
 // them. Nothing about rooms can tell them apart.
 func (s *CanvasSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: tombSeat(tombEntranceOrigin, 5, tombDoorRow)},
@@ -307,7 +307,7 @@ func TestAnOldDialectBlobIsRefusedByName(t *testing.T) {
 		"the old blob still PARSES — that is exactly why the refusal has to be by name")
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data,
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data,
 	})
 	require.Error(t, err, "a room-chain blob must not load as a region one")
 	require.ErrorIs(t, err, encounter.ErrInvalidData)
@@ -323,7 +323,7 @@ func TestAnOldDialectBlobIsRefusedByName(t *testing.T) {
 // painted.
 func TestAFieldAlwaysFitsOneGrid(t *testing.T) {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("crypt", -20, -20, 6, 6)},
@@ -352,7 +352,7 @@ func TestPropsAreCompiledThroughTheOneConversion(t *testing.T) {
 	field.Props = wallColumn(int(tombHallOrigin.X)+5, int(tombHallOrigin.Y)+2, int(tombHallOrigin.Y)+4)
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: tombSeat(tombHallOrigin, 3, 3)},
@@ -377,7 +377,7 @@ func TestPropsAreCompiledThroughTheOneConversion(t *testing.T) {
 func TestAWallThatCannotBeDrawnIsRefusedAtConstruction(t *testing.T) {
 	setup := func(b spatial.Boundary) *encounter.SetupInput {
 		return &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("hall", 4, 4, 6, 6)}, Walls: []encounter.WallInput{{Boundary: b}},

--- a/rulebooks/dnd5e/encounter/canvasread_test.go
+++ b/rulebooks/dnd5e/encounter/canvasread_test.go
@@ -57,7 +57,7 @@ func TestCanvasReadSuite(t *testing.T) {
 // point: a map with nothing in the way agrees with any other map.
 func (s *CanvasReadSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: tombSeat(tombEntranceOrigin, 5, tombDoorRow)},

--- a/rulebooks/dnd5e/encounter/chase_test.go
+++ b/rulebooks/dnd5e/encounter/chase_test.go
@@ -56,7 +56,7 @@ func TestVaultChase(t *testing.T) {
 	// composition's room-shaped topology (rpg-toolkit#1044).
 	pursuit := &pursuitDecider{target: alice}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(corridorRoom, 0, 0, 10, 10), rectRegion(vaultRoom, 10, 0, 10, 10)}, Walls: corridorWall,
@@ -122,7 +122,7 @@ func TestVaultChase(t *testing.T) {
 	// INTEL does — beliefs are state and traveled in the aggregate).
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &pursuitDecider{doorways: atlas.Doorways, target: alice},
 		}})
 	require.NoError(t, err, "beat 3: the suspended chase crosses a process boundary")

--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -458,7 +458,67 @@ func (e *Encounter) driveOneMonsterTurn(
 	if berr != nil {
 		return 0, false, fmt.Errorf("append beat: %w", berr)
 	}
+
+	// ANNOUNCE HERE, not from the caller once the whole drive is done. This
+	// call has just ended one driven member's turn and the clock has already
+	// named the next; the loop above will drive that member NEXT. Announcing
+	// from out there would publish this member's turn-end and the next one's
+	// turn-start after the next one had already swung — the exact ordering
+	// [Announcer]'s own doc exists to explain.
+	if aerr := e.announce(out.Milestones); aerr != nil {
+		return 0, false, fmt.Errorf("announce: %w", aerr)
+	}
 	return seq, out.RoundWrapped, nil
+}
+
+// boundariesFrom translates the leaf's milestones into this composition's own
+// vocabulary, keeping the two kinds anything publishes.
+//
+// clock.RoundStarted translates to NOTHING, and loses nothing: clock.Turn.End
+// increments the round before stamping the TurnStarted that follows a wrap, so
+// the round advancing is already visible as a changed Round on the next turn
+// boundary. See [BoundaryKind] for why there is no round boundary at all.
+//
+// Anything else the leaf may grow — Ticked, MemberJoined, Merged — is skipped
+// rather than mapped, so a new milestone kind cannot silently become a boundary
+// nobody decided to publish.
+func boundariesFrom(ms []clock.Milestone) []Boundary {
+	crossed := make([]Boundary, 0, len(ms))
+	for _, m := range ms {
+		var kind BoundaryKind
+		switch m.Kind {
+		case clock.TurnStarted:
+			kind = TurnStarted
+		case clock.TurnEnded:
+			kind = TurnEnded
+		default:
+			continue
+		}
+		crossed = append(crossed, Boundary{
+			Kind:    kind,
+			Subject: MemberID(m.Subject),
+			Round:   m.Round,
+		})
+	}
+	return crossed
+}
+
+// announce hands one clock advance's boundaries to the Announcer capability,
+// at the moment they were crossed.
+//
+// context.Background() for the reason Strike below already uses it: this
+// module's verbs take no context.Context, and threading one through every clock
+// verb to reach here is a wider change than this slice asks for.
+//
+// An empty set is not announced. That is not an optimization — an advance that
+// crossed nothing is not an event, and calling a capability to tell it nothing
+// happened is how a capability learns to ignore its argument.
+func (e *Encounter) announce(ms []clock.Milestone) error {
+	crossed := boundariesFrom(ms)
+	if len(crossed) == 0 {
+		return nil
+	}
+	return e.announcer.Announce(context.Background(), e, crossed)
 }
 
 // executeTurnIntent runs one Act call's answer and reports whether this
@@ -927,7 +987,8 @@ func (e *Encounter) form(in *FormInput) (*FormOutput, error) {
 		}
 	}
 	bubble := &clock.Turn{}
-	if _, serr := bubble.SetOrder(&clock.SetOrderInput{Order: in.Order}); serr != nil {
+	formed, serr := bubble.SetOrder(&clock.SetOrderInput{Order: in.Order})
+	if serr != nil {
 		return nil, fmt.Errorf("form set order: %w", serr)
 	}
 	e.bubbles = append(e.bubbles, bubble)
@@ -945,6 +1006,16 @@ func (e *Encounter) form(in *FormInput) (*FormOutput, error) {
 	seq, err := e.appendClockBeat(beat, in.Order...)
 	if err != nil {
 		return nil, fmt.Errorf("form append beat: %w", err)
+	}
+
+	// The first turn of the fight starts here, and until this line nothing
+	// ever said so: SetOrder has always returned TurnStarted for whoever won
+	// initiative, and this composition has always dropped it. A condition
+	// carried into the fight — one applied while exploring — would wait for a
+	// turn-start that only arrived after somebody else's turn had already
+	// ended.
+	if aerr := e.announce(formed.Milestones); aerr != nil {
+		return nil, fmt.Errorf("form announce: %w", aerr)
 	}
 
 	// If initiative rolled an unplayed member first, nobody has reached this
@@ -1211,6 +1282,12 @@ func (e *Encounter) EndTurn(in *EndTurnInput) (*EndTurnOutput, error) {
 	}, order...)
 	if err != nil {
 		return nil, fmt.Errorf("end turn append beat: %w", err)
+	}
+
+	// The caller's own turn end, announced BEFORE any unplayed member is
+	// driven below — same ordering rule as driveOneMonsterTurn's.
+	if aerr := e.announce(out.Milestones); aerr != nil {
+		return nil, fmt.Errorf("end turn %q: announce: %w", in.Member, aerr)
 	}
 
 	next := MemberID(out.Next)

--- a/rulebooks/dnd5e/encounter/clocks_internal_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_internal_test.go
@@ -28,7 +28,7 @@ import (
 // save. With it, the defect is loud: ErrInvalidData, never a guess.
 func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 	enc, err := NewEncounter(&SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: FieldInput{
 			Canvas:  CanvasInput{Void: VoidIsOpaque(), Orientation: HexesArePointyTop()},
 			Regions: []RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
@@ -72,7 +72,7 @@ func TestClockOfReportsAMemberOnNoClockInsteadOfGuessing(t *testing.T) {
 func TestFormRejections(t *testing.T) {
 	newEnc := func() *Encounter {
 		enc, err := NewEncounter(&SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: FieldInput{Canvas: CanvasInput{Void: VoidIsOpaque(), Orientation: HexesArePointyTop()}, Regions: []RegionInput{rectRegion("r1", 0, 0, 8, 8), rectRegion("r2", 8, 0, 8, 8)}, Walls: sealedSeam(7, 8)},
 			Members: []MemberInput{
 				{ID: "alice", Kind: KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
@@ -185,7 +185,7 @@ func sealedSeam(atX, height int) []WallInput {
 // form directly, the same white-box reason TestFormRejections does.
 func TestFormRefusesAPlayerFreeBubble(t *testing.T) {
 	enc, err := NewEncounter(&SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: FieldInput{Canvas: CanvasInput{Void: VoidIsOpaque(), Orientation: HexesArePointyTop()}, Regions: []RegionInput{rectRegion("r1", 0, 0, 8, 8)}},
 		Members: []MemberInput{
 			{ID: "goblin", Kind: KindMonster, Position: spatial.Position{X: 1, Y: 1}},
@@ -225,7 +225,7 @@ func (rogueDriver) Act(MonsterView) (TurnIntent, error) {
 func TestADriverReturningAnUnrecognisedIntentIsErrBadTurnOutcome(t *testing.T) {
 	enc, err := NewEncounter(&SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		TurnDriver: rogueDriver{}, Striker: passStriker{},
+		TurnDriver: rogueDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: FieldInput{
 			Canvas:  CanvasInput{Void: VoidIsOpaque(), Orientation: HexesArePointyTop()},
 			Regions: []RegionInput{rectRegion("room-1", 0, 0, 8, 8)},

--- a/rulebooks/dnd5e/encounter/clocks_test.go
+++ b/rulebooks/dnd5e/encounter/clocks_test.go
@@ -26,7 +26,7 @@ type ClocksTestSuite struct {
 // monster in one room.
 func (s *ClocksTestSuite) twoMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			// The goblin waits in the NEXT ROOM, which is how real content is
@@ -136,7 +136,7 @@ func (s *ClocksTestSuite) TestABubbleRoundTripsAndIsReachedThroughItsMembers() {
 	}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().NoError(err)
 
 	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -190,7 +190,7 @@ func (s *ClocksTestSuite) TestAMemberOutsideTheFightKeepsFreeRoamingWhileItRuns(
 	}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().NoError(err)
 
 	fighting, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -224,7 +224,7 @@ func (s *ClocksTestSuite) TestMutatingTheReturnedOrderCannotCorruptTheEncounter(
 	data.Bubbles = []clock.TurnData{{Order: []core.EntityID{goblin, alice}, ActiveIdx: 0, Round: 1}}
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().NoError(err)
 
 	out, err := reloaded.ClockOf(&encounter.ClockOfInput{Member: alice})
@@ -248,7 +248,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAMemberOnTwoClocks() {
 		data.Bubbles = []clock.TurnData{{Order: []core.EntityID{goblin, alice}, ActiveIdx: 0, Round: 1}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -264,7 +264,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAMemberOnTwoClocks() {
 		}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -290,7 +290,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		data.Clock.Budgets["ghost"] = 0
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -304,7 +304,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -317,7 +317,7 @@ func (s *ClocksTestSuite) TestLoadRejectsANonMemberOnAClock() {
 		}}
 
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 		s.Require().Error(err)
 		s.ErrorIs(err, encounter.ErrInvalidData)
 	})
@@ -337,7 +337,7 @@ func (s *ClocksTestSuite) TestABlobFromBeforeClockMembershipLoadsEveryoneOntoThe
 	data.Bubbles = nil
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().NoError(err)
 
 	for _, id := range []core.EntityID{alice, goblin} {
@@ -363,7 +363,7 @@ const (
 // monster in one room, plus an external ending so closure is reachable.
 func (s *ClocksTestSuite) fiveMemberEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -406,7 +406,7 @@ func (s *ClocksTestSuite) assertR6(enc *encounter.Encounter, members ...core.Ent
 		s.Require().NoError(err, "member %q must be on exactly one clock", id)
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: enc.ToData()})
 	s.Require().NoError(err, "the persisted shape must pass the trust boundary (R6)")
 }
 
@@ -710,7 +710,7 @@ func (s *ClocksTestSuite) TestTheActiveFightMemberCanStep() {
 func (s *ClocksTestSuite) TestPumpDoesNotThinkForAFightMonster() {
 	wanderer := &patrolDecider{positions: []spatial.Position{{X: 5, Y: 5}, {X: 6, Y: 5}}}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -783,7 +783,7 @@ func (s *ClocksTestSuite) TestLoadRejectsAnIdleBubble() {
 	data.Bubbles = []clock.TurnData{{}}
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().Error(err)
 	s.ErrorIs(err, encounter.ErrInvalidData)
 }
@@ -803,7 +803,7 @@ func (s *ClocksTestSuite) TestAMidFightBlobRoundTrips() {
 	enc := s.fiveMemberEncounter()
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	// Reached through a member of the fight — bob is exploring next door.
@@ -901,7 +901,7 @@ func (r monstersBeforePlayers) RollInitiative(members []core.EntityID) ([]core.E
 // EndTurn (see form's own doc).
 func (s *ClocksTestSuite) TestFightStartDrivesAnUnplayedMemberFirstInInitiative() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Initiative: monstersBeforePlayers{kinds: map[core.EntityID]encounter.MemberKind{
 			alice: encounter.KindPlayer, goblin: encounter.KindMonster,
 		}},

--- a/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
+++ b/rulebooks/dnd5e/encounter/cmd/freeroam-workbench/main.go
@@ -107,7 +107,7 @@ func solidPillar(x, y float64) encounter.PropInput {
 func dungeonSetup() *encounter.SetupInput {
 	return &encounter.SetupInput{
 		Sight: torchAndDarkvision{}, Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{},
-		TurnDriver: encounter.PassDriver{}, Striker: noAttacksExpected{},
+		TurnDriver: encounter.PassDriver{}, Striker: noAttacksExpected{}, Announcer: nobodyIsListening{},
 		Field: encounter.FieldInput{
 			// You cannot see across the space the crypt's two regions do not
 			// cover — the fiction is the mountain they were cut from, and the
@@ -585,7 +585,7 @@ func main() {
 				continue
 			}
 			loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Sight: torchAndDarkvision{}, Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{}, TurnDriver: encounter.PassDriver{}, Striker: noAttacksExpected{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+				Sight: torchAndDarkvision{}, Standing: rollAllStanding{}, Initiative: rollOrderAsGiven{}, TurnDriver: encounter.PassDriver{}, Striker: noAttacksExpected{}, Announcer: nobodyIsListening{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 					"goblin": goblinPatrol(),
 				}})
 			if err != nil {
@@ -649,6 +649,18 @@ type rollAllStanding struct{}
 
 func (rollAllStanding) Standing([]encounter.MemberID) ([]encounter.MemberID, error) {
 	return nil, nil
+}
+
+// nobodyIsListening is the workbench's Announcer capability. The workbench
+// drives clocks — turns end here — so unlike noAttacksExpected this really is
+// called. It succeeds silently: there is no rulebook attached to this scene,
+// so there is nothing a turn boundary could mean to anything in it.
+type nobodyIsListening struct{}
+
+func (nobodyIsListening) Announce(
+	context.Context, *encounter.Encounter, []encounter.Boundary,
+) error {
+	return nil
 }
 
 // noAttacksExpected is the workbench's Striker capability. The workbench

--- a/rulebooks/dnd5e/encounter/continuity_test.go
+++ b/rulebooks/dnd5e/encounter/continuity_test.go
@@ -129,7 +129,7 @@ func vaultChaseHexSetup() *encounter.SetupInput {
 	}
 	pursuit := &pursuitDecider{doorways: doorwaysFrom(field), target: alice}
 	return &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 6, Y: 5}},
@@ -346,7 +346,7 @@ func TestVaultChaseAbsoluteContinuity(t *testing.T) {
 	beforeReload := alicePath[len(alicePath)-1]
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &pursuitDecider{doorways: doorwaysFrom(vaultChaseHexSetup().Field), target: alice},
 		}})
 	require.NoError(t, err, "the suspended chase crosses a process boundary")

--- a/rulebooks/dnd5e/encounter/data.go
+++ b/rulebooks/dnd5e/encounter/data.go
@@ -645,6 +645,14 @@ type LoadEncounterInput struct {
 	// reconstituted. Refused at the door, never guarded at the use site, and
 	// never defaulted.
 	Striker Striker
+
+	// Announcer publishes the temporal boundaries a clock advance crossed.
+	// REQUIRED, exactly as it is on SetupInput and for the same reason: a
+	// loaded encounter's clock can advance the moment it is reconstituted,
+	// and a boundary nobody announced is a turn-scoped condition that never
+	// expires. Refused at the door, never guarded at the use site, and never
+	// defaulted.
+	Announcer Announcer
 }
 
 // Validate reports whether the input is usable. It checks only the input's own
@@ -673,6 +681,10 @@ func (in *LoadEncounterInput) Validate() error {
 	}
 	if in.Striker == nil {
 		return fmt.Errorf("load encounter: Striker is required: %w", ErrNoStriker)
+	}
+
+	if in.Announcer == nil {
+		return fmt.Errorf("load encounter: Announcer is required: %w", ErrNoAnnouncer)
 	}
 
 	return nil
@@ -1023,6 +1035,7 @@ func LoadEncounter(input *LoadEncounterInput) (*Encounter, error) {
 		sight:       input.Sight,
 		turnDriver:  input.TurnDriver,
 		striker:     input.Striker,
+		announcer:   input.Announcer,
 		endings:     nil,
 		retention:   normalizeRetention(data.Retention),
 		logFloor:    logFloorOf(data.Log),

--- a/rulebooks/dnd5e/encounter/data_test.go
+++ b/rulebooks/dnd5e/encounter/data_test.go
@@ -72,7 +72,7 @@ type DataTestSuite struct {
 // for g1's pass, and next_seq incremented to match.
 func (s *DataTestSuite) TestGoldenJSONRich() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{
@@ -125,7 +125,7 @@ func (s *DataTestSuite) TestGoldenJSONRich() {
 // ending order changes which outcome the campaign receives.
 func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion("r1", 0, 0, 5, 5)}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
@@ -138,7 +138,7 @@ func (s *DataTestSuite) TestEndingsOrderSurvivesReload() {
 	enc1, err := encounter.NewEncounter(setup)
 	s.Require().NoError(err)
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc1.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: enc1.ToData()})
 	s.Require().NoError(err)
 
 	out, err := enc2.Step(&encounter.StepInput{Member: "p1", To: cellAt(3, 3)})
@@ -174,7 +174,7 @@ func (s *DataTestSuite) TestWallHeightSurvivesPersistenceAndAtlas() {
 	raised := wall(4, 1, 5, 1)
 	raised.Height = 2.5
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("r1", 0, 1, 5, 5), rectRegion("r2", 5, 0, 5, 5)},
@@ -201,7 +201,7 @@ func (s *DataTestSuite) TestWallHeightSurvivesPersistenceAndAtlas() {
 	s.ElementsMatch([]float64{2.5, 0}, heights(enc), "the atlas carries the authored multiplier, and 0 where none was authored")
 
 	loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Data: enc.ToData(),
 	})
 	s.Require().NoError(err)
@@ -210,7 +210,7 @@ func (s *DataTestSuite) TestWallHeightSurvivesPersistenceAndAtlas() {
 
 func (s *DataTestSuite) TestSetupInputNotAliased() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("r1", 0, 1, 5, 5), rectRegion("r2", 5, 0, 5, 5)},
@@ -242,7 +242,7 @@ func (s *DataTestSuite) TestSetupInputNotAliased() {
 	// And the corrupted-input snapshot must still LOAD (the M4 symptom
 	// was an encounter that became permanently unsavable).
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().NoError(err)
 }
 
@@ -266,7 +266,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 	s.Run("post-setup open encounter survives round-trip", func() {
 		// Create a simple encounter
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)}, Props: wallColumn(5, 3, 7), Walls: []encounter.WallInput{{Boundary: spatial.Boundary{
@@ -305,7 +305,7 @@ func (s *DataTestSuite) TestRoundTripPostSetup() {
 
 		// Load from data (without decider for goblin)
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Convert to data again
@@ -326,7 +326,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 	s.Run("mid-fade ghost survives reload still Held", func() {
 		// Create encounter with a wall that will cause a ghost to form
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)},
@@ -387,7 +387,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 
 		// Load and verify ghost is still there
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Get holdings - ghost should still be Held (not Current)
@@ -412,7 +412,7 @@ func (s *DataTestSuite) TestRoundTripMidFade() {
 func (s *DataTestSuite) TestRoundTripPostExit() {
 	s.Run("exited member persists in everMembers and can Story", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)},
@@ -450,7 +450,7 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 
 		// Load and verify everMembers includes the exited player
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Story should work for the exited member
@@ -465,7 +465,7 @@ func (s *DataTestSuite) TestRoundTripPostExit() {
 func (s *DataTestSuite) TestRoundTripClosed() {
 	s.Run("closed encounter with ending outcome round-trips", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)},
@@ -511,7 +511,7 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 
 		// Load and verify outcome matches
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		status2, _ := enc2.Status()
@@ -527,7 +527,7 @@ func (s *DataTestSuite) TestRoundTripClosed() {
 func (s *DataTestSuite) TestPumpContinuesTick() {
 	s.Run("Pump continues tick sequence post-reload", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)},
@@ -568,7 +568,7 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 		s.Require().Equal(2, data1.Clock.HighWater, "precondition: two ticks persisted")
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data1})
 		s.Require().NoError(err)
 
 		out, err := enc2.Pump(&encounter.PumpInput{})
@@ -581,7 +581,7 @@ func (s *DataTestSuite) TestPumpContinuesTick() {
 func (s *DataTestSuite) TestMoveWorksPostReload() {
 	s.Run("Move works on reloaded encounter", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)},
@@ -615,7 +615,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 
 		// Load
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Move should work
@@ -634,7 +634,7 @@ func (s *DataTestSuite) TestMoveWorksPostReload() {
 func (s *DataTestSuite) TestGoldenJSONOpen() {
 	s.Run("small open encounter golden JSON", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
@@ -675,7 +675,7 @@ func (s *DataTestSuite) TestGoldenJSONOpen() {
 func (s *DataTestSuite) TestGoldenJSONClosed() {
 	s.Run("small closed encounter golden JSON", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
@@ -739,7 +739,7 @@ func (s *DataTestSuite) TestGoldenJSONClosed() {
 func (s *DataTestSuite) TestAliasImmunityToData() {
 	s.Run("mutating ToData result doesn't affect aggregate", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
@@ -800,7 +800,7 @@ func (s *DataTestSuite) TestAliasImmunityToData() {
 func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 	s.Run("mutating caller's Data after LoadEncounter doesn't affect loaded aggregate", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
@@ -828,7 +828,7 @@ func (s *DataTestSuite) TestAliasImmunityLoadEncounter() {
 		// Load FIRST, then vandalize the caller's Data: the loaded
 		// aggregate must be untouched (load-side deep copy).
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 		s.Require().NoError(err)
 
 		data.Members[0].ID = "mutated"
@@ -856,7 +856,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		// persisted holding says Held (a ghost). A load that re-runs
 		// first-light surveil would resurrect it to Current.
 		enc1, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)}},
 			Members: []encounter.MemberInput{
 				{ID: "playerA", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
@@ -877,7 +877,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 		data.Intel.Holdings["playerA"]["goblin"] = holding
 
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 		s.Require().NoError(err)
 
 		view, err := enc2.View(&encounter.ViewInput{Member: "playerA"})
@@ -890,7 +890,7 @@ func (s *DataTestSuite) TestNoSurveilOnLoad() {
 func (s *DataTestSuite) TestDeciderReattachment() {
 	s.Run("reload with decider resumes monster decision", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)},
@@ -935,7 +935,7 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 			},
 		}
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 				encounter.MemberID("goblin"): decider,
 			}})
 		s.Require().NoError(err)
@@ -955,7 +955,7 @@ func (s *DataTestSuite) TestDeciderReattachment() {
 func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 	s.Run("reload without decider makes monster hold", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)},
@@ -995,7 +995,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 
 		// Load WITHOUT goblin's decider
 		enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		s.Require().NoError(err)
 
 		// Pump should succeed (goblin holds)
@@ -1015,7 +1015,7 @@ func (s *DataTestSuite) TestDeciderReattachmentWithoutDecider() {
 // nil entry is equivalent to an absent one: the monster simply holds.
 func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)},
@@ -1033,7 +1033,7 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 	data1 := enc1.ToData()
 
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 			"goblin": nil,
 		}})
 	s.Require().NoError(err, "a present-but-nil reattachment entry must load, not reject")
@@ -1050,7 +1050,7 @@ func (s *DataTestSuite) TestDeciderReattachmentNilEntryHolds() {
 // same reattachment map: the real one decides normally, the nil one holds.
 func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10), rectRegion("antechamber", 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -1071,7 +1071,7 @@ func (s *DataTestSuite) TestDeciderReattachmentMixedNilAndReal() {
 
 	ratDecider := &testDecider{intent: encounter.IntentMoveTo{To: cellAt(3, 8)}}
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{
 			"goblin": nil,
 			"rat":    ratDecider,
 		}})
@@ -1170,7 +1170,7 @@ func (s *DataTestSuite) TestLoadNilInputRejected() {
 // call sites, so it is stated once rather than left implied by them.
 func (s *DataTestSuite) TestLoadNilDecidersIsLegal() {
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Data: validEncounterData(),
 	})
 	s.Require().NoError(err)
@@ -1190,7 +1190,7 @@ func (s *DataTestSuite) TestLoadPropOnBoundaryCellAccepted() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().NoError(err, "a prop on a room's boundary cell, including a corner, must be legal at Load too")
 }
 
@@ -1207,7 +1207,7 @@ func (s *DataTestSuite) TestLoadTwoPropsOnOneCellRejected() {
 		Endings: []encounter.EndingData{{Key: "done", Kind: "external"}},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoField)
@@ -1229,7 +1229,7 @@ func (s *DataTestSuite) TestLoadDuplicateEndingKeyRejected() {
 		},
 	}
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().Error(err)
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
 	s.Require().ErrorIs(err, encounter.ErrNoEnding)
@@ -1312,7 +1312,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 			data := validEncounterData()
 			tc.mutate(&data)
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 			s.Require().Error(err, tc.name)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData, tc.name)
 			s.Require().Contains(err.Error(), tc.fragment,
@@ -1326,7 +1326,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 	// The valid base itself must load — the one-defect discipline only
 	// means something if zero defects pass.
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: validEncounterData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: validEncounterData()})
 	s.Require().NoError(err, "the valid base fixture must load")
 }
 
@@ -1342,7 +1342,7 @@ func (s *DataTestSuite) TestLoadRejections() {
 func (s *DataTestSuite) TestLoadRejectsPlayerWithDecider() {
 	data := validEncounterData()
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			"p1": &spyDecider{},
 		}})
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)
@@ -1352,7 +1352,7 @@ func (s *DataTestSuite) TestLoadRejectsPlayerWithDecider() {
 func (s *DataTestSuite) TestMutation1ToDataAliases() {
 	s.Run("mutation 1: ToData aliases slices", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
@@ -1390,7 +1390,7 @@ func (s *DataTestSuite) TestMutation1ToDataAliases() {
 func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 	s.Run("mutation 2: wire tag renamed", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
@@ -1419,7 +1419,7 @@ func (s *DataTestSuite) TestMutation2WireTagRenamed() {
 func (s *DataTestSuite) TestMutation3StowawayField() {
 	s.Run("mutation 3: stowaway field in EncounterData", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
@@ -1450,7 +1450,7 @@ func (s *DataTestSuite) TestMutation3StowawayField() {
 func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 	s.Run("mutation 4: leaf data substitution (Intel/Log swapped)", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 5, 5)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
@@ -1481,7 +1481,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 
 		// Control: loading dataA verbatim, p1 holds p2.
 		ctrl, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: dataA})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: dataA})
 		s.Require().NoError(err)
 		ctrlView, err := ctrl.View(&encounter.ViewInput{Member: "p1"})
 		s.Require().NoError(err)
@@ -1492,7 +1492,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 		// is genuinely consumed, never re-derived from the field.
 		dataA.Intel = dataB.Intel
 		swapped, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: dataA})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: dataA})
 		s.Require().NoError(err)
 		swappedView, err := swapped.View(&encounter.ViewInput{Member: "p1"})
 		s.Require().NoError(err)
@@ -1504,7 +1504,7 @@ func (s *DataTestSuite) TestMutation4LeafSubstitution() {
 func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 	s.Run("mutation 6: no re-surveil on load (ghost stays ghost)", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 10, 10)},
@@ -1550,7 +1550,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 
 		data := enc1.ToData()
 		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{}})
 
 		holdings2, _ := enc2.View(&encounter.ViewInput{Member: "playerA"})
 		var goblinStatusAfter intel.Status
@@ -1571,7 +1571,7 @@ func (s *DataTestSuite) TestMutation6ReSurveilOnLoad() {
 func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 	s.Run("mutation 7: tick continuation (clock not reset)", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room1", 0, 0, 10, 10)}, Props: []encounter.PropInput{}, Walls: []encounter.WallInput{},
@@ -1589,7 +1589,7 @@ func (s *DataTestSuite) TestMutation7TickResetOnLoad() {
 		tick1 := data1.Clock.HighWater
 
 		enc2, _ := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data1, Deciders: map[encounter.MemberID]encounter.Decider{}})
 		data2 := enc2.ToData()
 		tick2 := data2.Clock.HighWater
 

--- a/rulebooks/dnd5e/encounter/defeat_internal_test.go
+++ b/rulebooks/dnd5e/encounter/defeat_internal_test.go
@@ -47,7 +47,7 @@ func (d *oneDown) Standing(members []MemberID) ([]MemberID, error) {
 func TestADecidedFightRefusesToCountAGhost(t *testing.T) {
 	rulebook := &oneDown{}
 	enc, err := NewEncounter(&SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: rulebook, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: rulebook, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: FieldInput{Canvas: openAir(), Regions: []RegionInput{rectRegion("crypt", 0, 0, 12, 12)}},
 		Members: []MemberInput{
 			{ID: "alice", Kind: KindPlayer, Position: spatial.Position{X: 0, Y: 2}},

--- a/rulebooks/dnd5e/encounter/defeat_test.go
+++ b/rulebooks/dnd5e/encounter/defeat_test.go
@@ -377,7 +377,7 @@ func (s *DefeatSuite) TestOnlyTheDecidedFightEnds() {
 
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:       data,
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: &downList{down: []encounter.MemberID{goblin}},
 	})
 	s.Require().NoError(err)

--- a/rulebooks/dnd5e/encounter/dialect_test.go
+++ b/rulebooks/dnd5e/encounter/dialect_test.go
@@ -60,7 +60,7 @@ var dialectOrigin = spatial.Position{X: 30, Y: 10}
 // coordinates.
 func (s *DialectSuite) closedBlob() encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{
 			rectRegion("hall", int(dialectOrigin.X), int(dialectOrigin.Y), 8, 8),
 		}},
@@ -89,7 +89,7 @@ const aRoomBearingSighting = `{"room":"hall","x":2,"y":5}`
 // load is the host's side of the seam: hand the loader a blob and see what it says.
 func (s *DialectSuite) load(data encounter.EncounterData) error {
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	return err
 }

--- a/rulebooks/dnd5e/encounter/doors_test.go
+++ b/rulebooks/dnd5e/encounter/doors_test.go
@@ -99,7 +99,7 @@ func doorField(height int, state encounter.DoorState, id encounter.DoorID, rows 
 // single-edge door, both players so nothing forms a fight.
 func (s *DoorSuite) doorway(state encounter.DoorState) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: doorField(3, state, theDoor, 1),
 		Members: []encounter.MemberInput{
 			{ID: nessa, Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 1}},
@@ -212,7 +212,7 @@ func (s *DoorSuite) TestAGateIsOneThingNotFour() {
 	gateRows := []int{1, 2, 3, 4}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   doorField(6, encounter.DoorIsClosed(), theGate, gateRows...),
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -257,7 +257,7 @@ func (s *DoorSuite) TestADoorMustSayWhatStateItIsIn() {
 	field.Doors[0].State = nil
 
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   field,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -289,7 +289,7 @@ func (s *DoorSuite) TestAShutDoorLeavesAGhostRatherThanForgetting() {
 // setup opens a field, or returns why it could not be built.
 func (s *DoorSuite) setup(field encounter.FieldInput) error {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   field,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -375,7 +375,7 @@ func (s *DoorSuite) TestAnUndirectedCrossingIsTheSameCrossingEitherWayRound() {
 	field.Doors = []encounter.DoorInput{backwards}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: nessa, Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 1}},
@@ -406,7 +406,7 @@ func (s *DoorSuite) TestDoorsAreReadInStableOrder() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   field,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -502,7 +502,7 @@ func (s *DoorSuite) TestABlobWhoseDoorMakesNoSenseIsRefusedByName() {
 
 			_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 				Data:  data,
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			})
 			s.Require().ErrorIs(err, encounter.ErrBadDoor)
 			s.Require().ErrorIs(err, encounter.ErrInvalidData)
@@ -527,7 +527,7 @@ func (s *DoorSuite) TestABlobFromBeforeDoorsExistedLoadsFine() {
 
 	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:  data,
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().NoError(err)
 	s.Empty(back.Doors(), "no doors, and no complaint about it")
@@ -615,7 +615,7 @@ func threeChambers(first, second encounter.DoorState, gate1, gate2 encounter.Doo
 
 func (s *DoorSuite) walkerIn(field encounter.FieldInput) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: nessa, Kind: encounter.KindPlayer, Position: spatial.Position{X: 0, Y: 1}},

--- a/rulebooks/dnd5e/encounter/drivereentrancy_internal_test.go
+++ b/rulebooks/dnd5e/encounter/drivereentrancy_internal_test.go
@@ -20,7 +20,7 @@ func threePlayerMonsterBubble(t *testing.T) *Encounter {
 	t.Helper()
 	enc, err := NewEncounter(&SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		TurnDriver: passDriver{}, Striker: passStriker{},
+		TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: FieldInput{
 			Canvas:  openAir(),
 			Regions: []RegionInput{rectRegion("room-1", 0, 0, 8, 8)},

--- a/rulebooks/dnd5e/encounter/dungeonspec/capabilities_test.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/capabilities_test.go
@@ -81,3 +81,12 @@ func (noAttacksExpected) Strike(
 ) error {
 	return errors.New("dungeonspec_test: no scene here ever attacks")
 }
+
+// quietAnnouncer hears every boundary and does nothing. These scenes are about
+// geometry, not about what a turn boundary means to a condition — but unlike
+// noAttacksExpected it really is called, so it succeeds rather than refusing.
+type quietAnnouncer struct{}
+
+func (quietAnnouncer) Announce(context.Context, *encounter.Encounter, []encounter.Boundary) error {
+	return nil
+}

--- a/rulebooks/dnd5e/encounter/dungeonspec/compile_test.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/compile_test.go
@@ -163,7 +163,7 @@ func (s *CompileSuite) TestCompile_DoorInsideARegionIsLegal() {
 
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		TurnDriver: passDriver{}, Striker: noAttacksExpected{},
+		TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{},
 		Field:   c.Field,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/encounter/dungeonspec/golden_test.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/golden_test.go
@@ -146,7 +146,7 @@ func compiledAtlas(t *testing.T, path string) (dungeonspec.Compiled, encounter.A
 	require.NoError(t, err)
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		TurnDriver: passDriver{}, Striker: noAttacksExpected{},
+		TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{},
 		Field:   compiled.Field,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/encounter/dungeonspec/tomb_test.go
+++ b/rulebooks/dnd5e/encounter/dungeonspec/tomb_test.go
@@ -81,7 +81,7 @@ func (s *TombSuite) SetupTest() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{},
 		Field:   compiled.Field,
 		Members: members,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},

--- a/rulebooks/dnd5e/encounter/encounter.go
+++ b/rulebooks/dnd5e/encounter/encounter.go
@@ -188,6 +188,12 @@ type Encounter struct {
 	// [Striker].
 	striker Striker
 
+	// announcer publishes the temporal boundaries a clock advance crossed.
+	// Required at both constructors for the same reason striker is; see
+	// [Announcer], whose doc explains why it is a capability rather than a
+	// return value.
+	announcer Announcer
+
 	// driving is true for the duration of ONE driveMonsterTurns call, at
 	// any depth of Go call stack — runtime state, never persisted (there is
 	// no stack mid-verb for ToData to capture, and none is needed: a fresh
@@ -493,6 +499,15 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		return nil, fmt.Errorf("newencounter: %w", ErrNoStriker)
 	}
 
+	// And once more, one seam further on: a fight forming starts round 1 and
+	// somebody's first turn, so an encounter that cannot announce a boundary
+	// would let every turn-scoped condition in it live forever — silently,
+	// which is how this went unnoticed for months. Never defaulted — see
+	// [Announcer]'s own doc.
+	if in.Announcer == nil {
+		return nil, fmt.Errorf("newencounter: %w", ErrNoAnnouncer)
+	}
+
 	// Check ending keys: empty/reserved, and duplicate (#929 hardening
 	// round E — two endings sharing a key both used to load; End scans
 	// in declaration order, so a reached_position twin declared FIRST
@@ -582,6 +597,7 @@ func NewEncounter(in *SetupInput) (*Encounter, error) {
 		sight:       in.Sight,
 		turnDriver:  in.TurnDriver,
 		striker:     in.Striker,
+		announcer:   in.Announcer,
 		endings:     nil,
 		retention:   normalizeRetention(in.Retention),
 	}

--- a/rulebooks/dnd5e/encounter/encounter_test.go
+++ b/rulebooks/dnd5e/encounter/encounter_test.go
@@ -45,7 +45,7 @@ func (s *EncounterTestSuite) TestSetupFirstLight() {
 	s.Run("two members clear line of sight", func() {
 		// Arrange: 10x10 room, alice at (2,2) player, goblin at (7,7) monster
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -113,7 +113,7 @@ func (s *EncounterTestSuite) TestSetupWallBlocksSight() {
 		// around now (spatial v0.9.1, see testwalls_test.go), so a fixture
 		// that wants sight blocked has to build something worth blocking.
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)}, Props: wallColumn(4, 0, 9),
@@ -164,7 +164,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: no field", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{},
@@ -180,7 +180,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: no endings", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
@@ -194,7 +194,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: reserved ending key", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
@@ -210,7 +210,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: empty ending key", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
@@ -226,7 +226,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 	s.Run("validation order: empty member ID", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
@@ -245,7 +245,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	s.Run("validation order: duplicate member IDs", func() {
 		alice := core.EntityID("alice")
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
@@ -267,7 +267,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 	s.Run("atomicity: after error, valid setup works", func() {
 		// First attempt: fails validation
 		setup1 := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field:   encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{}},
 			Members: []encounter.MemberInput{},
 			Endings: []encounter.EndingInput{
@@ -279,7 +279,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 
 		// Second attempt: valid
 		setup2 := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
@@ -307,7 +307,7 @@ func (s *EncounterTestSuite) TestSetupValidationOrderAndAtomicity() {
 // interior one.
 func (s *EncounterTestSuite) TestSetupPropOnBoundaryCellAccepted() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 5, 5)}, Props: []encounter.PropInput{rubble(0, 2), rubble(4, 2), rubble(2, 0), rubble(2, 4), rubble(0, 0), rubble(4, 4)},
@@ -328,7 +328,7 @@ func (s *EncounterTestSuite) TestSetupPropOnBoundaryCellAccepted() {
 // room-list defect vocabulary.
 func (s *EncounterTestSuite) TestSetupTwoPropsOnOneCellRejected() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 5, 5)}, Props: []encounter.PropInput{rubble(3, 3), rubble(3, 3)},
@@ -349,7 +349,7 @@ func (s *EncounterTestSuite) TestSetupTwoPropsOnOneCellRejected() {
 // forever, the external ending having no other way to fire).
 func (s *EncounterTestSuite) TestSetupDuplicateEndingKeyRejected() {
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 5, 5)},
@@ -370,7 +370,7 @@ func (s *EncounterTestSuite) TestSetupDuplicateEndingKeyRejected() {
 // Pump's IntentMoveTo, so this also covers decider-driven moves).
 func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("hex-room", 0, 0, 8, 8)},
@@ -406,7 +406,7 @@ func (s *EncounterTestSuite) TestMoveHexIntegralAxial() {
 // TestJoinHexIntegralAxial is Join's verb-seam counterpart.
 func (s *EncounterTestSuite) TestJoinHexIntegralAxial() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("hex-room", 0, 0, 8, 8)},
@@ -454,7 +454,7 @@ func (s *EncounterTestSuite) TestSetupOpeningBeat() {
 	s.Run("opening beat reaches all members via Story", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -506,7 +506,7 @@ func (s *EncounterTestSuite) TestSetupBadPlacementSentinel() {
 	s.Run("member placed on a cell no region owns errors with ErrBadPlacement", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -533,7 +533,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 	s.Run("three members mutually visible all see each other", func() {
 		// Arrange: ONE room, THREE mutually visible members (alice, bob players; goblin monster)
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 20, 20)},
@@ -588,7 +588,7 @@ func (s *EncounterTestSuite) TestSetupCompletePercept() {
 func (s *EncounterTestSuite) TestMembers() {
 	s.Run("returns stable order", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -615,7 +615,7 @@ func (s *EncounterTestSuite) TestMovePerceptRefreshes() {
 	s.Run("mover's vantage refreshes, others see mover at new position", func() {
 		// Arrange: alice and bob in clear sight
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 20, 20)},
@@ -693,7 +693,7 @@ func (s *EncounterTestSuite) TestMoveGhostForms() {
 		// A wall rather than the single pillar this fixture used to have —
 		// spatial v0.9.1 leans around a lone obstacle (see testwalls_test.go).
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 20, 20)}, Props: wallRow(10, 7, 13),
@@ -750,7 +750,7 @@ func (s *EncounterTestSuite) TestMoveSequentialConsistency() {
 	s.Run("after sequential moves, spatial index remains valid (CanMoveEntityBetweenRooms-style)", func() {
 		// Arrange: alice in one room
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 20, 20)},
@@ -798,7 +798,7 @@ func (s *EncounterTestSuite) TestMoveEndingFires() {
 	s.Run("player reaching ReachedPosition trigger fires the ending", func() {
 		// Arrange: alice is player, will reach stairs (no member filter = any player)
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 20, 20), rectRegion(room2, 20, 0, 20, 20)}, Walls: squareSeamWall(19, 20),
@@ -880,7 +880,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 	s.Run("validation order and R5 atomicity", func() {
 		s.Run("nil input returns ErrNilInput", func() {
 			setup := &encounter.SetupInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 				Field: encounter.FieldInput{
 					Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 					Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -901,7 +901,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("empty member ID returns ErrNoMember", func() {
 			setup := &encounter.SetupInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 				Field: encounter.FieldInput{
 					Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 					Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -925,7 +925,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("closed encounter returns ErrClosed", func() {
 			setup := &encounter.SetupInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 				Field: encounter.FieldInput{
 					Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 					Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -959,7 +959,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("not a member returns ErrNotMember", func() {
 			setup := &encounter.SetupInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 				Field: encounter.FieldInput{
 					Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 					Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -983,7 +983,7 @@ func (s *EncounterTestSuite) TestMoveValidationAndAtomicity() {
 
 		s.Run("failed move leaves members unchanged", func() {
 			setup := &encounter.SetupInput{
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 				Field: encounter.FieldInput{
 					Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 					Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -1025,7 +1025,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 	s.Run("mutating returned outcome does not affect internal state", func() {
 		// Arrange
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 20, 20)},
@@ -1078,7 +1078,7 @@ func (s *EncounterTestSuite) TestMoveOutcomeCopyOut() {
 // (19,19).
 func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 20, 20)}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 2}},
@@ -1097,7 +1097,7 @@ func (s *EncounterTestSuite) newBasicEncounter() *encounter.Encounter {
 // an External ending (for testing End verb).
 func (s *EncounterTestSuite) newBasicEncounterWithExternalEnding() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 20, 20)}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 2}},
@@ -1168,7 +1168,7 @@ func (s *EncounterTestSuite) TestMoveSpatialRejectionAtomic() {
 // arrival-Current and T3 pins).
 func (s *EncounterTestSuite) newTwoRoomEncounterWithConnection() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("room-a", 0, 0, 10, 10), rectRegion("room-b", 10, 0, 10, 10)}, Walls: twoRoomWall(),
@@ -1330,7 +1330,7 @@ func (s *EncounterTestSuite) holdingOf(
 // any other step's destination.
 func (s *EncounterTestSuite) TestACrossingFiresAnEndingOnArrival() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("room-a", 0, 0, 10, 10), rectRegion("room-b", 10, 0, 10, 10)}, Walls: twoRoomWall(),
@@ -1365,7 +1365,7 @@ func (s *EncounterTestSuite) TestACrossingFiresAnEndingOnArrival() {
 // unfiltered ending's cell must NOT close the encounter, doorway or not.
 func (s *EncounterTestSuite) TestAMonsterCrossingOntoAnUnfilteredEndingDoesNotClose() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("room-a", 0, 0, 10, 10), rectRegion("room-b", 10, 0, 10, 10)}, Walls: twoRoomWall(),
@@ -1473,7 +1473,7 @@ func (s *EncounterTestSuite) TestJoinLateJoinerSeenByIncumbents() {
 	s.Run("late joiner seen by and sees incumbents", func() {
 		// Arrange: setup with alice and bob
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -1621,7 +1621,7 @@ func (s *EncounterTestSuite) TestJoinValidation() {
 func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 	s.Run("join on stairs fires ReachedPosition ending", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -1666,7 +1666,7 @@ func (s *EncounterTestSuite) TestJoinOnStairsFiresEnding() {
 func (s *EncounterTestSuite) TestExitCarryForward() {
 	s.Run("exit carry-forward matches final state", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -1753,7 +1753,7 @@ func (s *EncounterTestSuite) TestExitValidation() {
 func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 	s.Run("last member exit closes with abandoned ending", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -1798,7 +1798,7 @@ func (s *EncounterTestSuite) TestExitLastMemberClosesWithAbandoned() {
 func (s *EncounterTestSuite) TestExitDepartedGhostFades() {
 	s.Run("remaining member's holdings persist after departure", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -1863,7 +1863,7 @@ func (s *EncounterTestSuite) TestEndExternalOnly() {
 
 	s.Run("End fires External endings", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -1998,7 +1998,7 @@ func (s *EncounterTestSuite) TestQueriesLivePostClose() {
 func (s *EncounterTestSuite) TestStoryForExitedMembers() {
 	s.Run("exited members can still read story", func() {
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -311,6 +311,22 @@ var (
 	// world, not a legal outcome any caller is meant to recover from.
 	ErrRefusingStriker = errors.New("encounter: RefusingStriker: a driven turn reached a construction-only world")
 
+	// ErrNoAnnouncer is what both constructors return when no Announcer was
+	// supplied. Every clock advance crosses boundaries — a turn ending, a
+	// fight forming — and this module refuses to guess what one MEANS to a
+	// condition, exactly as it refuses to guess how a strike resolves or
+	// what an unplayed member does. Never defaulted: an Announcer that
+	// silently did nothing would let every turn-scoped condition live
+	// forever, which is precisely the bug this capability closed
+	// (rpg-project#294).
+	ErrNoAnnouncer = errors.New("encounter: no announcer capability")
+
+	// ErrRefusingAnnouncer is what [RefusingAnnouncer.Announce] always
+	// returns: a clock advanced on a world built only to be inspected. A
+	// host bug — nothing should reach EndTurn or form against such a
+	// world — not a legal outcome any caller is meant to recover from.
+	ErrRefusingAnnouncer = errors.New("encounter: RefusingAnnouncer: a clock advanced on a construction-only world")
+
 	// ErrBadIntent indicates a TurnDriver returned a syntactically valid
 	// TurnIntent this composition cannot execute: an Attack naming a target
 	// that is not currently Seen, not Standing, or out of the named

--- a/rulebooks/dnd5e/encounter/example_doorway_test.go
+++ b/rulebooks/dnd5e/encounter/example_doorway_test.go
@@ -51,7 +51,7 @@ func Example_theDoorway() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: "alice", Kind: encounter.KindPlayer, Position: spatial.Position{X: 7, Y: 4}},

--- a/rulebooks/dnd5e/encounter/example_dungeon_test.go
+++ b/rulebooks/dnd5e/encounter/example_dungeon_test.go
@@ -28,7 +28,7 @@ import (
 func Example_theDungeon() {
 	gate := openDoorway("gate", 7, 4, 8, 4)
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 8, 8), rectRegion("vault", 8, 0, 8, 8)},

--- a/rulebooks/dnd5e/encounter/example_tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/example_tombwatch_test.go
@@ -45,7 +45,7 @@ func Example_theTombWatch() {
 	// The crypt: a wall across y=6 from x=5 to x=7; alice enters at (2,6); a goblin
 	// stands at (6,10). One way out: the stairs at (11,11).
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("crypt", 0, 0, 12, 12)}, Props: wallRow(6, 5, 7),
@@ -86,7 +86,7 @@ func Example_theTombWatch() {
 	fmt.Println("-- the table saves and comes back tomorrow --")
 	data := enc.ToData()
 	enc, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	if err != nil {
 		fmt.Println("load:", err)
 		return

--- a/rulebooks/dnd5e/encounter/field.go
+++ b/rulebooks/dnd5e/encounter/field.go
@@ -535,6 +535,13 @@ type SetupInput struct {
 	// [Striker]'s own doc.
 	Striker Striker
 
+	// Announcer publishes the temporal boundaries a clock advance crossed —
+	// a turn ending, a fight forming. REQUIRED, refused at construction
+	// (ErrNoAnnouncer). There is no default, and the reason it cannot have
+	// one is in [Announcer]'s own doc: a silent Announcer and a missing one
+	// look identical, and one of them is the bug.
+	Announcer Announcer
+
 	// Retention is how many story beats the encounter keeps. Older beats are
 	// trimmed after each append, so an encounter's blob does not grow without
 	// bound and a save does not rewrite the whole history.

--- a/rulebooks/dnd5e/encounter/killingblow_test.go
+++ b/rulebooks/dnd5e/encounter/killingblow_test.go
@@ -64,7 +64,7 @@ func (s *KillingBlowSuite) apart(standing encounter.Standing) *encounter.Encount
 	s.T().Helper()
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: standing,
 		Retention: encounter.RetentionUnbounded,
 		Field:     encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(cryptID, 0, 0, 12, 12)}, Props: wallRow(6, 0, 11)},

--- a/rulebooks/dnd5e/encounter/memberdown_internal_test.go
+++ b/rulebooks/dnd5e/encounter/memberdown_internal_test.go
@@ -32,7 +32,7 @@ func TestAClosedEncounterIsNotClosedAgainByAnArrival(t *testing.T) {
 	standing := &somebodyDown{}
 
 	enc, err := NewEncounter(&SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: standing, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: standing, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: FieldInput{
 			Canvas:  CanvasInput{Void: VoidIsOpaque(), Orientation: HexesArePointyTop()},
 			Regions: []RegionInput{rectRegion("room-1", 0, 0, 10, 10)},

--- a/rulebooks/dnd5e/encounter/memberdown_test.go
+++ b/rulebooks/dnd5e/encounter/memberdown_test.go
@@ -44,7 +44,7 @@ func (s *MemberDownSuite) doomed(standing encounter.Standing) *encounter.Encount
 	s.T().Helper()
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: standing,
 		Retention: encounter.RetentionUnbounded,
 		Field:     encounter.FieldInput{Canvas: openAir(), Regions: []encounter.RegionInput{rectRegion(cryptID, 0, 0, 12, 12)}},
@@ -110,7 +110,7 @@ func (s *MemberDownSuite) TestAnotherBodyIsNotTheDoom() {
 // brings death saves (TriggerMemberDown's doc).
 func (s *MemberDownSuite) TestSetupRefusesADoomNamingNobody() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: &downList{},
 		Retention: encounter.RetentionUnbounded,
 		Field:     encounter.FieldInput{Canvas: openAir(), Regions: []encounter.RegionInput{rectRegion(cryptID, 0, 0, 12, 12)}},
@@ -139,7 +139,7 @@ func (s *MemberDownSuite) TestTheDoomSurvivesTheRoundTrip() {
 	down := &downList{down: []encounter.MemberID{goblin, wolf}}
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:       saved,
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: down,
 	})
 	s.Require().NoError(err)
@@ -163,7 +163,7 @@ func (s *MemberDownSuite) TestLoadRefusesADoomNamingNobody() {
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:       saved,
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: &downList{},
 	})
 	s.Require().ErrorIs(err, encounter.ErrInvalidData)

--- a/rulebooks/dnd5e/encounter/monsterturn_test.go
+++ b/rulebooks/dnd5e/encounter/monsterturn_test.go
@@ -94,7 +94,7 @@ func (s *scriptedStriker) Strike(
 func (s *MonsterTurnTestSuite) adjacentSkeletonEncounter(driver encounter.TurnDriver, striker encounter.Striker) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		TurnDriver: driver, Striker: striker,
+		TurnDriver: driver, Striker: striker, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -123,7 +123,7 @@ func (s *MonsterTurnTestSuite) adjacentSkeletonEncounter(driver encounter.TurnDr
 func (s *MonsterTurnTestSuite) farSkeletonEncounter(driver encounter.TurnDriver, striker encounter.Striker) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		TurnDriver: driver, Striker: striker,
+		TurnDriver: driver, Striker: striker, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -451,7 +451,7 @@ func (s *MonsterTurnTestSuite) TestMemberFactsRoundTripThroughToDataAndLoadEncou
 	loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:  saved,
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		TurnDriver: passDriver{}, Striker: passStriker{},
+		TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().NoError(err)
 
@@ -499,7 +499,7 @@ func (s *MonsterTurnTestSuite) TestSetupRejectsANegativeMemberFact() {
 		mutate(&mi)
 		return &encounter.SetupInput{
 			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-			TurnDriver: passDriver{}, Striker: passStriker{},
+			TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 8, 8)},
@@ -582,7 +582,7 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathWalksAroundAWall() {
 	driver := &scriptedDriver{}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed},
+		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 5, 3)}, Walls: wall,
@@ -633,7 +633,7 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathIsEmptyWhenSightedButUnreachabl
 	driver := &scriptedDriver{}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed},
+		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			// Sight crosses void here (VoidIsTransparent), but a 4-cell gap
 			// of void between the two rooms is still not floor for either
@@ -672,7 +672,7 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathStopsAtTheMemberOwnLongestReach
 	driver := &scriptedDriver{}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed},
+		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 3)},
@@ -748,7 +748,7 @@ func (s *MonsterTurnTestSuite) TestSeenMemberPathFindsTheNearestInRangeCellNotJu
 	driver := &scriptedDriver{}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{},
-		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed},
+		TurnDriver: driver, Striker: &scriptedStriker{kind: encounter.OutcomeMissed}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 5, 3)}, Walls: wall,
@@ -831,7 +831,7 @@ func (s *MonsterTurnTestSuite) TestDrivenKillingBlowEndsTheDriveCleanly() {
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: standing, Initiative: orderAsGiven{},
-		TurnDriver: driver, Striker: striker,
+		TurnDriver: driver, Striker: striker, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -938,7 +938,7 @@ func (s *MonsterTurnTestSuite) TestADownedTeammateDoesNotHandTheDrivenMonsterASe
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: standing, Initiative: orderAsGiven{},
-		TurnDriver: driver, Striker: striker,
+		TurnDriver: driver, Striker: striker, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  openAir(),
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},

--- a/rulebooks/dnd5e/encounter/names_test.go
+++ b/rulebooks/dnd5e/encounter/names_test.go
@@ -31,7 +31,7 @@ const namesRoom = "hall"
 func namesScene(members []encounter.MemberInput) (*encounter.Encounter, error) {
 	return encounter.NewEncounter(&encounter.SetupInput{
 		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(namesRoom, 0, 0, 10, 10)},
@@ -119,7 +119,7 @@ func (s *NamesTestSuite) TestNameRoundTripsThroughPersistence() {
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Initiative: orderAsGiven{}, Standing: everyoneStanding{},
-		Sight: everyoneSeesTheWholeMap{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/encounter/outcome_test.go
+++ b/rulebooks/dnd5e/encounter/outcome_test.go
@@ -30,7 +30,7 @@ const outcomeRoom = "yard"
 // other's sight, so nothing forms a fight before a test asks for one.
 func (s *OutcomeTestSuite) scene() *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(outcomeRoom, 0, 0, 12, 12)}, Props: wallRow(6, 4, 8)},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 6, Y: 2}},

--- a/rulebooks/dnd5e/encounter/placement_test.go
+++ b/rulebooks/dnd5e/encounter/placement_test.go
@@ -48,7 +48,7 @@ var gate = openDoorway("gate", 37, 14, 38, 14)
 
 func (s *PlacementSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{
@@ -325,7 +325,7 @@ func (s *PlacementSuite) TestTheOutcomeSurvivesARoundTripStillAbsolute() {
 	s.Require().NoError(err)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Data: s.enc.ToData(), Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Data: s.enc.ToData(), Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/encounter/props_test.go
+++ b/rulebooks/dnd5e/encounter/props_test.go
@@ -95,7 +95,7 @@ func (s *PropsSuite) chamber(ref string, blocksMovement, blocksSight *bool) *enc
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("crypt", int(propsOrigin.X), int(propsOrigin.Y), 12, 8)},
@@ -192,7 +192,7 @@ func (s *PropsSuite) TestCandlesAreThereAndInNobodysWay() {
 // as "a pillar and a statue are the same cell".
 func (s *PropsSuite) TestTheMapSaysWHICHThingIsWhere() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("tomb", int(propsOrigin.X), int(propsOrigin.Y), 12, 8)},
@@ -230,7 +230,7 @@ func (s *PropsSuite) TestTheMapSaysWHICHThingIsWhere() {
 func (s *PropsSuite) TestAPropMustSayWhatItDoes() {
 	build := func(p encounter.PropInput) error {
 		_, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion("crypt", int(propsOrigin.X), int(propsOrigin.Y), 12, 8)},
@@ -280,7 +280,7 @@ func (s *PropsSuite) TestAPropSurvivesASave() {
 
 	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().NoError(err)
 
@@ -321,7 +321,7 @@ func (s *PropsSuite) TestAnOldBlobsRoomsAreRefusedLoudly() {
 
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Contains(err.Error(), "rooms",
@@ -345,7 +345,7 @@ func (s *PropsSuite) TestAPersistedPropMustSayWhatItDoesToo() {
 		mutate(&data.Field.Props[0])
 		_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 			Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-			Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		})
 		return err
 	}
@@ -377,7 +377,7 @@ func (s *PropsSuite) TestAPersistedPropMustSayWhatItDoesToo() {
 func (s *PropsSuite) TestEditingTheSetupAfterwardsCannotChangeTheSavedDungeon() {
 	solid := true
 	setup := &encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("crypt", int(propsOrigin.X), int(propsOrigin.Y), 12, 8)},
@@ -439,7 +439,7 @@ func (s *PropsSuite) TestASavedPropIsNotAliasedByTheSnapshot() {
 // design, so a prop that authors neither carries the zero value of both.
 func (s *PropsSuite) TestFacingAndOffsetAreCarriedButNeverInterpreted() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("tomb", int(propsOrigin.X), int(propsOrigin.Y), 12, 8)},
@@ -481,7 +481,7 @@ func (s *PropsSuite) TestFacingAndOffsetAreCarriedButNeverInterpreted() {
 // (TestAPropSurvivesASave).
 func (s *PropsSuite) TestFacingAndOffsetSurviveASave() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("crypt", int(propsOrigin.X), int(propsOrigin.Y), 12, 8)},
@@ -505,7 +505,7 @@ func (s *PropsSuite) TestFacingAndOffsetSurviveASave() {
 
 	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/encounter/pump_test.go
+++ b/rulebooks/dnd5e/encounter/pump_test.go
@@ -206,7 +206,7 @@ func (p *pursuitDecider) Decide(snap encounter.Snapshot) (encounter.Intent, erro
 // cleanup: an exited monster's decider must never be consulted again.
 func (s *PumpTestSuite) TestPumpDoesNotConsultExitedMonsterDecider() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall()},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Position: spatial.Position{X: 11, Y: 1}},
@@ -240,7 +240,7 @@ func (s *PumpTestSuite) TestPumpGoblinPatrols() {
 		}
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -326,7 +326,7 @@ func (s *PumpTestSuite) TestPumpDeciderIsolation() {
 		// asymmetric perception (#1020) or a faction model, at which point
 		// this test should grow the positive case again.
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
@@ -374,7 +374,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 		errDecider := &errorDecider{err: deciderErr}
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -440,7 +440,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAborts() {
 // NEXT (successful) pump reports reading 1, not 2.
 func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall()},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Position: spatial.Position{X: 11, Y: 1}},
@@ -464,7 +464,7 @@ func (s *PumpTestSuite) TestPumpFailedPumpAdvancesNothing() {
 // have moved — no partial mutation (R5).
 func (s *PumpTestSuite) TestPumpPartialAbort() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall()},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Position: spatial.Position{X: 11, Y: 1}},
@@ -507,7 +507,7 @@ func (s *PumpTestSuite) TestPumpPartialAbort() {
 func (s *PumpTestSuite) TestPumpMutatingDeciderCannotCorrupt() {
 	vandal := &vandalDecider{}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall()},
 		Members: []encounter.MemberInput{
 			{ID: core.EntityID("alice"), Kind: encounter.KindPlayer, Position: spatial.Position{X: 11, Y: 1}},
@@ -551,7 +551,7 @@ func (s *PumpTestSuite) TestPumpMonsterOnUnfilteredStairsDontClose() {
 		}
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -603,7 +603,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 		aliceID := core.EntityID("alice")
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -660,7 +660,7 @@ func (s *PumpTestSuite) TestPumpMonsterWithNilDecider() {
 // this seam.
 func (s *PumpTestSuite) TestPumpJoinedMonsterWithNilDeciderHolds() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall()},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 10, Y: 0}},
@@ -697,7 +697,7 @@ func (s *PumpTestSuite) TestPumpClosedEncounterViaReachedPosition() {
 		}
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -762,7 +762,7 @@ func (s *PumpTestSuite) TestPumpTickBeatAndMoveBeats() {
 		}
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -834,7 +834,7 @@ func (s *PumpTestSuite) TestPumpClockAdvanceByOne() {
 		goblinID := core.EntityID("goblin")
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -901,7 +901,7 @@ func (s *PumpTestSuite) TestPumpPlayerWithDeciderRejected() {
 		aliceID := core.EntityID("alice")
 
 		setup := &encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 				Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -972,7 +972,7 @@ func (s *PumpTestSuite) TestPumpSnapshotIsOwnPlacement() {
 	spyB := &snapshotSpyDecider{}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("room-a", 0, 0, 10, 10), rectRegion("room-b", 10, 0, 10, 10)}, Walls: twoRoomSealedWall(),
@@ -1019,7 +1019,7 @@ func (s *PumpTestSuite) TestAnIntendedStepCrossesADoorway() {
 	decider := &onceStepDecider{to: cellAt(10, 5)}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("room-a", 0, 0, 10, 10), rectRegion("room-b", 10, 0, 10, 10)}, Walls: twoRoomWall(),
@@ -1082,7 +1082,7 @@ func (s *PumpTestSuite) TestPumpReportsMovementOnTheMap() {
 	patrol := &patrolDecider{positions: []spatial.Position{cellAt(49, 25), cellAt(50, 25)}}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(cellar, 40, 20, 10, 10), rectRegion(shrine, 50, 20, 10, 10)},
@@ -1189,7 +1189,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenAWallIsInTheWay() {
 	decider := &onceStepDecider{to: cellAt(10, 2)}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("room-a", 0, 0, 10, 10), rectRegion("room-b", 10, 0, 10, 10)}, Walls: twoRoomWall(),
@@ -1242,7 +1242,7 @@ func (s *PumpTestSuite) TestPumpDoesNotAbortWhenTheCellIsNowhere() {
 	decider := &onceStepDecider{to: cellAt(500, 500)}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("room-a", 0, 0, 10, 10), rectRegion("room-b", 10, 0, 10, 10)}, Walls: twoRoomWall(),
@@ -1290,7 +1290,7 @@ func (s *PumpTestSuite) TestPumpDeciderErrorAbortsEvenWithTraversableTopology() 
 	deciderErr := errors.New("test decider error")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("room-a", 0, 0, 10, 10), rectRegion("room-b", 10, 0, 10, 10)}, Walls: twoRoomWall(),
@@ -1331,7 +1331,7 @@ func (s *PumpTestSuite) TestPumpPursuitAcrossConnection() {
 	goblinID := core.EntityID("goblin")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("room-a", 0, 0, 10, 10), rectRegion("room-b", 10, 0, 10, 10)}, Walls: twoRoomWall(),
@@ -1435,7 +1435,7 @@ func (s *PumpTestSuite) TestPumpFullTickThenEvaluateAcrossTraverse() {
 	bID := core.EntityID("zzz-goblin")
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("room-a", 0, 0, 10, 10), rectRegion("room-b", 10, 0, 10, 10)}, Walls: twoRoomWall(),
@@ -1535,7 +1535,7 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 
 	s.Run("control: decision order and declaration order agree", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall()},
 			Members: []encounter.MemberInput{
 				{ID: aID, Kind: encounter.KindMonster, Position: spatial.Position{X: 5, Y: 5}, Decider: &patrolDecider{positions: []spatial.Position{cellA}}},
@@ -1558,7 +1558,7 @@ func (s *PumpTestSuite) TestPumpEndingEvaluationIsDecisionOrderNotDeclarationOrd
 
 	s.Run("cross: decision order dominates — the SECOND-declared ending wins", func() {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall()},
 			Members: []encounter.MemberInput{
 				// Same decision order (aaa first, zzz second), but now each
@@ -1615,7 +1615,7 @@ func (s *PumpTestSuite) TestPumpSurvivesReentrantSelfExitingDecider() {
 	decider := &reentrantSelfExitDecider{self: goblinID}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomSealedWall()},
 		Members: []encounter.MemberInput{
 			{ID: aliceID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 11, Y: 1}},
@@ -1659,7 +1659,7 @@ func (s *PumpTestSuite) TestPumpStopsMovingAMonsterOnceSeen() {
 	gate := openDoorway("door", 9, 5, 10, 5)
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10), rectRegion(room2, 10, 0, 10, 10)}, Walls: twoRoomWall(),
@@ -1748,7 +1748,7 @@ func (s *PumpTestSuite) TestPumpDeciderHuntsLastKnownPosition() {
 	hidden := cellAt(4, 5)
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},

--- a/rulebooks/dnd5e/encounter/pursuit_test.go
+++ b/rulebooks/dnd5e/encounter/pursuit_test.go
@@ -80,7 +80,7 @@ func (s *PursuitSuite) SetupTest() {
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			// Alice stands at the threshold; the goblin is across the room
@@ -210,7 +210,7 @@ func (s *PursuitSuite) freeRoamWith(decider encounter.Decider) {
 
 	data := s.enc.ToData()
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Data:     data,
 		Deciders: map[encounter.MemberID]encounter.Decider{hunter: decider},
 	})

--- a/rulebooks/dnd5e/encounter/region_test.go
+++ b/rulebooks/dnd5e/encounter/region_test.go
@@ -43,7 +43,7 @@ func threeRegions() []encounter.RegionInput {
 
 func (s *RegionSetupSuite) setupWith(regions []encounter.RegionInput) (*encounter.Encounter, error) {
 	return encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   encounter.FieldInput{Canvas: pointyCanvas(), Regions: regions},
 		Members: []encounter.MemberInput{{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 6, Y: 4}}},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -59,7 +59,7 @@ func (s *RegionSetupSuite) loadWith(edit func(*encounter.RegionData)) error {
 	edit(&data.Field.Regions[1])
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	return err
 }
@@ -272,7 +272,7 @@ func (s *RegionSetupSuite) TestSetup_RefusesRegionDefectsByName() {
 // offset pair means nothing until the orientation is known.
 func (s *RegionSetupSuite) TestAFieldSaysWhichWayItsHexesPoint() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()}, Regions: threeRegions()},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -286,7 +286,7 @@ func (s *RegionSetupSuite) TestAFieldSaysWhichWayItsHexesPoint() {
 		data.Field.Canvas.Orientation = word
 		_, lerr := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 			Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-			Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		})
 		s.Require().ErrorIs(lerr, encounter.ErrNoField, "orientation %q", word)
 		s.Contains(lerr.Error(), "orientation")
@@ -298,7 +298,7 @@ func (s *RegionSetupSuite) TestAFieldSaysWhichWayItsHexesPoint() {
 func (s *RegionSetupSuite) TestTheOrientationSurvivesASave() {
 	flat := encounter.HexesAreFlatTop()
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: flat}, Regions: threeRegions()},
 		Members: []encounter.MemberInput{{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 15, Y: 8}}},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
@@ -310,7 +310,7 @@ func (s *RegionSetupSuite) TestTheOrientationSurvivesASave() {
 
 	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data: data, Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{},
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().NoError(err)
 
@@ -351,7 +351,7 @@ func (s *RegionSetupSuite) TestEdges_MustBeAdjacentUnderOrientation() {
 	}
 	build := func(o encounter.Orientation, a, b [2]int) error {
 		_, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: encounter.FieldInput{
 				Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: o},
 				Regions: []encounter.RegionInput{rectRegion("window", 0, 0, size, size)},
@@ -404,7 +404,7 @@ func (s *RegionSetupSuite) TestEdges_MustBeAdjacentUnderOrientation() {
 func (s *RegionSetupSuite) TestEdgesMustStandOnTheFloor() {
 	build := func(walls []encounter.WallInput, doors []encounter.DoorInput) error {
 		_, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field:   encounter.FieldInput{Canvas: pointyCanvas(), Regions: threeRegions(), Walls: walls, Doors: doors},
 			Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 		})

--- a/rulebooks/dnd5e/encounter/regions_test.go
+++ b/rulebooks/dnd5e/encounter/regions_test.go
@@ -40,7 +40,7 @@ func TestRegionSuite(t *testing.T) {
 // same opening, carol and dave one row up with the seam wall between them.
 func (s *RegionSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: tombSeat(tombEntranceOrigin, 5, tombDoorRow)},
@@ -230,7 +230,7 @@ func (s *RegionSuite) TestAStepChangesTheRegionAMemberIsIn() {
 // reports every member's region, derived from where they each stand.
 func (s *RegionSuite) TestReachingTheTombChamberClosesTheDelve() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: tombSeat(tombHallOrigin, 9, tombDoorRow)},
@@ -285,7 +285,7 @@ func (s *RegionSuite) TestTheRegionIsDerivedAcrossPersistenceToo() {
 	s.NotContains(string(blob), `"region"`, "and it did not come back under a new name either")
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().NoError(err)
 
 	status, err := reloaded.Status()
@@ -344,7 +344,7 @@ func (s *RegionSuite) TestAStaleRegionLabelInABlobCannotChangeTheAnswer() {
 	s.Require().NoError(json.Unmarshal(tampered, &data))
 
 	loaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().NoError(err, "an unknown key is ignored, not a defect to refuse")
 
 	status, err := loaded.Status()
@@ -411,7 +411,7 @@ func (s *RegionSuite) TestAFractionalPositionIsNotACell() {
 // local coordinate cannot pass as an absolute one.
 func (s *RegionSuite) oneRoom(w, h int, origin spatial.Position) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  pointyCanvas(),
 			Regions: []encounter.RegionInput{rectRegion("only", int(origin.X), int(origin.Y), w, h)},

--- a/rulebooks/dnd5e/encounter/retention_test.go
+++ b/rulebooks/dnd5e/encounter/retention_test.go
@@ -34,7 +34,7 @@ type RetentionTestSuite struct {
 // with the ending at (4,4).
 func (s *RetentionTestSuite) walkingEncounter(retention int) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion("r1", 0, 0, 5, 5)}},
 		Members: []encounter.MemberInput{
 			{ID: "p1", Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
@@ -242,7 +242,7 @@ func (s *RetentionTestSuite) TestRetentionSurvivesReload() {
 	s.Equal(window, data.Retention, "retention is persisted, not inferred")
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data})
 	s.Require().NoError(err)
 
 	// The reloaded encounter must still be trimming to the SAME window: keep
@@ -263,7 +263,7 @@ func (s *RetentionTestSuite) TestFloorSurvivesReload() {
 	s.generateBeats(enc, 40)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	_, err = reloaded.Story(&encounter.StoryInput{Audience: "p1", AfterSeq: 33})
@@ -283,7 +283,7 @@ func (s *RetentionTestSuite) TestUntrimmedEncounterHasNoFloor() {
 	s.generateBeats(enc, 5)
 
 	reloaded, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc.ToData()})
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: enc.ToData()})
 	s.Require().NoError(err)
 
 	for seq := uint64(1); seq <= 6; seq++ {

--- a/rulebooks/dnd5e/encounter/sight_test.go
+++ b/rulebooks/dnd5e/encounter/sight_test.go
@@ -86,7 +86,7 @@ func cells(from, to spatial.Position) int {
 // thing deciding percepts is sight.
 func (s *SightSuite) theLongRow(sight encounter.Sight) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: sight, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: sight, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: tombSeat(tombEntranceOrigin, 0, tombDoorRow)},
@@ -187,7 +187,7 @@ func (s *SightSuite) TestTheEdgeOfYourSightIsInsideIt() {
 // before it — would pass every other test in this file.
 func (s *SightSuite) TestSightIsStillGeometryFirst() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: &sightList{fallback: darkvision}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: &sightList{fallback: darkvision}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: tombField(),
 		Members: []encounter.MemberInput{
 			{ID: carol, Kind: encounter.KindPlayer, Position: tombSeat(tombEntranceOrigin, 5, tombDoorRow-1)},
@@ -238,7 +238,7 @@ func (s *SightSuite) TestTheConeStillNarrows() {
 		}}, marks...)
 
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: &sightList{fallback: generous}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: &sightList{fallback: generous}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field:   tombField(),
 			Members: members,
 			Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
@@ -341,7 +341,7 @@ func (s *SightSuite) TestTheFarSightedSpotTheShortSightedAndSurpriseThem() {
 
 	scene := func(sight encounter.Sight) *encounter.Encounter {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: sight, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: sight, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: tombField(),
 			Members: []encounter.MemberInput{
 				{ID: alice, Kind: encounter.KindPlayer, Position: tombSeat(tombEntranceOrigin, 0, tombDoorRow)},
@@ -400,7 +400,7 @@ func (s *SightSuite) TestTheFarSightedSpotTheShortSightedAndSurpriseThem() {
 func TestASceneThatDoesNotSayHowFarAnyoneCanSeeIsRefused(t *testing.T) {
 	t.Run("setup", func(t *testing.T) {
 		_, err := encounter.NewEncounter(&encounter.SetupInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: tombField(),
 			Members: []encounter.MemberInput{
 				{ID: alice, Kind: encounter.KindPlayer, Position: tombSeat(tombEntranceOrigin, 0, tombDoorRow)},
@@ -413,7 +413,7 @@ func TestASceneThatDoesNotSayHowFarAnyoneCanSeeIsRefused(t *testing.T) {
 
 	t.Run("load", func(t *testing.T) {
 		enc, err := encounter.NewEncounter(&encounter.SetupInput{
-			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+			Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			Field: tombField(),
 			Members: []encounter.MemberInput{
 				{ID: alice, Kind: encounter.KindPlayer, Position: tombSeat(tombEntranceOrigin, 0, tombDoorRow)},
@@ -423,7 +423,7 @@ func TestASceneThatDoesNotSayHowFarAnyoneCanSeeIsRefused(t *testing.T) {
 		require.NoError(t, err)
 
 		_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
-			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: enc.ToData(),
+			Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: enc.ToData(),
 		})
 		require.Error(t, err)
 		require.ErrorIs(t, err, encounter.ErrNoSight)

--- a/rulebooks/dnd5e/encounter/sightdecode_test.go
+++ b/rulebooks/dnd5e/encounter/sightdecode_test.go
@@ -82,7 +82,7 @@ func TestDecodeSightPayloadRefusesTheRoomBearingDialect(t *testing.T) {
 // invented.
 func TestDecodeSightPayloadAgreesWithAViewsOwnPayload(t *testing.T) {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 8, 8)},

--- a/rulebooks/dnd5e/encounter/standing_test.go
+++ b/rulebooks/dnd5e/encounter/standing_test.go
@@ -61,7 +61,7 @@ func (s *deathScene) scene(standing encounter.Standing, members ...encounter.Mem
 	s.T().Helper()
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: standing,
 		Retention: encounter.RetentionUnbounded,
 		Field:     encounter.FieldInput{Canvas: openAir(), Regions: []encounter.RegionInput{rectRegion(cryptID, 0, 0, 12, 12)}},
@@ -168,7 +168,7 @@ func (s *deathScene) beatsOf(enc *encounter.Encounter, audience encounter.Member
 // — a default would be this module deciding a rule it is not allowed to know.
 func (s *StandingSuite) TestSetupRefusesAnEncounterThatCannotAskWhoIsDown() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}, Regions: []encounter.RegionInput{rectRegion(cryptID, 0, 0, 12, 12)}},
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 0, Y: 2}},
@@ -187,7 +187,7 @@ func (s *StandingSuite) TestLoadRefusesAnEncounterThatCannotAskWhoIsDown() {
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:       saved,
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 
 	s.Require().ErrorIs(err, encounter.ErrNoStanding)
@@ -202,7 +202,7 @@ func (s *StandingSuite) TestALoadedEncounterAsksToo() {
 	down := &downList{down: []encounter.MemberID{goblin}}
 	enc, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:       saved,
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: down,
 	})
 	s.Require().NoError(err)
@@ -403,7 +403,7 @@ func (s *StandingSuite) TestTheStorySaysItOnce() {
 // composition still says down).
 func (s *StandingSuite) TestAForgottenDeathIsToldAgain() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Sight: everyoneSeesTheWholeMap{}, Standing: &downList{down: []encounter.MemberID{goblin}},
 		Retention: 4,
 		Field:     encounter.FieldInput{Canvas: openAir(), Regions: []encounter.RegionInput{rectRegion(cryptID, 0, 0, 12, 12)}},

--- a/rulebooks/dnd5e/encounter/step_test.go
+++ b/rulebooks/dnd5e/encounter/step_test.go
@@ -117,7 +117,7 @@ func stepField() encounter.FieldInput {
 // the only thing that happens.
 func (s *StepSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: stepSeat(stepWestOrigin, spatial.Position{X: 5, Y: 2})},
@@ -374,7 +374,7 @@ func (s *StepSuite) TestAStepAndAMonsterStepAgreeOnWhatIsCrossable() {
 // "nobody has seen anybody".
 func (s *StepSuite) sceneWithMonster(at spatial.Position, decider encounter.Decider) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: goblin, Kind: encounter.KindMonster, Position: stepSeat(stepWestOrigin, at), Decider: decider},
@@ -404,7 +404,7 @@ func (s *StepSuite) whereIn(enc *encounter.Encounter, id encounter.MemberID) spa
 func (s *StepSuite) TestAStepFiresAReachedPositionEnding() {
 	target := spatial.Position{X: 4, Y: 2}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: stepSeat(stepWestOrigin, spatial.Position{X: 5, Y: 2})},
@@ -427,7 +427,7 @@ func (s *StepSuite) TestAStepFiresAReachedPositionEnding() {
 // against where the member landed, not where they left.
 func (s *StepSuite) TestACrossingFiresAReachedPositionEndingOnTheFarSide() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: stepSeat(stepWestOrigin, stepDoorWestLocal)},
@@ -493,7 +493,7 @@ func (s *StepSuite) TestAStepRefusesAFightMember() {
 	// is Active and the goblin is not: rpg-toolkit#1169 refuses HIS step
 	// now, not hers (see TestAnActiveFightMemberSteps for hers).
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: stepSeat(stepWestOrigin, spatial.Position{X: 1, Y: 1})},
@@ -513,7 +513,7 @@ func (s *StepSuite) TestAStepRefusesAFightMember() {
 // actually waiting on moves through Step like anyone else.
 func (s *StepSuite) TestAnActiveFightMemberSteps() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: stepField(),
 		Members: []encounter.MemberInput{
 			{ID: alice, Kind: encounter.KindPlayer, Position: stepSeat(stepWestOrigin, spatial.Position{X: 1, Y: 1})},

--- a/rulebooks/dnd5e/encounter/testturndriver_internal_test.go
+++ b/rulebooks/dnd5e/encounter/testturndriver_internal_test.go
@@ -30,3 +30,11 @@ type passStriker struct{}
 func (passStriker) Strike(context.Context, *Encounter, MemberID, MemberID, core.Ref) error {
 	return errPassStrikerNeverAttacks
 }
+
+// quietAnnouncer is the internal-package twin of encounter_test's own — see
+// its doc.
+type quietAnnouncer struct{}
+
+func (quietAnnouncer) Announce(context.Context, *Encounter, []Boundary) error {
+	return nil
+}

--- a/rulebooks/dnd5e/encounter/testturndriver_test.go
+++ b/rulebooks/dnd5e/encounter/testturndriver_test.go
@@ -44,3 +44,16 @@ type passStriker struct{}
 func (passStriker) Strike(context.Context, *encounter.Encounter, encounter.MemberID, encounter.MemberID, core.Ref) error {
 	return errPassStrikerNeverAttacks
 }
+
+// quietAnnouncer hears every boundary and does nothing with it.
+//
+// UNLIKE passStriker, this one really is called — every fixture that ends a
+// turn crosses a boundary — so it cannot refuse. It succeeds silently because
+// these fixtures are about clocks, geometry and members rather than about what
+// a turn boundary MEANS, which is the rulebook's question and not this
+// module's (C1). The test that IS about announcement uses a recording one.
+type quietAnnouncer struct{}
+
+func (quietAnnouncer) Announce(context.Context, *encounter.Encounter, []encounter.Boundary) error {
+	return nil
+}

--- a/rulebooks/dnd5e/encounter/tombdoor_test.go
+++ b/rulebooks/dnd5e/encounter/tombdoor_test.go
@@ -68,7 +68,7 @@ var (
 
 func (s *TombDoorSuite) SetupTest() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{
@@ -262,7 +262,7 @@ func (s *TombDoorSuite) TestTheDoorSurvivesASave() {
 func (s *TombDoorSuite) reload(data encounter.EncounterData) *encounter.Encounter {
 	back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:  data,
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/encounter/tombwatch_test.go
+++ b/rulebooks/dnd5e/encounter/tombwatch_test.go
@@ -56,7 +56,7 @@ func TestTombWatch(t *testing.T) {
 	// cannot get through.
 	goblinPatrol := &patrolDecider{positions: []spatial.Position{cellAt(7, 10), cellAt(6, 10)}}
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(cryptRoom, 0, 0, 12, 12)}, Props: wallRow(6, 5, 7),
@@ -129,7 +129,7 @@ func TestTombWatch(t *testing.T) {
 	// does not — beliefs are state and traveled in the aggregate).
 	data := enc.ToData()
 	enc2, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{}, Data: data, Deciders: map[encounter.MemberID]encounter.Decider{
 			goblin: &patrolDecider{positions: []spatial.Position{cellAt(7, 10), cellAt(6, 10)}},
 		}})
 	require.NoError(t, err, "beat 4: the suspended scene crosses a process boundary")
@@ -267,7 +267,7 @@ func TestTombWatch(t *testing.T) {
 		})
 	}
 	sequel, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
 			Regions: []encounter.RegionInput{rectRegion(cryptRoom, 0, 0, 12, 12)}, Props: wallRow(6, 5, 7),

--- a/rulebooks/dnd5e/encounter/turndriver.go
+++ b/rulebooks/dnd5e/encounter/turndriver.go
@@ -285,6 +285,112 @@ func (RefusingStriker) Strike(context.Context, *Encounter, MemberID, MemberID, c
 	return ErrRefusingStriker
 }
 
+// BoundaryKind names a temporal boundary a clock verb crossed.
+//
+// TWO KINDS, because two are what anything publishes. play/clock also reports
+// RoundStarted, and this composition translates it to nothing — losing nothing,
+// because clock.Turn.End increments the round BEFORE stamping the TurnStarted
+// that follows a wrap. The round advancing is therefore already visible as a
+// changed Round on the next turn boundary, and a second way to say it would be
+// a second way to disagree.
+//
+// Nor is a round boundary merely unpublished-for-now. 5e measures durations in
+// rounds and resolves every one of them on a turn — "until the start of your
+// next turn", "at the end of its turn" — so the round is a COORDINATE rather
+// than a trigger. Kirk ruled it 2026-08-27: "rage is from my turn to my turn.
+// If I am last in initiative I keep rage until the end of my next turn. what
+// would need round end?" Nothing did. The day something does, the kind arrives
+// with its publisher and its first subscriber together.
+type BoundaryKind string
+
+const (
+	// TurnStarted marks Subject's turn beginning.
+	TurnStarted BoundaryKind = "turn_started"
+	// TurnEnded marks Subject's turn ending.
+	TurnEnded BoundaryKind = "turn_ended"
+)
+
+// Boundary is one temporal boundary this composition crossed, in this
+// composition's own vocabulary.
+//
+// A translation of [clock.Milestone] rather than a re-export of it, for the
+// reason every other clock report here is translated: the leaf speaks
+// core.EntityID and this module speaks MemberID, and a host must never come to
+// name an inner type.
+type Boundary struct {
+	// Kind is which boundary was crossed.
+	Kind BoundaryKind
+
+	// Subject is whose turn it is about. Never empty: both kinds are about
+	// somebody.
+	Subject MemberID
+
+	// Round is which round of the fight the boundary belongs to.
+	Round int
+}
+
+// Announcer publishes the temporal boundaries a clock advance crossed.
+//
+// SUPPLIED, NEVER DEFAULTED (rpg-toolkit#1033), like every other
+// rulebook-facing capability on this module and for the same reason: this
+// module's go.mod cannot import the rulebook (C1), so it cannot know what a
+// turn boundary MEANS to a condition. What it can do is notice the boundary —
+// which is its job, since "the composition is the first layer allowed to have
+// an opinion about the game" — and hand it to something that can.
+//
+// # Why a capability rather than a return value
+//
+// This is the whole reason this type exists instead of another output field.
+//
+// [Encounter.EndTurn] drives every consecutive unplayed member forward inside
+// one call (rpg-toolkit#1162), and those members ATTACK during the drive,
+// through [Striker]. Boundaries merely returned and published afterwards would
+// put every driven member's turn-start AFTER that member had already swung.
+//
+// Today that is invisible: nothing on a monster's sheet subscribes to a turn
+// boundary. Which is exactly the shape of defect worth refusing to build —
+// correct by coincidence, silent the moment the coincidence ends. So the
+// boundary is announced AT the crossing, before the member the clock landed on
+// acts, and an implementation gets the live *Encounter for the same reason
+// Striker does.
+//
+// # Required, never defaulted
+//
+// A nil Announcer is not "boundaries are switched off". It is "every condition
+// scoped to a turn silently never expires" — which is the bug this capability
+// was introduced to fix, and it went unnoticed for months precisely because
+// nothing said anything. Refused at the door, exactly as [TurnDriver],
+// [Striker], Standing and Sight are.
+type Announcer interface {
+	// Announce publishes the boundaries one clock advance crossed, in the
+	// causal order given, before the next member acts.
+	//
+	// An error here is an ANNOUNCER MALFUNCTION and aborts the caller's
+	// whole verb, exactly as [TurnDriver.Act] and [Striker.Strike] errors
+	// do. Nothing is persisted until the caller's own commit, so a failure
+	// costs the retry and nothing else.
+	Announce(ctx context.Context, enc *Encounter, crossed []Boundary) error
+}
+
+// RefusingAnnouncer is an Announcer for construction-only worlds — the exact
+// twin of [RefusingStriker], and for the identical reason.
+//
+// A clock cannot advance on a world built only to be inspected: rpg-api's
+// placement probes, a template's acceptance test, resolution's own reconstructed
+// snapshot (which never calls EndTurn or form, so no boundary can be crossed
+// inside one). Reaching this is therefore a HOST BUG.
+//
+// NOT A NO-OP, and the difference is the whole point. A silently-succeeding
+// default would be indistinguishable from a boundary nobody published — which
+// is the defect this capability exists to end. The test for an absent value is
+// not "is it harmless" but "does it say what the author meant".
+type RefusingAnnouncer struct{}
+
+// Announce always fails with ErrRefusingAnnouncer.
+func (RefusingAnnouncer) Announce(context.Context, *Encounter, []Boundary) error {
+	return ErrRefusingAnnouncer
+}
+
 // Striker resolves and records one member's attack against another.
 //
 // SUPPLIED, NEVER DEFAULTED (rpg-toolkit#1033), for the same reason every

--- a/rulebooks/dnd5e/encounter/void_test.go
+++ b/rulebooks/dnd5e/encounter/void_test.go
@@ -78,7 +78,7 @@ func gappedField(void encounter.Void) encounter.FieldInput {
 // that nothing forms a fight and sight is the only thing under test.
 func (s *VoidSuite) gapped(void encounter.Void) *encounter.Encounter {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: gappedField(void),
 		Members: []encounter.MemberInput{
 			{ID: brenna, Kind: encounter.KindPlayer, Position: spatial.Position{X: 3, Y: 1}},
@@ -160,7 +160,7 @@ func (s *VoidSuite) TestTransparentVoidIsStillNotFloor() {
 // gap.
 func (s *VoidSuite) TestOpaqueVoidDoesNotBlockSightWithinAChamber() {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: gappedField(encounter.VoidIsOpaque()),
 		Members: []encounter.MemberInput{
 			{ID: brenna, Kind: encounter.KindPlayer, Position: spatial.Position{X: 0, Y: 0}},
@@ -200,7 +200,7 @@ func (s *VoidSuite) TestTheHandedOutCanvasAnswersTheSameWay() {
 // it construction data (rpg-toolkit#1033's law, applied to the map).
 func (s *VoidSuite) TestAFieldMustSayWhatItsVoidIs() {
 	_, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: encounter.FieldInput{
 			Regions: []encounter.RegionInput{rectRegion(voidWest, 0, 0, 4, 4)},
 		},
@@ -231,7 +231,7 @@ func (s *VoidSuite) TestTheDeclarationSurvivesASave() {
 
 			back, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 				Data:  data,
-				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+				Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 			})
 			s.Require().NoError(err)
 
@@ -269,7 +269,7 @@ func (s *VoidSuite) TestAnOldBlobIsRefusedByName() {
 
 	_, err = encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:  old,
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Contains(err.Error(), "canvas.void", "the refusal names the field the blob does not carry")
@@ -287,7 +287,7 @@ func (s *VoidSuite) TestAnUnknownVoidIsRefusedByName() {
 
 	_, err := encounter.LoadEncounter(&encounter.LoadEncounterInput{
 		Data:  data,
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 	})
 	s.Require().ErrorIs(err, encounter.ErrNoField)
 	s.Contains(err.Error(), "lava", "the refusal quotes the word it does not know")
@@ -309,7 +309,7 @@ func (s *VoidSuite) TestAnUnknownVoidIsRefusedByName() {
 func (s *VoidSuite) TestTheCanvasKeepsItsOwnCopyOfTheChambers() {
 	field := gappedField(encounter.VoidIsOpaque())
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field: field,
 		Members: []encounter.MemberInput{
 			{ID: brenna, Kind: encounter.KindPlayer, Position: spatial.Position{X: 3, Y: 1}},
@@ -390,7 +390,7 @@ func contiguousField(void encounter.Void) encounter.FieldInput {
 // canvasOf opens a field with nobody in it and hands back its map.
 func (s *VoidSuite) canvasOf(field encounter.FieldInput) spatial.Room {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: everyoneSeesTheWholeMap{}, Standing: everyoneStanding{}, Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   field,
 		Endings: []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/encounter/voidcost_internal_test.go
+++ b/rulebooks/dnd5e/encounter/voidcost_internal_test.go
@@ -137,7 +137,7 @@ func benchSightRefreshOn(b *testing.B, field FieldInput, rooms, dim, members int
 	}
 
 	enc, err := NewEncounter(&SetupInput{
-		Sight: benchSight{1 << 20}, Standing: benchStanding{}, Initiative: benchRoller{}, TurnDriver: passDriver{}, Striker: passStriker{},
+		Sight: benchSight{1 << 20}, Standing: benchStanding{}, Initiative: benchRoller{}, TurnDriver: passDriver{}, Striker: passStriker{}, Announcer: quietAnnouncer{},
 		Field:   field,
 		Members: mi,
 		Endings: []EndingInput{{Key: "done", Trigger: TriggerExternal{}}},


### PR DESCRIPTION
**PR 2 of 5** for rpg-project#294 — *a boundary is an interaction*. Design: KirkDiggler/rpg-project#293.

## The clock already crossed these. Nobody was told.

`play/clock.Turn.End` has always returned the whole ordered milestone sequence from every advance — `TurnEnded(a, N)` → `[RoundStarted(N+1)]` → `TurnStarted(b, N)` — and `Milestone`'s own doc says what it is for: *"a temporal boundary returned — never published — by the verb that caused it, in causal order."*

**This composition dropped every one.** Zero mentions of `Milestone` in the package outside tests; `clocks.go:461` collapsed the whole sequence into a `bool`. So no turn boundary has ever reached the rules, and the seven conditions that subscribe to one in `Apply` have never fired.

## Why `Announcer` is a capability and not another output field

This is the design, and it is forced by a temporal fact rather than chosen.

`EndTurn` drives every consecutive unplayed member forward **inside one call** (#1162), and those members **attack during the drive**, through `Striker`. Boundaries merely returned and published by the caller afterwards would put each driven member's turn-start *after* the swing it had already made.

Nothing on a monster's sheet subscribes to a turn boundary today, so that ordering is currently invisible in behaviour — which is exactly the shape of correct-by-coincidence worth refusing to build.

It is the **third instance** of a shape already here: `Decider` (world tick) → `TurnDriver` (a monster's turn) → `Announcer` (every clock advance). `RefusingAnnouncer` is `RefusingStriker`'s twin, and deliberately **not a no-op**: a silently-succeeding default is indistinguishable from a boundary nobody published, which is the defect being fixed.

Supplied, never defaulted (#1033). A nil `Announcer` is not "boundaries are off" — it is every turn-scoped condition living forever, silently.

## `form` announces too, which closes an old gap

`SetOrder` has always returned `TurnStarted` for whoever won initiative, and `form` has always dropped it. **Every fight's first turn began with nothing said.** One line, no new machinery — `form` already consults `TurnDriver` at the same point.

## Two kinds, not four

`clock.RoundStarted` translates to **nothing**, and loses nothing: `Turn.End` increments the round *before* stamping the `TurnStarted` that follows a wrap, so the round advancing is already visible as a changed `Round` on the next turn boundary.

Kirk ruled out round boundaries outright (design §3.1): 5e measures durations in rounds and resolves every one of them on a turn, so **the round is a coordinate, not a trigger**. `TestTheRoundAdvancesWithoutARoundBoundary` pins both halves — none published, and the wrap still visible.

## The tests, and what they survived

The first ordering test I wrote **survived a mutant that deleted the announce from `driveOneMonsterTurn` entirely**, while its comment claimed to test exactly that. With one monster after alice, that monster's turn-start comes from *alice's* `EndTurn`; the drive loop never enters into it.

`TestTheSECONDDrivenMemberAlsoHearsItsTurnStartFirst` is the real case — two consecutive unplayed members, where one turn ends and the next begins inside the loop with nobody's `EndTurn` between. Who is driven second is derived from the journal rather than assumed, so the test is about announcement and not about `orderAsGiven`.

Both capabilities write into **one** journal, because two recorders could each be right about their own calls and say nothing about the order the two happened in.

Then each of the three announce sites was deleted in turn and the suite re-run:

| site removed | tests that die |
|---|---|
| `driveOneMonsterTurn` | 2 |
| `EndTurn` | 2 |
| `form` | 1 |

No site is covered only by a test that would pass without it.

## Evidence

`go build`, `go vet`, `go test ./...`, `golangci-lint run ./...` — **0 issues**, 3 packages green. 55 files touched; 265 of them are the mechanical `Announcer:` insert at test construction sites.

No `Closes` keyword: #294 spans five PRs and only the last carries it.

— platform agent, on behalf of KirkDiggler