### PR TITLE
feat(events)!: CombatEndEvent names its subject, not a character

### DIFF
--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -522,7 +522,21 @@ func (c *Character) ShortRest(ctx context.Context) error {
 
 // EndCombat publishes CombatEndEvent so combat-scoped conditions can remove
 // themselves (RAW: rage ends when combat ends) — mirrors LongRest/ShortRest's
-// RestEvent publish. A condition opts into combat-scoped lifetime by
+// RestEvent publish.
+//
+// DEAD, AND KNOWN TO BE: this method has no callers anywhere — not in the
+// toolkit, not in rpg-api, not in a test. What actually ends a fight for its
+// members is the composition noticing the fight end and announcing a
+// CombatEnded boundary through its Announcer, once per member
+// (rpg-project#295). This is the second publisher of a topic that finally has
+// a real one, and it is a footgun besides: calling it ends ONE character's
+// rage without any fight having ended.
+//
+// Left in place deliberately rather than deleted here. combat.TurnManager is
+// in exactly the same position for the turn topics after rpg-project#294, and
+// the two should go together in one pass rather than one at a time as each
+// slice happens to walk past. Tracked so it is a decision rather than a
+// leftover. A condition opts into combat-scoped lifetime by
 // subscribing to CombatEndTopic in its own Apply (see
 // RagingCondition.onCombatEnd); a condition that should outlive combat (e.g.
 // a curse) simply does not subscribe, so this is not a lifetime taxonomy on
@@ -536,7 +550,7 @@ func (c *Character) EndCombat(ctx context.Context) error {
 
 	combatEndTopic := dnd5eEvents.CombatEndTopic.On(c.bus)
 	err := combatEndTopic.Publish(ctx, dnd5eEvents.CombatEndEvent{
-		CharacterID: c.id,
+		SubjectID: c.id,
 	})
 	if err != nil {
 		return rpgerr.Wrapf(err, "failed to publish combat end event")

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -316,7 +316,7 @@ func (r *RagingCondition) onRest(ctx context.Context, event dnd5eEvents.RestEven
 // silently re-apply it in the next encounter (rpg-toolkit#752).
 func (r *RagingCondition) onCombatEnd(ctx context.Context, event dnd5eEvents.CombatEndEvent) error {
 	// Only end rage if this is our character
-	if event.CharacterID != r.CharacterID {
+	if event.SubjectID != r.CharacterID {
 		return nil
 	}
 	return r.endRage(ctx, "combat_ended")

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -727,9 +727,16 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsOnCombatEnd() {
 	// Publish a combat-end event for this character (no attack, no hit,
 	// no rest — just the encounter ending, e.g. the killing blow that ended
 	// the fight).
+	//
+	// PUBLISHED BY HAND, and worth being honest about: until rpg-project#295
+	// nothing in production published this topic at all, so this test was green
+	// against a publisher that did not exist. It proves the handler, which is
+	// all a unit test here can prove. What proves the CHAIN is in the session
+	// package, driven through a real Dissolve and read out of the persisted
+	// sheet — see ideas/session-combat/combat-end/design.md §6.
 	combatEndTopic := dnd5eEvents.CombatEndTopic.On(s.bus)
 	err = combatEndTopic.Publish(s.ctx, dnd5eEvents.CombatEndEvent{
-		CharacterID: "barbarian-1",
+		SubjectID: "barbarian-1",
 	})
 	s.Require().NoError(err)
 
@@ -770,10 +777,15 @@ func (s *RagingConditionTestSuite) TestRagingConditionIgnoresOtherCharacterComba
 	})
 	s.Require().NoError(err)
 
-	// Publish a combat-end event for a DIFFERENT character
+	// Publish a combat-end event for a DIFFERENT character.
+	//
+	// This is the test the whole shape of combat end rests on: because the
+	// handler answers "is this about me?" by comparing subjects, a fight's
+	// ending has to be announced ONCE PER MEMBER. A single subject-less event
+	// would match nobody and expire nothing (design §1.1).
 	combatEndTopic := dnd5eEvents.CombatEndTopic.On(s.bus)
 	err = combatEndTopic.Publish(s.ctx, dnd5eEvents.CombatEndEvent{
-		CharacterID: "barbarian-2", // Different character
+		SubjectID: "barbarian-2", // Different character
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -733,7 +733,8 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsOnCombatEnd() {
 	// against a publisher that did not exist. It proves the handler, which is
 	// all a unit test here can prove. What proves the CHAIN is in the session
 	// package, driven through a real Dissolve and read out of the persisted
-	// sheet — see ideas/session-combat/combat-end/design.md §6.
+	// sheet — see rpg-project's ideas/session-combat/combat-end/design.md §6.
+	// (That doc lives in the rpg-project repo, not this one.)
 	combatEndTopic := dnd5eEvents.CombatEndTopic.On(s.bus)
 	err = combatEndTopic.Publish(s.ctx, dnd5eEvents.CombatEndEvent{
 		SubjectID: "barbarian-1",
@@ -782,7 +783,8 @@ func (s *RagingConditionTestSuite) TestRagingConditionIgnoresOtherCharacterComba
 	// This is the test the whole shape of combat end rests on: because the
 	// handler answers "is this about me?" by comparing subjects, a fight's
 	// ending has to be announced ONCE PER MEMBER. A single subject-less event
-	// would match nobody and expire nothing (design §1.1).
+	// would match nobody and expire nothing — rpg-project's
+	// ideas/session-combat/combat-end/design.md §1.1.
 	combatEndTopic := dnd5eEvents.CombatEndTopic.On(s.bus)
 	err = combatEndTopic.Publish(s.ctx, dnd5eEvents.CombatEndEvent{
 		SubjectID: "barbarian-2", // Different character

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -663,14 +663,31 @@ type RestEvent struct {
 	CharacterID string              // ID of the character resting
 }
 
-// CombatEndEvent is published when the combat/encounter a character was
-// participating in has ended. Combat-scoped conditions (e.g. RagingCondition)
-// subscribe to CombatEndTopic in their Apply to remove themselves — RAW: rage
-// ends when combat ends. This is an opt-in, per-condition lifetime: a
-// condition that should outlive combat (e.g. a curse) simply does not
-// subscribe. Mirrors the RestEvent self-termination pattern.
+// CombatEndEvent is published when a fight a member was in has ended.
+//
+// ONE PER MEMBER, never one for the fight. Every attached effect hears every
+// publish on the interaction's single bus (R1), so a subscriber answers "is
+// this about me?" by comparing the subject against its own owner — which is
+// exactly what conditions.RagingCondition.onCombatEnd does. A subject-less
+// "the fight ended" would match nobody and expire nothing.
+//
+// SubjectID is whoever that fight ended for: a player's character, or a monster
+// that was in it. Named for what it denotes rather than for what happens to be
+// plugged into it today, for the same reason [TurnStartEvent] is — the
+// composition ends a fight for everyone it held, and it holds monsters.
+//
+// NO ROUND, unlike the turn events. A fight ending is not a coordinate in a
+// clock that no longer exists: play/clock's Turn.Dissolve sets the round back
+// to zero, because round numbers are per-fight and always were. That fact is
+// also why this event has to exist at all — see rpg-project's
+// ideas/session-combat/combat-end/design.md §0.
+//
+// Combat-scoped conditions subscribe to CombatEndTopic in their Apply to remove
+// themselves — RAW: rage ends when combat ends. This is an opt-in,
+// per-condition lifetime: a condition that should outlive combat (e.g. a curse)
+// simply does not subscribe. Mirrors the RestEvent self-termination pattern.
 type CombatEndEvent struct {
-	CharacterID string // ID of the character whose combat just ended
+	SubjectID string // whoever the fight just ended for
 }
 
 // ResourceConsumedEvent is published when a character uses a resource


### PR DESCRIPTION
First of five for **combat end** — KirkDiggler/rpg-project#295, part 1 of 3. Design: KirkDiggler/rpg-project#298.

A fight ends for everyone it held, and it holds monsters. `CombatEndEvent.CharacterID` becomes `SubjectID`, for the same reason the turn events were renamed in #294 — Kirk's rule: *"we should be naming things for what they represent not what we currently have plugged in"*.

## Two facts the doc now records

**ONE PER MEMBER, never one for the fight.** `RagingCondition.onCombatEnd` answers *"is this about me?"* by comparing the subject against its own owner. A subject-less "the fight ended" would match **nobody** and expire **nothing**. That single handler is what forces the fan-out in the encounter PR that follows, so it is written down where the type is rather than left in a design doc.

**NO ROUND, unlike the turn events.** A fight ending is not a coordinate in a clock that no longer exists — `play/clock`'s `Turn.Dissolve` sets the round back to `0`, because round numbers are per-fight. That same fact is *why* this slice exists: a rage that outlives its fight subtracts a stored round from a clock that has restarted at 1, and never expires.

## `Character.EndCombat` is left in place, and documented as dead

It has **no callers anywhere** — not in the toolkit, not in rpg-api, not in a test. It is also a footgun: calling it ends one character's rage with no fight having ended. `combat.TurnManager` is in exactly the same position for the turn topics after #294, so the two should go in **one** pass rather than one at a time as each slice happens to walk past it. Named as a decision rather than left as a leftover.

## Tests

The two existing combat-end tests publish this topic **by hand** — they were green against a publisher that did not exist. I said so in the test rather than leaving it to be rediscovered, and pointed at where the chain actually gets proved (the session PR, driven through a real `Dissolve` and read out of the persisted sheet).

`TestRagingConditionIgnoresOtherCharacterCombatEnd` is left exactly as it is — it is the test the whole per-member shape rests on. **Mutation-checked**: removing the owner guard from `onCombatEnd` fails that test and only that test.

27 packages green, build and vet clean.

---

Chain: **events** → encounter → resolution → session → rpg-api

— platform agent, on behalf of KirkDiggler
