### PR TITLE
feat(resolution): a boundary is an interaction

### DIFF
--- a/rulebooks/dnd5e/resolution/boundary.go
+++ b/rulebooks/dnd5e/resolution/boundary.go
@@ -1,0 +1,150 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+)
+
+// BoundaryInput names the temporal boundaries one clock advance crossed.
+//
+// Data at the seam (R2), and the composition's own [encounter.Boundary] rather
+// than a copy of it: this package already takes that module's EncounterData
+// whole, and a second shape for the same three fields would be one more place
+// for the two to disagree.
+type BoundaryInput struct {
+	// Crossed is the boundaries, in the causal order the composition crossed
+	// them. Required and non-empty — see [NewBoundary].
+	Crossed []encounter.Boundary
+}
+
+// BoundaryOutcome is what a boundary interaction produced.
+//
+// Deliberately thin. A boundary's real output is not this value at all: it is
+// the DIRTY SHEETS that come back on [Output], because everything a boundary
+// does happens inside a condition deciding its own turn is over. Announced is
+// here so a caller can tell "the interaction ran and published four things"
+// from "the interaction ran and published nothing", which is otherwise
+// invisible on a verb that changes no hit points and spends no economy.
+type BoundaryOutcome struct {
+	// Announced is how many boundaries were published on the bus.
+	Announced int
+}
+
+func (BoundaryOutcome) isOutcome() {}
+
+// NewBoundary returns the machine that publishes one clock advance's
+// boundaries.
+//
+// Every attached effect hears them on the interaction's own bus, so a
+// condition scoped to a turn — dodging, disengaging, raging, reckless attack,
+// sneak-attack-used, a death save waiting on its owner's turn — gets its
+// chance to expire, tick, or fire, and comes back dirty.
+//
+// # A boundary is an interaction, and that is the whole shape
+//
+// The composition NOTICES the boundary; it cannot publish one, because it
+// holds no bus (ADR-0038) and the leaf below it *"returns its results as
+// values, and never publishes to a bus"*. This package is the only place a bus
+// exists. So the composition hands the boundary out through its Announcer
+// capability, its host turns that into a call here, and everyone attached hears
+// it — which is the same journey a swing already makes, with time as the
+// declaring actor instead of a player.
+//
+// # No new step kind
+//
+// A crossing is "do this on the bus and hand me the next step", which is what
+// [Gather] already does for the contest's imposition. Adding a Step case
+// against one more example is the mistake [ADR-0007] exists to remember.
+//
+// It does move the tally this package's own doc keeps, and that is recorded
+// rather than left for someone to rediscover — see "The bus-effect tally".
+//
+// # Refuses an empty set
+//
+// An advance that crossed nothing is not an interaction, and running one would
+// load every sheet, attach every effect, publish nothing and hand back a clean
+// world — an expensive way to do nothing, and a resolution in the registration
+// list that no boundary explains. The composition already declines to announce
+// an empty set; this refuses one for the same reason from the other side.
+func NewBoundary(in *BoundaryInput) (Machine, error) {
+	if in == nil {
+		return nil, ErrNilInput
+	}
+	if len(in.Crossed) == 0 {
+		return nil, fmt.Errorf("%w: no boundaries to announce", ErrBadBoundary)
+	}
+	for i, b := range in.Crossed {
+		if b.Subject == "" {
+			return nil, fmt.Errorf("%w: boundary %d has no subject", ErrBadBoundary, i)
+		}
+		if _, ok := boundaryTopics[b.Kind]; !ok {
+			return nil, fmt.Errorf("%w: boundary %d has unknown kind %q", ErrBadBoundary, i, b.Kind)
+		}
+	}
+	crossed := make([]encounter.Boundary, len(in.Crossed))
+	copy(crossed, in.Crossed)
+	return &boundaryMachine{crossed: crossed}, nil
+}
+
+// boundaryTopics is the whole map from a crossing to what it publishes.
+//
+// A SEALED LOOKUP rather than a switch with a default, so a boundary kind this
+// build does not know is refused by [NewBoundary] at the door instead of
+// silently publishing nothing. The composition's kind set and this one are the
+// same set by construction: if one grows, this refuses until the other does.
+var boundaryTopics = map[encounter.BoundaryKind]func(
+	ctx context.Context, bus events.EventBus, b encounter.Boundary,
+) error{
+	encounter.TurnStarted: func(ctx context.Context, bus events.EventBus, b encounter.Boundary) error {
+		return dnd5eEvents.TurnStartTopic.On(bus).Publish(ctx, dnd5eEvents.TurnStartEvent{
+			SubjectID: string(b.Subject),
+			Round:     b.Round,
+		})
+	},
+	encounter.TurnEnded: func(ctx context.Context, bus events.EventBus, b encounter.Boundary) error {
+		return dnd5eEvents.TurnEndTopic.On(bus).Publish(ctx, dnd5eEvents.TurnEndEvent{
+			SubjectID: string(b.Subject),
+			Round:     b.Round,
+		})
+	},
+}
+
+type boundaryMachine struct {
+	crossed []encounter.Boundary
+}
+
+// Start is pure preflight: it validates nothing further (NewBoundary already
+// refused what it could) and yields the first crossing without publishing.
+func (m *boundaryMachine) Start(_ context.Context, _ *Participants) (Step, error) {
+	return m.at(0), nil
+}
+
+// at yields the step that publishes crossing i, or Done when they are exhausted.
+//
+// One step per crossing rather than one step publishing all of them: each is a
+// separate thing that happened, and a step log that reads "end alice's turn"
+// then "start bob's turn" is the record the composition's causal ordering was
+// preserved for.
+func (m *boundaryMachine) at(i int) Step {
+	if i >= len(m.crossed) {
+		return Done{Outcome: BoundaryOutcome{Announced: len(m.crossed)}}
+	}
+	b := m.crossed[i]
+	publish := boundaryTopics[b.Kind]
+	return Gather{
+		name: fmt.Sprintf("announce %s for %s", b.Kind, b.Subject),
+		run: func(ctx context.Context, bus events.EventBus) (Step, error) {
+			if err := publish(ctx, bus, b); err != nil {
+				return nil, fmt.Errorf("announce %s for %q: %w", b.Kind, b.Subject, err)
+			}
+			return m.at(i + 1), nil
+		},
+	}
+}

