### PR TITLE
feat(encounter): a fight ending is a boundary, once per member

### DIFF
--- a/rulebooks/dnd5e/encounter/clocks.go
+++ b/rulebooks/dnd5e/encounter/clocks.go
@@ -491,6 +491,15 @@ func boundariesFrom(ms []clock.Milestone) []Boundary {
 			kind = TurnStarted
 		case clock.TurnEnded:
 			kind = TurnEnded
+		case clock.Dissolved:
+			// NOT dropped for the reasons the default arm drops things, and
+			// called out by name so it does not read that way. A fight ending
+			// DOES become boundaries — one per member — but it cannot be built
+			// here: clock.Turn.Dissolve stamps no Subject, because a clock
+			// knows it emptied and not who it emptied of, and the roster
+			// arrives BESIDE the milestones rather than inside them. See
+			// combatEndBoundaries, which is where this one is translated.
+			continue
 		default:
 			continue
 		}
@@ -505,6 +514,14 @@ func boundariesFrom(ms []clock.Milestone) []Boundary {
 
 // announce hands one clock advance's boundaries to the Announcer capability,
 // at the moment they were crossed.
+func (e *Encounter) announce(ms []clock.Milestone) error {
+	return e.announceBoundaries(boundariesFrom(ms))
+}
+
+// announceBoundaries is the half of announce that reaches the capability,
+// shared by the milestone-translating path above and by the fight-ending
+// fan-out ([Encounter.dissolveBubble]), which builds its boundaries from a
+// roster rather than translating them one for one.
 //
 // context.Background() for the reason Strike below already uses it: this
 // module's verbs take no context.Context, and threading one through every clock
@@ -513,12 +530,52 @@ func boundariesFrom(ms []clock.Milestone) []Boundary {
 // An empty set is not announced. That is not an optimization — an advance that
 // crossed nothing is not an event, and calling a capability to tell it nothing
 // happened is how a capability learns to ignore its argument.
-func (e *Encounter) announce(ms []clock.Milestone) error {
-	crossed := boundariesFrom(ms)
+func (e *Encounter) announceBoundaries(crossed []Boundary) error {
 	if len(crossed) == 0 {
 		return nil
 	}
 	return e.announcer.Announce(context.Background(), e, crossed)
+}
+
+// combatEndBoundaries fans one fight's ending out to the members it ended for.
+//
+// NOT part of boundariesFrom, and it cannot be. The leaf's clock.Dissolved
+// milestone carries the round but no Subject — a clock knows it emptied, not
+// who it emptied of — and the roster arrives beside the milestones rather than
+// inside them. Turning "a clock emptied" into "the fight ended for each of
+// these members" is this composition's own knowledge, the same kind as MemberID
+// rather than core.EntityID, and pushing it down into play/clock would put a
+// rulebook's opinion in a package that is not allowed to have one.
+//
+// PER MEMBER because the only subscriber that exists compares an ending's
+// subject against its own owner (dnd5e/conditions.RagingCondition.onCombatEnd).
+// A single subject-less ending would match nobody and expire nothing — which is
+// the state combat end has actually been in since it was written.
+//
+// The round comes from the milestone rather than from the caller, so the one
+// number in the answer still has exactly one source.
+//
+// ERRORS rather than returning nothing when the milestones hold no
+// clock.Dissolved. bubble.Dissolve has just reported success, so its absence is
+// a broken contract and not an empty result — and a silent empty here is
+// precisely how CombatEndTopic came to have a subscriber and no publisher.
+func combatEndBoundaries(ms []clock.Milestone, members []MemberID) ([]Boundary, error) {
+	round, found := 0, false
+	for _, m := range ms {
+		if m.Kind == clock.Dissolved {
+			round, found = m.Round, true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("combat end boundaries: %w", ErrNoDissolveMilestone)
+	}
+
+	crossed := make([]Boundary, 0, len(members))
+	for _, id := range members {
+		crossed = append(crossed, Boundary{Kind: CombatEnded, Subject: id, Round: round})
+	}
+	return crossed, nil
 }
 
 // executeTurnIntent runs one Act call's answer and reports whether this

--- a/rulebooks/dnd5e/encounter/combatend_internal_test.go
+++ b/rulebooks/dnd5e/encounter/combatend_internal_test.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/play/clock"
+)
+
+// TestCombatEndBoundariesRefusesADissolutionTheClockDidNotReport pins the loud
+// half of combatEndBoundaries' contract, which is unreachable from outside:
+// bubble.Dissolve always stamps its milestone, so production never gets here.
+//
+// WHITE-BOX for the reason clocks_internal_test's own subject is — the branch
+// exists as a net under an invariant of another package, and the only way to
+// stand under it is to hand it the state that package promises never to
+// produce.
+//
+// It matters more than an unreachable branch usually would. The alternative
+// implementation — return no boundaries and no error — reads as harmless and
+// is not: a fight would end announcing nothing, which is bit-for-bit the state
+// combat end was already in before rpg-project#295 and is exactly how it stayed
+// there unnoticed for months.
+func TestCombatEndBoundariesRefusesADissolutionTheClockDidNotReport(t *testing.T) {
+	_, err := combatEndBoundaries(nil, []MemberID{"alice"})
+	require.ErrorIs(t, err, ErrNoDissolveMilestone)
+
+	// And a set holding OTHER milestones is equally not a dissolution. A turn
+	// ending in the list does not make the list say a fight ended, and reading
+	// "the round" off whatever happens to be first would be how that mistake
+	// looks in code.
+	_, err = combatEndBoundaries(
+		[]clock.Milestone{{Kind: clock.TurnEnded, Subject: "alice", Round: 3}},
+		[]MemberID{"alice"},
+	)
+	require.ErrorIs(t, err, ErrNoDissolveMilestone)
+}
+
+// TestCombatEndBoundariesReadsItsRoundFromTheDissolution keeps the one number
+// in the answer tied to the one milestone that means it.
+//
+// The decoy is the test. A TurnEnded carrying a DIFFERENT round sits ahead of
+// the dissolution in the list, so an implementation that reads the round off
+// the first milestone — or off the last — produces 3 or 9 rather than 4 and
+// fails here.
+func TestCombatEndBoundariesReadsItsRoundFromTheDissolution(t *testing.T) {
+	crossed, err := combatEndBoundaries(
+		[]clock.Milestone{
+			{Kind: clock.TurnEnded, Subject: "alice", Round: 3},
+			{Kind: clock.Dissolved, Round: 4},
+			{Kind: clock.TurnStarted, Subject: "goblin", Round: 9},
+		},
+		[]MemberID{"alice", "goblin"},
+	)
+	require.NoError(t, err)
+	require.Equal(t, []Boundary{
+		{Kind: CombatEnded, Subject: "alice", Round: 4},
+		{Kind: CombatEnded, Subject: "goblin", Round: 4},
+	}, crossed, "one boundary per member, all carrying the round the fight ended on")
+}
+
+// TestAFightEndingForNobodyAnnouncesNothing — an empty roster is not an error,
+// unlike a missing milestone. clock.Turn.Dissolve refuses an already-empty
+// clock (ErrIdle) so this cannot arrive from production either, but the two
+// absences mean opposite things and the code should say so: no members is a
+// fight that ended for nobody, which is nothing to announce; no milestone is
+// the clock failing to say what it did.
+func TestAFightEndingForNobodyAnnouncesNothing(t *testing.T) {
+	crossed, err := combatEndBoundaries([]clock.Milestone{{Kind: clock.Dissolved, Round: 2}}, nil)
+	require.NoError(t, err)
+	require.Empty(t, crossed)
+}

--- a/rulebooks/dnd5e/encounter/combatend_test.go
+++ b/rulebooks/dnd5e/encounter/combatend_test.go
@@ -1,0 +1,312 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package encounter_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+	"github.com/stretchr/testify/suite"
+)
+
+type CombatEndTestSuite struct {
+	suite.Suite
+}
+
+func TestCombatEndSuite(t *testing.T) { suite.Run(t, new(CombatEndTestSuite)) }
+
+// journalKiller is journalStriker's twin for the ending that nobody asks for:
+// it records the swing on the SAME list the announcer writes to, and the swing
+// it wraps drops its target.
+//
+// journalStriker cannot be reused because its inner is a *scriptedStriker and
+// the whole point here is the one that kills.
+type journalKiller struct {
+	j     *journal
+	inner *killerStriker
+}
+
+func (k journalKiller) Strike(
+	ctx context.Context, enc *encounter.Encounter, attacker, target encounter.MemberID, action core.Ref,
+) error {
+	k.j.add("strike:" + string(attacker))
+	return k.inner.Strike(ctx, enc, attacker, target, action)
+}
+
+// failAfterForming works until a test switches it off.
+//
+// It has to exist because forming a fight ALREADY announces — a fight's first
+// turn start, which rpg-project#294 added — so an announcer that fails from the
+// start cannot build the fight whose ending is under test. Switching it on
+// afterwards isolates the failure to the ending, and the construction
+// succeeding first is its own small proof that the form-time announcement is
+// real.
+type failAfterForming struct {
+	j    *journal
+	fail *error
+}
+
+func (a failAfterForming) Announce(
+	_ context.Context, _ *encounter.Encounter, crossed []encounter.Boundary,
+) error {
+	for _, b := range crossed {
+		a.j.add(fmt.Sprintf("%s:%s:r%d", b.Kind, b.Subject, b.Round))
+	}
+	if a.fail != nil {
+		return *a.fail
+	}
+	return nil
+}
+
+// fightWithStanding is boundary_test's fightWithMonsters with the Standing
+// capability opened up as well.
+//
+// A fight that ends ITSELF is half of what this file is about, and
+// everyoneStanding can never produce one — nobody is ever down, so no fight is
+// ever decided.
+func (s *CombatEndTestSuite) fightWithStanding(
+	driver encounter.TurnDriver, striker encounter.Striker, announcer encounter.Announcer,
+	standing encounter.Standing, monsters ...core.EntityID,
+) (*encounter.Encounter, error) {
+	members := []encounter.MemberInput{
+		{ID: alice, Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 2}},
+	}
+	for i, id := range monsters {
+		members = append(members, encounter.MemberInput{
+			ID: id, Kind: encounter.KindMonster,
+			Position:  spatial.Position{X: float64(3 + i), Y: 2},
+			SpeedFeet: 30, Targeting: "closest",
+			Actions: []encounter.ActionView{
+				{Ref: testMeleeAction, Name: "Shortsword", RangeFeet: 5, Kind: "melee"},
+			},
+		})
+	}
+	return encounter.NewEncounter(&encounter.SetupInput{
+		Sight: everyoneSeesTheWholeMap{}, Standing: standing, Initiative: orderAsGiven{},
+		TurnDriver: driver, Striker: striker, Announcer: announcer,
+		Field: encounter.FieldInput{
+			Canvas:  encounter.CanvasInput{Void: encounter.VoidIsOpaque(), Orientation: encounter.HexesArePointyTop()},
+			Regions: []encounter.RegionInput{rectRegion(room1, 0, 0, 10, 10)},
+		},
+		Members: members,
+		Endings: []encounter.EndingInput{{Key: "called", Trigger: encounter.TriggerExternal{}}},
+	})
+}
+
+// combatEndsIn returns the subjects of every combat-end boundary the journal
+// saw, sorted — so a test asserts on WHO the fight ended for without also
+// asserting on an order the composition never promised.
+func combatEndsIn(j *journal) []string {
+	var subjects []string
+	for _, e := range j.entries {
+		rest, ok := strings.CutPrefix(e, "combat_ended:")
+		if !ok {
+			continue
+		}
+		subjects = append(subjects, strings.Split(rest, ":")[0])
+	}
+	sort.Strings(subjects)
+	return subjects
+}
+
+// TestADecidedEndingReachesEveryMemberOfTheFight is the fan-out, and it is the
+// whole shape of combat end rather than a detail of it.
+//
+// DissolveInput names ONE member — the fight is reached through anybody in it
+// (R6) — but the fight ends for everybody it held. The only subscriber that
+// exists asks whether an ending is its own
+// (dnd5e/conditions.RagingCondition.onCombatEnd), so a single ending announced
+// once would expire nothing at all.
+//
+// The members the caller did NOT name are the assertion — and they are
+// monsters, which is deliberate. Nothing on a monster subscribes to combat end
+// today, and the ending is announced for them anyway: which members of a fight
+// an ending is "about" is the effect's own predicate to answer, not a filter
+// for this composition to hold (R3).
+func (s *CombatEndTestSuite) TestADecidedEndingReachesEveryMemberOfTheFight() {
+	j := &journal{}
+	enc, err := s.fightWithStanding(
+		passDriver{}, passStriker{}, journalAnnouncer{j: j}, everyoneStanding{}, goblin, bob)
+	s.Require().NoError(err)
+
+	out, err := enc.Dissolve(&encounter.DissolveInput{Member: alice})
+	s.Require().NoError(err)
+
+	held := make([]string, 0, len(out.Members))
+	for _, id := range out.Members {
+		held = append(held, string(id))
+	}
+	sort.Strings(held)
+
+	s.Require().Len(held, 3, "precondition: the fight held all three: %v", held)
+	s.Equal(held, combatEndsIn(j),
+		"the fight ended for exactly the members it held, no more and no fewer: %v", j.entries)
+	s.Contains(combatEndsIn(j), string(bob),
+		"a member the caller never named still had their fight end: %v", j.entries)
+}
+
+// TestAnEndingNobodyAskedForIsAnnouncedToo is the other caller of the one
+// place a fight ends, and the one no host controls.
+//
+// A driven monster's own killing blow decides the fight from inside Record,
+// which Strike calls before returning — several frames down inside the
+// caller's EndTurn. Nothing out there gets a chance to announce this, which is
+// why the announcement lives at the ending itself rather than at either call
+// site.
+func (s *CombatEndTestSuite) TestAnEndingNobodyAskedForIsAnnouncedToo() {
+	j := &journal{}
+	standing := &downList{}
+	striker := journalKiller{j: j, inner: &killerStriker{
+		scriptedStriker: &scriptedStriker{kind: encounter.OutcomeStruck},
+		standing:        standing,
+	}}
+	enc, err := s.fightWithStanding(
+		&scriptedDriver{intents: []encounter.TurnIntent{
+			encounter.Attack{Target: alice, Action: testMeleeAction},
+		}},
+		striker, journalAnnouncer{j: j}, standing, goblin)
+	s.Require().NoError(err)
+
+	// alice ends her turn; the goblin is driven, swings, and drops the only
+	// player in the fight — so the fight decides itself mid-drive.
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+
+	s.Equal([]string{"alice", "goblin"}, combatEndsIn(j),
+		"a fight that ended itself still ended for everyone in it: %v", j.entries)
+
+	swung := j.indexOf("strike:goblin")
+	s.Require().NotEqual(-1, swung, "the goblin never swung: %v", j.entries)
+	for i, e := range j.entries {
+		if strings.HasPrefix(e, "combat_ended:") {
+			s.Greater(i, swung,
+				"the fight ends because of the swing, so it is announced after it: %v", j.entries)
+		}
+	}
+}
+
+// TestACombatEndCarriesTheRoundTheFightEndedOn pins the one number in the
+// answer to the clock that produced it rather than to a default.
+//
+// It matters more than it looks. Round numbers are PER-FIGHT — clock.Turn's
+// SetOrder starts every bubble at 1 and Dissolve sets it back to 0 — so a zero
+// here would be indistinguishable from "the clock had no idea", which is the
+// shape of the bug that made this whole slice necessary.
+func (s *CombatEndTestSuite) TestACombatEndCarriesTheRoundTheFightEndedOn() {
+	j := &journal{}
+	enc, err := s.fightWithStanding(
+		passDriver{}, passStriker{}, journalAnnouncer{j: j}, everyoneStanding{}, goblin)
+	s.Require().NoError(err)
+
+	// alice ends, the goblin is driven and passes, the order wraps to round 2.
+	_, err = enc.EndTurn(&encounter.EndTurnInput{Member: alice})
+	s.Require().NoError(err)
+	s.Require().Contains(j.entries, "turn_started:alice:r2",
+		"precondition: the fight is in round 2: %v", j.entries)
+
+	_, err = enc.Dissolve(&encounter.DissolveInput{Member: alice})
+	s.Require().NoError(err)
+
+	s.Contains(j.entries, "combat_ended:alice:r2",
+		"the ending carries the round it happened in, not round one and not zero: %v", j.entries)
+}
+
+// TestAnAnnouncerMalfunctionAbortsTheDissolve — the same contract Striker and
+// TurnDriver have, and for the same reason. Nothing is persisted until the
+// caller's own commit, so a failure costs the retry and nothing else; a
+// dissolve that reported success while the boundary it owed nobody published
+// would cost a barbarian's rage, silently, forever.
+func (s *CombatEndTestSuite) TestAnAnnouncerMalfunctionAbortsTheDissolve() {
+	var live error
+	j := &journal{}
+	enc, err := s.fightWithStanding(
+		passDriver{}, passStriker{}, failAfterForming{j: j, fail: &live}, everyoneStanding{}, goblin)
+	s.Require().NoError(err)
+
+	boom := errors.New("announcer is down")
+	live = boom
+
+	_, err = enc.Dissolve(&encounter.DissolveInput{Member: alice})
+	s.Require().ErrorIs(err, boom, "an announcer malfunction fails the verb that caused it")
+}
+
+// TestEveryPathThatEndsAFightAnnouncesIt is the structural half, in the shape
+// TestNoCodePathProducesACastlessInteraction established.
+//
+// The two behavioural tests above cover the two callers of dissolveBubble that
+// exist TODAY. That is only a complete claim while there are two, and a
+// behavioural suite structurally cannot notice a third being added — which is
+// precisely how CombatEndTopic came to have seven subscribers' worth of
+// attention and no publisher at all.
+//
+// So the count is asserted directly, off the AST. A third way to end a fight
+// fails this test and lands the author here, at the two tests that would need
+// a sibling.
+func (s *CombatEndTestSuite) TestEveryPathThatEndsAFightAnnouncesIt() {
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, ".", func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	s.Require().NoError(err)
+	pkg, ok := pkgs["encounter"]
+	s.Require().True(ok, "the encounter package itself must be parseable")
+
+	callers := map[string]bool{}
+	var announces bool
+	for _, file := range pkg.Files {
+		ast.Inspect(file, func(n ast.Node) bool {
+			fn, isFunc := n.(*ast.FuncDecl)
+			if !isFunc {
+				return true
+			}
+			ast.Inspect(fn.Body, func(inner ast.Node) bool {
+				call, isCall := inner.(*ast.CallExpr)
+				if !isCall {
+					return true
+				}
+				sel, isSel := call.Fun.(*ast.SelectorExpr)
+				if !isSel {
+					return true
+				}
+				switch sel.Sel.Name {
+				case "dissolveBubble":
+					callers[fn.Name.Name] = true
+				case "announceBoundaries":
+					if fn.Name.Name == "dissolveBubble" {
+						announces = true
+					}
+				}
+				return true
+			})
+			return true
+		})
+	}
+
+	s.True(announces,
+		"dissolveBubble itself must announce — that is what makes both callers safe")
+
+	names := make([]string, 0, len(callers))
+	for name := range callers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	s.Equal([]string{"Dissolve", "noticeDown"}, names,
+		"a third way to end a fight needs a third test above; these two are covered by "+
+			"TestADecidedEndingReachesEveryMemberOfTheFight and TestAnEndingNobodyAskedForIsAnnouncedToo")
+
+	// A guard on the guard: if the walk above found nothing at all it would
+	// pass an empty comparison against an empty expectation and prove nothing.
+	s.Require().NotEmpty(callers, "the AST walk found no callers, so it tested nothing")
+}

--- a/rulebooks/dnd5e/encounter/dissolve.go
+++ b/rulebooks/dnd5e/encounter/dissolve.go
@@ -190,5 +190,22 @@ func (e *Encounter) dissolveBubble(bubble *clock.Turn, cause DissolveCause) (*Di
 		return nil, fmt.Errorf("dissolve append beat: %w", err)
 	}
 
+	// AFTER the beat, and after the re-homing above: the story says the fight
+	// ended before anything is told the fight ended, and the world an announcer
+	// looks at is a settled one — everyone back on the world clock, the bubble
+	// pruned. The same order driveOneMonsterTurn uses for a turn boundary.
+	//
+	// HERE rather than at the two callers, because this is the one place a
+	// fight ends. An explicit [Encounter.Dissolve] and the composition noticing
+	// defeat both arrive at this function, and announcing out there would be
+	// two chances to forget — one of them on a path no host controls.
+	crossed, cerr := combatEndBoundaries(out.Milestones, out.Members)
+	if cerr != nil {
+		return nil, fmt.Errorf("dissolve: %w", cerr)
+	}
+	if aerr := e.announceBoundaries(crossed); aerr != nil {
+		return nil, fmt.Errorf("dissolve announce: %w", aerr)
+	}
+
 	return &DissolveOutput{Members: out.Members, Cause: cause, Seq: seq}, nil
 }