--- a/rulebooks/dnd5e/resolution/boundary_test.go
+++ b/rulebooks/dnd5e/resolution/boundary_test.go
@@ -1,0 +1,198 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+	"github.com/stretchr/testify/suite"
+)
+
+type BoundaryTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func TestBoundarySuite(t *testing.T) { suite.Run(t, new(BoundaryTestSuite)) }
+
+func (s *BoundaryTestSuite) SetupTest() { s.ctx = context.Background() }
+
+// heard records every turn boundary that reached the bus, in the order it
+// arrived — which is the only thing these tests are about.
+type heard struct {
+	starts []dnd5eEvents.TurnStartEvent
+	ends   []dnd5eEvents.TurnEndEvent
+	order  []string
+}
+
+func (h *heard) listen(ctx context.Context, bus events.EventBus) {
+	_, _ = dnd5eEvents.TurnStartTopic.On(bus).Subscribe(ctx,
+		func(_ context.Context, e dnd5eEvents.TurnStartEvent) error {
+			h.starts = append(h.starts, e)
+			h.order = append(h.order, "start:"+e.SubjectID)
+			return nil
+		})
+	_, _ = dnd5eEvents.TurnEndTopic.On(bus).Subscribe(ctx,
+		func(_ context.Context, e dnd5eEvents.TurnEndEvent) error {
+			h.ends = append(h.ends, e)
+			h.order = append(h.order, "end:"+e.SubjectID)
+			return nil
+		})
+}
+
+// runBoundary drives a boundary interaction on a bus this test holds, so it can
+// hear what was published. resolveOn exists for exactly this.
+func (s *BoundaryTestSuite) runBoundary(crossed []encounter.Boundary) (*Output, *heard, error) {
+	machine, err := NewBoundary(&BoundaryInput{Crossed: crossed})
+	s.Require().NoError(err)
+
+	h := &heard{}
+	bus := events.NewEventBus()
+	h.listen(s.ctx, bus)
+
+	out, err := resolveOn(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Character: probeSheet(heroID)}},
+		Initiative:   orderAsGiven{}, TurnDriver: passDriver{},
+		Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Roller:  dice.NewRoller(),
+		Machine: machine,
+	}, newSurface(bus))
+	return out, h, err
+}
+
+func (s *BoundaryTestSuite) world() encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{},
+		Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Field: encounter.FieldInput{
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	return enc.ToData()
+}
+
+// TestEveryCrossingReachesTheBusInOrder is the point of the whole machine: a
+// clock advance's boundaries arrive on the interaction's own bus, in the causal
+// order the composition crossed them, where every attached effect hears them.
+func (s *BoundaryTestSuite) TestEveryCrossingReachesTheBusInOrder() {
+	out, h, err := s.runBoundary([]encounter.Boundary{
+		{Kind: encounter.TurnEnded, Subject: "alice", Round: 1},
+		{Kind: encounter.TurnStarted, Subject: "bob", Round: 1},
+		{Kind: encounter.TurnEnded, Subject: "bob", Round: 1},
+		{Kind: encounter.TurnStarted, Subject: "alice", Round: 2},
+	})
+	s.Require().NoError(err)
+
+	s.Equal([]string{"end:alice", "start:bob", "end:bob", "start:alice"}, h.order,
+		"causal order survives the trip from the composition to the bus")
+
+	// The machine ITSELF attaches nothing: every registration on the way in
+	// belongs to a participant's own sheet-keeper, which is what R3 attaching
+	// everyone already produces. A boundary interaction only publishes.
+	for _, h := range out.Hooks {
+		s.Equal(heroID, h.Participant, "every hook belongs to a participant, none to the machine")
+	}
+	s.Require().IsType(BoundaryOutcome{}, out.Outcome)
+	s.Equal(4, out.Outcome.(BoundaryOutcome).Announced)
+}
+
+// TestTheRoundRidesOnTheTurn pins the other half of Kirk's ruling from this
+// side of the seam: there is no round event, and the round is not lost — it
+// arrives as a field on the turn boundary that follows the wrap.
+func (s *BoundaryTestSuite) TestTheRoundRidesOnTheTurn() {
+	_, h, err := s.runBoundary([]encounter.Boundary{
+		{Kind: encounter.TurnEnded, Subject: "alice", Round: 1},
+		{Kind: encounter.TurnStarted, Subject: "alice", Round: 2},
+	})
+	s.Require().NoError(err)
+
+	s.Require().Len(h.ends, 1)
+	s.Require().Len(h.starts, 1)
+	s.Equal(1, h.ends[0].Round, "the turn that ended belonged to round 1")
+	s.Equal(2, h.starts[0].Round, "and the one that started belongs to round 2")
+}
+
+// TestTheSubjectSurvivesTheTranslation — a monster's id reaches the event
+// unchanged. The field it lands in is called SubjectID precisely so this is not
+// a lie (rpg-toolkit#1258).
+func (s *BoundaryTestSuite) TestTheSubjectSurvivesTheTranslation() {
+	_, h, err := s.runBoundary([]encounter.Boundary{
+		{Kind: encounter.TurnEnded, Subject: "goblin-7", Round: 3},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(h.ends, 1)
+	s.Equal("goblin-7", h.ends[0].SubjectID)
+}
+
+// TestAnUnknownKindIsRefusedRatherThanPublishedAsNothing is the load-bearing
+// refusal. The composition's kind set and this package's topic table are the
+// same set by construction; if one grows, a switch with a default would
+// silently publish nothing and the new boundary would be as inert as
+// TurnStartTopic has been all along.
+func (s *BoundaryTestSuite) TestAnUnknownKindIsRefusedRatherThanPublishedAsNothing() {
+	_, err := NewBoundary(&BoundaryInput{Crossed: []encounter.Boundary{
+		{Kind: encounter.BoundaryKind("round_ended"), Subject: "alice", Round: 1},
+	}})
+	s.Require().ErrorIs(err, ErrBadBoundary)
+}
+
+// TestAnEmptyAdvanceIsNotAnInteraction — running one would load every sheet,
+// attach every effect, publish nothing, and leave a resolution in the record
+// that no boundary explains.
+func (s *BoundaryTestSuite) TestAnEmptyAdvanceIsNotAnInteraction() {
+	_, err := NewBoundary(&BoundaryInput{})
+	s.Require().ErrorIs(err, ErrBadBoundary)
+
+	_, err = NewBoundary(nil)
+	s.Require().ErrorIs(err, ErrNilInput)
+}
+
+// TestASubjectlessCrossingIsRefused — both kinds are about somebody, and a
+// crossing with no subject would publish an event every condition's own guard
+// silently ignores. Inert, and indistinguishable from not having happened.
+func (s *BoundaryTestSuite) TestASubjectlessCrossingIsRefused() {
+	_, err := NewBoundary(&BoundaryInput{Crossed: []encounter.Boundary{
+		{Kind: encounter.TurnEnded, Round: 1},
+	}})
+	s.Require().ErrorIs(err, ErrBadBoundary)
+}
+
+// TestTheInputIsCopied — a caller that reuses its slice cannot change what this
+// machine will publish after it was built.
+func (s *BoundaryTestSuite) TestTheInputIsCopied() {
+	crossed := []encounter.Boundary{{Kind: encounter.TurnEnded, Subject: "alice", Round: 1}}
+	machine, err := NewBoundary(&BoundaryInput{Crossed: crossed})
+	s.Require().NoError(err)
+
+	crossed[0].Subject = "somebody-else"
+
+	h := &heard{}
+	bus := events.NewEventBus()
+	h.listen(s.ctx, bus)
+	_, err = resolveOn(s.ctx, &Input{
+		World:        s.world(),
+		Participants: []Participant{{Character: probeSheet(heroID)}},
+		Initiative:   orderAsGiven{}, TurnDriver: passDriver{},
+		Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Roller:  dice.NewRoller(),
+		Machine: machine,
+	}, newSurface(bus))
+	s.Require().NoError(err)
+
+	s.Require().Len(h.ends, 1)
+	s.Equal("alice", h.ends[0].SubjectID)
+}

--- a/rulebooks/dnd5e/resolution/contest_test.go
+++ b/rulebooks/dnd5e/resolution/contest_test.go
@@ -56,14 +56,14 @@ func (s *ContestTestSuite) wolfsKnockdown() *saves.SaveGate {
 }
 
 func (s *ContestTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
-			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 2, Y: 1}},
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: wolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 2, Y: 1}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/resolution/cost_test.go
+++ b/rulebooks/dnd5e/resolution/cost_test.go
@@ -139,14 +139,14 @@ func (s *CostTestSuite) strikeCost(data *character.Data) *combat.SpendProfile {
 }
 
 func (s *CostTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
-			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 5, Y: 6}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/resolution/damage_custody_test.go
+++ b/rulebooks/dnd5e/resolution/damage_custody_test.go
@@ -265,14 +265,14 @@ func (s *DamageCustodyTestSuite) TestTypedOutcomePreservesMixedVulnerabilityAndI
 // Real content, and the case a synthetic subscriber cannot pin: a raging
 // barbarian takes half from the wolf's piercing bite.
 func (s *DamageCustodyTestSuite) TestARagingTargetsResistanceReadsTheEventsDamageType() {
-	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	world, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
-			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 5, Y: 6}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -396,14 +396,14 @@ func (s *DamageCustodyTestSuite) addFlatOnBus(bus events.EventBus, amount int, t
 // it keeps a character's AC chain out of the arithmetic under test, and the
 // damage fold is the same fold whoever is swinging.
 func (s *DamageCustodyTestSuite) roomWith(attacker, target encounter.MemberID) encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: attacker, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
-			{ID: target, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+			{ID: attacker, Kind: encounter.KindMonster, Position: spatial.Position{X: 5, Y: 5}},
+			{ID: target, Kind: encounter.KindMonster, Position: spatial.Position{X: 5, Y: 6}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/resolution/dirty_test.go
+++ b/rulebooks/dnd5e/resolution/dirty_test.go
@@ -90,15 +90,15 @@ func (s *DirtyTestSuite) ragingHero() *character.Data {
 
 func (s *DirtyTestSuite) world() encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{},
 		Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
-			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 5, Y: 6}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -159,16 +159,16 @@ func (s *DirtyTestSuite) TestAnUntouchedParticipantIsNotReturned() {
 	bite := monsters.NewWolf(wolfID).ToData().Actions[0]
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{},
 		Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
-			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
-			{ID: secondWolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 5, Y: 6}},
+			{ID: secondWolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 1, Y: 1}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/resolution/doc.go
+++ b/rulebooks/dnd5e/resolution/doc.go
@@ -145,6 +145,19 @@
 // argument reverses with it. At that point the question comes back as an ADR
 // with the new tally as its evidence. Until then there is nothing to decide.
 //
+// THE TALLY HAS MOVED, and this is the paragraph that asked to be told.
+// [NewBoundary] yields one pure-effect step per boundary a clock advance
+// crossed — two on an ordinary turn end, and as many as a driven fight
+// produces — so pure effects now outnumber folds in any interaction that is a
+// boundary at all. It does NOT force a fifth step kind: a crossing is "do this
+// on the bus and hand me the next step", which is exactly what [Gather] already
+// does for the imposition above, and extending a sealed set against one more
+// example is the mistake [ADR-0007] exists to remember. What has changed is
+// that the ratio argument can no longer be the reason. If the question comes
+// back, it comes back on whether "fold a chain" and "announce something" want
+// to be told apart by TYPE rather than by [Gather.Name] — which is a different
+// question from the one this section settled, and a better one.
+//
 // All three folds are this package's own. The damage chain was the last one
 // held elsewhere: slice 1 handed resolution's bus to combat.ResolveDamage,
 // because every exported attack and damage entry point in that package required

--- a/rulebooks/dnd5e/resolution/effective_ac_test.go
+++ b/rulebooks/dnd5e/resolution/effective_ac_test.go
@@ -98,14 +98,14 @@ func (s *EffectiveACTestSuite) defenseStyle() json.RawMessage {
 }
 
 func (s *EffectiveACTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
-			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 5, Y: 5}},
+			{ID: wolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 5, Y: 6}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -270,14 +270,14 @@ func (s *EffectiveACTestSuite) TestAMonsterTargetStillReportsItsStatBlockAC() {
 	second := monsters.NewWolf(secondWolfID).ToData()
 	attack := data.Actions[0]
 
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: wolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
-			{ID: secondWolfID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 6}},
+			{ID: wolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 5, Y: 5}},
+			{ID: secondWolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 5, Y: 6}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/resolution/errors.go
+++ b/rulebooks/dnd5e/resolution/errors.go
@@ -90,6 +90,14 @@ var (
 	// ErrBadAction indicates an invalid or unsupported shared action definition.
 	ErrBadAction = errors.New("resolution: invalid action definition")
 
+	// ErrBadBoundary indicates a boundary set this package cannot announce:
+	// empty, a crossing with no subject, or a kind this build has no topic
+	// for. The last is the load-bearing one — the composition's boundary
+	// kinds and this package's topic table are the same set by
+	// construction, so a kind added on one side is REFUSED here rather than
+	// silently published as nothing.
+	ErrBadBoundary = errors.New("resolution: invalid boundary set")
+
 	// ErrOutOfRange indicates a valid attack whose target lies beyond its delivery.
 	ErrOutOfRange = errors.New("resolution: target is out of range")
 

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.102.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.6
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,10 +16,10 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.102.0 h1:ODT3LGh2tMXvNUNytmvfPlzf2gdGqYeUjU7SVfTbwNg=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.102.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.6 h1:O4YgK5tjVmeAY2L+Oj9IIuRh3SCFFRvODemW42u5Zyw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.30.6/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.0 h1:atNifq4Wp4GLg43AwvvL0s0qT3xXFl3SlkGBRMYlPxY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.0 h1:kn+Xnipla3I6bDFbSfZGlZXSeIcX0mTjGvHofAQH8To=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/resolution/regionfixtures_test.go
+++ b/rulebooks/dnd5e/resolution/regionfixtures_test.go
@@ -1,0 +1,38 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// rectRegion paints a rectangular floor in the encounter's one absolute frame,
+// the same way the composition's own suites do.
+//
+// These fixtures used to say Rooms + RoomInput{Width, Height} and give each
+// member a Room, because this package's tests were pinned to an encounter two
+// world-models old (v0.30.6) while its non-test code was already compatible
+// with the current one. Nothing caught it: a module's tests compile against its
+// OWN pin, and only a consumer linking everything together picks the newer
+// version by MVS. So the suite was green against a shape the product had
+// stopped building — which is this slice's recurring theme, one layer over.
+func rectRegion(id string, col, row, w, h int) encounter.RegionInput {
+	cells := make([]spatial.Position, 0, w*h)
+	for r := 0; r < h; r++ {
+		for c := 0; c < w; c++ {
+			cells = append(cells, spatial.Position{X: float64(col + c), Y: float64(row + r)})
+		}
+	}
+	return encounter.RegionInput{
+		ID: id, Name: id, Cells: cells, Archetype: "crypt",
+		Lighting: &encounter.Lighting{Intensity: 1},
+	}
+}
+
+// hexCanvas is the orientation the product actually runs on. Square grids stay
+// an option in the toolkit; the game is hex exclusively.
+func hexCanvas() encounter.CanvasInput {
+	return encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()}
+}

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -302,6 +302,16 @@ func resolveOn(ctx context.Context, in *Input, surf *surface) (*Output, error) {
 		// was never built for; RefusingStriker names that loudly rather
 		// than fabricating a hit.
 		Striker: encounter.RefusingStriker{},
+		// And a construction-only Announcer, for the same reason and by the
+		// same argument. It READS like recursion — an Announcer's job is to
+		// call this package, and here this package is handing one over — and
+		// it is not: no clock advances inside a resolution. Boundaries are
+		// crossed by EndTurn and form, and the sentence directly above is
+		// that this package calls neither. A boundary reaching here would
+		// mean this reconstruction is being asked to do something it was
+		// never built for; RefusingAnnouncer names that loudly rather than
+		// swallowing it.
+		Announcer: encounter.RefusingAnnouncer{},
 	})
 	if err != nil {
 		return nil, fmt.Errorf("resolution: load world: %w", err)

--- a/rulebooks/dnd5e/resolution/resolve_test.go
+++ b/rulebooks/dnd5e/resolution/resolve_test.go
@@ -69,14 +69,14 @@ func (s *ResolveTestSuite) SetupTest() {
 // world is a two-member encounter, already normalised by a load/save cycle so
 // that "unchanged" can be asserted literally.
 func (s *ResolveTestSuite) world() encounter.EncounterData {
-	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
-			{ID: skeletonID, Kind: encounter.KindMonster, Room: "room-1", Position: spatial.Position{X: 5, Y: 5}},
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: skeletonID, Kind: encounter.KindMonster, Position: spatial.Position{X: 5, Y: 5}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -637,13 +637,13 @@ func (c *countingStanding) Standing(_ []encounter.MemberID) ([]encounter.MemberI
 // zero is how that stays a decision rather than a coincidence.
 func TestTheStandingCapabilityIsCarriedAndNeverAsked(t *testing.T) {
 	world, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -703,13 +703,13 @@ func (c *countingSight) Sight(members []encounter.MemberID) (map[encounter.Membe
 // darkvision it holds nothing of.
 func TestTheSightCapabilityIsCarriedAndNeverAsked(t *testing.T) {
 	world, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room-1", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 1, Y: 1}},
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/resolution/strike_test.go
+++ b/rulebooks/dnd5e/resolution/strike_test.go
@@ -59,14 +59,14 @@ func (r *actionRoller) RollN(_ context.Context, count, sides int) ([]int, error)
 
 func actionWorld(t *testing.T, targetX float64) encounter.EncounterData {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room", Width: 30, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room", 0, 0, 30, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: wolfID, Kind: encounter.KindMonster, Room: "room", Position: spatial.Position{X: 1, Y: 1}},
-			{ID: heroID, Kind: encounter.KindPlayer, Room: "room", Position: spatial.Position{X: targetX, Y: 1}},
+			{ID: wolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: targetX, Y: 1}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -107,14 +107,14 @@ func resolveActionDefinitionAgainstMonster(
 	t *testing.T, definition combatActions.Definition, roller dice.Roller,
 ) (*Output, error) {
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms:  []encounter.RoomInput{{ID: "room", Width: 10, Height: 10}},
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room", 0, 0, 10, 10)},
 		},
 		Members: []encounter.MemberInput{
-			{ID: wolfID, Kind: encounter.KindMonster, Room: "room", Position: spatial.Position{X: 1, Y: 1}},
-			{ID: secondWolfID, Kind: encounter.KindMonster, Room: "room", Position: spatial.Position{X: 2, Y: 1}},
+			{ID: wolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: secondWolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 2, Y: 1}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})

--- a/rulebooks/dnd5e/resolution/testrollers_test.go
+++ b/rulebooks/dnd5e/resolution/testrollers_test.go
@@ -97,6 +97,19 @@ func (noAttacksExpected) Strike(
 	return errors.New("resolution fixtures: no scene here ever attacks")
 }
 
+// quietAnnouncer hears every boundary and does nothing with it.
+//
+// UNLIKE noAttacksExpected this really is called — any pair of fixtures
+// standing in contact forms a bubble at first light, and forming one starts
+// round 1 and somebody's turn. It succeeds silently because these fixtures are
+// about what Resolve does with a world, not about what a turn boundary means
+// to a condition; boundary_test.go uses a recording one.
+type quietAnnouncer struct{}
+
+func (quietAnnouncer) Announce(context.Context, *encounter.Encounter, []encounter.Boundary) error {
+	return nil
+}
+
 // unlimitedSight is the range these fixtures hand out. Further than the longest
 // sightline any field in this package draws, because light is not this
 // package's subject — and stated as a number rather than left to a default,

--- a/rulebooks/dnd5e/resolution/world_test.go
+++ b/rulebooks/dnd5e/resolution/world_test.go
@@ -60,34 +60,47 @@ func (probeOutcome) isOutcome() {}
 func walledWorld(t *testing.T) encounter.EncounterData {
 	t.Helper()
 
-	var seam []spatial.Boundary
+	// SAME-ROW PAIRS ONLY. This loop used to author the diagonals too — "every
+	// edge, diagonals included, because spatial registers a boundary between
+	// ANY two adjacent cells and a same-row wall has a hole at each corner
+	// (rpg-toolkit#1106's lesson)". That lesson was learned on a SQUARE grid,
+	// where (9,y) and (10,y±1) touch at a corner. The product runs on pointy-top
+	// hex exclusively, where they do not touch at all, and the composition now
+	// refuses a wall between cells that are not adjacent — by name, which is how
+	// this surfaced rather than compiling into a wall that blocks nothing.
+	//
+	// Whether a hex seam needs its own hole-free pattern is the composition's
+	// question and not this package's. What this fixture owes the tests below is
+	// one authored wall on the installed map, at the pair they probe.
+	var seam []encounter.WallInput
 	for y := 0; y < 8; y++ {
-		for _, dy := range []int{-1, 0, 1} {
-			to := y + dy
-			if to < 0 || to >= 8 {
-				continue
-			}
-			seam = append(seam, spatial.Boundary{
-				From:              spatial.Position{X: 9, Y: float64(y)},
-				To:                spatial.Position{X: 10, Y: float64(to)},
-				BlocksMovement:    true,
-				BlocksLineOfSight: true,
-			})
-		}
+		seam = append(seam, encounter.WallInput{Boundary: spatial.Boundary{
+			From:              spatial.Position{X: 9, Y: float64(y)},
+			To:                spatial.Position{X: 10, Y: float64(y)},
+			BlocksMovement:    true,
+			BlocksLineOfSight: true,
+		}})
 	}
 
 	enc, err := encounter.NewEncounter(&encounter.SetupInput{
-		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Standing: everyoneStanding{},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{}, Announcer: quietAnnouncer{}, Standing: everyoneStanding{},
 		Sight: everyoneSeesTheWholeMap{},
 		Field: encounter.FieldInput{
-			Canvas: encounter.CanvasInput{Void: encounter.VoidIsOpaque()},
-			Rooms: []encounter.RoomInput{
-				{ID: "room-1", Width: 10, Height: 8, Boundaries: seam},
-				{ID: "room-2", Width: 10, Height: 8, Origin: spatial.Position{X: 10}},
+			Canvas: hexCanvas(),
+			// Two regions on ONE canvas in ONE absolute frame: room-1 owns
+			// columns 0-9, room-2 owns 10-19. They used to be Rooms with
+			// their own Origins and their own local coordinates; the seam
+			// between them is now a wall on the field rather than a boundary
+			// belonging to a room, which is the same fact said by the layer
+			// that actually owns it.
+			Regions: []encounter.RegionInput{
+				rectRegion("room-1", 0, 0, 10, 8),
+				rectRegion("room-2", 10, 0, 10, 8),
 			},
+			Walls: seam,
 		},
 		Members: []encounter.MemberInput{
-			{ID: heroID, Kind: encounter.KindPlayer, Room: "room-1", Position: spatial.Position{X: 9, Y: 4}},
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 9, Y: 4}},
 		},
 		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
 	})
@@ -141,8 +154,16 @@ func TestTheInstalledWorldKnowsAboutWallsThisPackageNeverBuilt(t *testing.T) {
 	probe := runProbe(t, walledWorld(t), []Participant{{Character: probeSheet(heroID)}})
 	require.True(t, probe.found, "a world was installed")
 
-	west := spatial.Position{X: 9, Y: 4}
-	east := spatial.Position{X: 10, Y: 4}
+	// ASKED IN THE ROOM'S OWN FRAME, not in the authored one. These used to be
+	// the literal authored cells, and they were the same numbers: rooms were
+	// local and square. The canvas is one absolute pointy-top hex field now, so
+	// what is authored as offset column 9 of row 4 is not the position the room
+	// reports back — and a test that hardcodes one frame while the composition
+	// speaks the other passes or fails for reasons that have nothing to do with
+	// walls. Compare rpg-toolkit#1150.
+	west, ok := probe.room.GetEntityPosition(heroID)
+	require.True(t, ok, "the hero is on the installed world")
+	east := spatial.Position{X: west.X + 1, Y: west.Y}
 
 	require.Equal(t, float64(1), probe.room.GetGrid().Distance(west, east),
 		"the two cells are adjacent, so nothing but a wall can separate them")
@@ -178,12 +199,20 @@ func TestAWorldIsInstalledForEveryInteraction(t *testing.T) {
 func TestTheInstalledWorldRefusesToBeWrittenTo(t *testing.T) {
 	probe := runProbe(t, walledWorld(t), []Participant{{Character: probeSheet(heroID)}})
 
+	before, ok := probe.room.GetEntityPosition(heroID)
+	require.True(t, ok)
+
 	err := probe.room.MoveEntity(heroID, spatial.Position{X: 1, Y: 1})
 	require.ErrorIs(t, err, encounter.ErrReadOnly)
 
-	at, ok := probe.room.GetEntityPosition(heroID)
+	// UNCHANGED, not merely "not where we aimed". The authored cell used to be
+	// written here as a literal; reading it back first says the same thing
+	// without asserting which coordinate frame the room answers in, and says
+	// the stronger half — that the refusal left the position alone — rather
+	// than only that the move did not land.
+	after, ok := probe.room.GetEntityPosition(heroID)
 	require.True(t, ok)
-	require.Equal(t, spatial.Position{X: 9, Y: 4}, at, "and the hero did not move")
+	require.Equal(t, before, after, "and the hero did not move")
 }
 
 // TestNoCodePathProducesARoomlessInteraction is the STRUCTURAL half, and it is


### PR DESCRIPTION
**PR 3 of 5** for rpg-project#294 — *a boundary is an interaction*. Design: KirkDiggler/rpg-project#293.

Two commits, and the first one is a finding rather than a chore.

---

## 1. This package's tests were pinned two world-models behind the product

`resolution/go.mod` pinned **encounter v0.30.6** while the product ships **v0.36.0**.

Its non-test code was compatible, so nothing broke and nothing said anything. But **a module's tests compile against its own pin**, and only a consumer linking everything together picks the newer version by MVS. So this suite has been green against a shape the product stopped building: `Rooms` with local coordinates and their own `Origin`s, members carrying a `Room`, walls belonging to a room, square-grid adjacency.

That is this slice's own theme, one layer over. *A green suite is not evidence when the suite is the only thing running the configuration it tests.*

**Taking the bump is not optional here.** `Announcer` is required at construction as of encounter v0.36.0, so a `Resolve` compiled against the old shape links against the new one and fails **every load** at runtime.

What the migration surfaced, worst-first:

- **The seam fixture authored square-grid diagonals.** `(9,y)-(10,y±1)` touch at a corner on squares and **do not touch at all** on pointy-top hex. The composition now refuses a non-adjacent wall *by name* — which is why this surfaced instead of compiling into a wall that blocks nothing. The old comment even explained itself: *"every edge, diagonals included... a same-row wall has a hole at each corner (#1106's lesson)"* — a lesson learned on squares.
- **The world probes hardcoded authored offset coordinates** while the room answers in its own frame. Same numbers when rooms were local and square; not now. Both probes read the position back and work relative to it, so the test is about walls rather than about which frame won. Compare #1150.
- **`TestTheInstalledWorldRefusesToBeWrittenTo` asserted the hero was still at a literal cell.** It now captures the position *before* the refused move and asserts it is **unchanged** — the stronger half, and frame-agnostic.

`resolve.go` also names `RefusingAnnouncer` beside `RefusingStriker`, with the reason it isn't the recursion it reads like: **no clock advances inside a resolution**, because this package calls neither `EndTurn` nor `form` — which `RefusingStriker`'s own comment at that exact call site already says.

## 2. The boundary machine

`NewBoundary` publishes one clock advance's boundaries onto this package's bus, where everything R3 attached hears them. Last link in a chain the composition cannot close for itself: `play/clock` returns milestones and never publishes, `encounter` notices them and holds no bus, and this is the only place a bus exists (ADR-0038).

**No new step kind.** A crossing is *"do this on the bus and hand me the next step"* — what `Gather` already does for the contest's imposition.

But `doc.go`'s bus-effect tally named its own reopening trigger, and this **moves it**: pure-effect steps now outnumber folds in any interaction that is a boundary. So the tally is updated in place rather than left to be rediscovered, with the note that if the question comes back it comes back on whether *"fold a chain"* and *"announce something"* want telling apart **by type** rather than by `Gather.Name` — a different question, and a better one.

**A sealed lookup, not a switch with a default.** The composition's boundary kinds and this table are the same set by construction, so a kind added on one side is refused here instead of silently publishing nothing — which is *precisely* how `TurnStartTopic` came to have seven subscribers and no publisher.

Refuses an empty advance, a subjectless crossing, and an unknown kind.

## Evidence

Every test was written, then the code mutated to check it bites:

| mutant | dies |
|---|---|
| publish in reverse order | `TestEveryCrossingReachesTheBusInOrder` |
| share the caller's slice (drop the copy) | `TestTheInputIsCopied` |
| swap the two topics | 4 tests |

`build`, `vet`, `test ./...`, `golangci-lint run ./...` — **0 issues**.

No `Closes` keyword: #294 spans five PRs and only the last carries it.

— platform agent, on behalf of KirkDiggler