--- a/rulebooks/dnd5e/encounter/errors.go
+++ b/rulebooks/dnd5e/encounter/errors.go
@@ -327,6 +327,18 @@ var (
 	// world — not a legal outcome any caller is meant to recover from.
 	ErrRefusingAnnouncer = errors.New("encounter: RefusingAnnouncer: a clock advanced on a construction-only world")
 
+	// ErrNoDissolveMilestone is a leaf that reported dissolving a bubble and
+	// then did not say so in its milestones. An INVARIANT of play/clock, not a
+	// caller mistake and not recoverable: combatEndBoundaries reads the round a
+	// fight ended on out of that milestone, and there is no honest value to
+	// substitute for it.
+	//
+	// Loud rather than empty on purpose. Returning no boundaries would end
+	// fights that expire nothing, which is indistinguishable from the state
+	// combat end was already in before rpg-project#295 and is exactly how it
+	// stayed there.
+	ErrNoDissolveMilestone = errors.New("encounter: bubble dissolved without a dissolved milestone")
+
 	// ErrBadIntent indicates a TurnDriver returned a syntactically valid
 	// TurnIntent this composition cannot execute: an Attack naming a target
 	// that is not currently Seen, not Standing, or out of the named

--- a/rulebooks/dnd5e/encounter/turndriver.go
+++ b/rulebooks/dnd5e/encounter/turndriver.go
@@ -287,8 +287,8 @@ func (RefusingStriker) Strike(context.Context, *Encounter, MemberID, MemberID, c
 
 // BoundaryKind names a temporal boundary a clock verb crossed.
 //
-// TWO KINDS, because two are what anything publishes. play/clock also reports
-// RoundStarted, and this composition translates it to nothing — losing nothing,
+// THREE KINDS, because three are what anything publishes. play/clock also
+// reports RoundStarted, and this composition translates it to nothing — losing nothing,
 // because clock.Turn.End increments the round BEFORE stamping the TurnStarted
 // that follows a wrap. The round advancing is therefore already visible as a
 // changed Round on the next turn boundary, and a second way to say it would be
@@ -308,6 +308,16 @@ const (
 	TurnStarted BoundaryKind = "turn_started"
 	// TurnEnded marks Subject's turn ending.
 	TurnEnded BoundaryKind = "turn_ended"
+
+	// CombatEnded marks the fight Subject was in ending, by either cause.
+	//
+	// ONE PER MEMBER, unlike the turn kinds which are about one member by
+	// nature. A fight ends once and ends for everybody it held, so this kind
+	// arrives as a run of boundaries rather than a single one — see
+	// combatEndBoundaries for why the fan-out lives in this module, and
+	// dnd5e/events.CombatEndEvent for why a subject-less ending would expire
+	// nothing at all.
+	CombatEnded BoundaryKind = "combat_ended"
 )
 
 // Boundary is one temporal boundary this composition crossed, in this
@@ -321,11 +331,19 @@ type Boundary struct {
 	// Kind is which boundary was crossed.
 	Kind BoundaryKind
 
-	// Subject is whose turn it is about. Never empty: both kinds are about
-	// somebody.
+	// Subject is who it is about. Never empty: every kind is about somebody,
+	// including [CombatEnded] — a fight ends for each of its members, and the
+	// only subscriber that exists asks whether an ending is its own.
 	Subject MemberID
 
-	// Round is which round of the fight the boundary belongs to.
+	// Round is which round of the fight the boundary belongs to — for
+	// [CombatEnded], the round it ended on.
+	//
+	// A COORDINATE, and one that does not survive its fight: play/clock's
+	// Turn.Dissolve sets the round back to zero, because round numbers are
+	// per-fight and there is no session-global counter. Anything storing a
+	// round to compare against a later one is only sound if it cannot outlive
+	// the clock the number came from — which is what CombatEnded is for.
 	Round int
 }
 


### PR DESCRIPTION
Second of five for **combat end** — KirkDiggler/rpg-project#295. Design: KirkDiggler/rpg-project#298. Pairs with #1262 (independent — encounter cannot import the rulebook, C1).

`BoundaryKind` grows a third kind, `CombatEnded`, and `dissolveBubble` announces it. The fight ending finally reaches the rules instead of being noticed and dropped.

## One per member, and that is forced rather than chosen

The only subscriber that exists — `RagingCondition.onCombatEnd` — asks whether an ending is its own by comparing subjects. A single subject-less "the fight ended" would match **nobody** and expire **nothing**. Per-member also keeps `Boundary.Subject`'s existing *"never empty"* invariant true rather than newly qualified, which is the strongest available signal the fan-out belongs at this layer.

## Why the fan-out is not in `boundariesFrom`, and cannot be

The leaf's `clock.Dissolved` milestone carries the round but **no Subject** — a clock knows it emptied, not who it emptied of — and the roster arrives *beside* the milestones rather than inside them. Turning "a clock emptied" into "the fight ended for each of these members" is this composition's own knowledge, the same kind as `MemberID` rather than `core.EntityID`. Pushing it into `play/clock` would put a rulebook's opinion in a package not allowed to have one, and add a sixth module to the chain to do it.

`boundariesFrom` now names `clock.Dissolved` **explicitly** so the drop reads as a decision instead of as the `default` arm swallowing something.

`combatEndBoundaries` **errors** rather than returning nothing when the milestones hold no dissolution. `bubble.Dissolve` has just reported success, so its absence is a broken contract, not an empty result — and a silent empty is precisely how `CombatEndTopic` came to have a subscriber and no publisher.

## Announced from `dissolveBubble`, after the beat

That is the one place a fight ends: an explicit `Dissolve` and the composition noticing defeat both arrive there. Announcing at the two call sites would be two chances to forget — and **one of them is a path no host controls**, a driven monster's killing blow deciding the fight from inside `Record`, several frames down inside someone else's `EndTurn`.

After the beat, so the story says the fight ended before anything is told it did, and the world an announcer looks at is settled — everyone re-homed, bubble pruned.

`announce` splits into the translating half and `announceBoundaries`, which reaches the capability. No behaviour change at the three existing call sites.

## Tests — and why the existing suite proved nothing

**The suite default is `quietAnnouncer{}`.** All three packages stayed green the moment the announce was wired in, which said exactly nothing about whether it fired. New tests carry it:

- **both endings, behaviourally** — a decided `Dissolve`, and a driven monster's killing blow
- **the fan-out reaching members the caller never named** — monsters, on purpose. Which members an ending is "about" is the effect's own predicate to answer, not a filter for this module to hold (R3)
- **the round read off the dissolution**, pinned with a decoy milestone carrying a different round
- **an announcer malfunction aborting the verb**, switched on *after* forming — forming already announces, so an always-failing announcer cannot build the fight whose ending is under test. That construction succeeding first is its own small proof the form-time announcement is real.
- **structurally**: `dissolveBubble` has exactly two callers and announces itself, off the AST. A behavioural suite cannot notice a third being added, which is how this vocabulary got into its current state.

**Mutation-checked, four mutants, all killed.** One is worth calling out: *"read the round off the first milestone"* **survives every behavioural test**, because a real dissolve returns exactly one milestone. The decoy in the internal test is the only thing that catches it — which is the same lesson as #1259's ordering test, arriving from a different direction.

---

Chain: events (#1262) → **encounter** → resolution → session → rpg-api

— platform agent, on behalf of KirkDiggler
