### PR TITLE
feat(resolution): a fight ending is a crossing like any other

### DIFF
--- a/rulebooks/dnd5e/resolution/boundary.go
+++ b/rulebooks/dnd5e/resolution/boundary.go
@@ -114,6 +114,18 @@ var boundaryTopics = map[encounter.BoundaryKind]func(
 			Round:     b.Round,
 		})
 	},
+	// No Round on the way out, and that is not an omission. A fight ending is
+	// not a coordinate in a clock that no longer exists — play/clock's
+	// Turn.Dissolve sets the round back to zero because round numbers are
+	// per-fight. Boundary.Round still says WHICH round it ended on, for the
+	// record; there is simply nothing on the event for it to become, and
+	// inventing a field so the mapping looks symmetrical would be inventing a
+	// number subscribers could compare against a later fight's.
+	encounter.CombatEnded: func(ctx context.Context, bus events.EventBus, b encounter.Boundary) error {
+		return dnd5eEvents.CombatEndTopic.On(bus).Publish(ctx, dnd5eEvents.CombatEndEvent{
+			SubjectID: string(b.Subject),
+		})
+	},
 }
 
 type boundaryMachine struct {

--- a/rulebooks/dnd5e/resolution/boundary_test.go
+++ b/rulebooks/dnd5e/resolution/boundary_test.go
@@ -27,9 +27,10 @@ func (s *BoundaryTestSuite) SetupTest() { s.ctx = context.Background() }
 // heard records every turn boundary that reached the bus, in the order it
 // arrived — which is the only thing these tests are about.
 type heard struct {
-	starts []dnd5eEvents.TurnStartEvent
-	ends   []dnd5eEvents.TurnEndEvent
-	order  []string
+	starts    []dnd5eEvents.TurnStartEvent
+	ends      []dnd5eEvents.TurnEndEvent
+	fightEnds []dnd5eEvents.CombatEndEvent
+	order     []string
 }
 
 func (h *heard) listen(ctx context.Context, bus events.EventBus) {
@@ -43,6 +44,12 @@ func (h *heard) listen(ctx context.Context, bus events.EventBus) {
 		func(_ context.Context, e dnd5eEvents.TurnEndEvent) error {
 			h.ends = append(h.ends, e)
 			h.order = append(h.order, "end:"+e.SubjectID)
+			return nil
+		})
+	_, _ = dnd5eEvents.CombatEndTopic.On(bus).Subscribe(ctx,
+		func(_ context.Context, e dnd5eEvents.CombatEndEvent) error {
+			h.fightEnds = append(h.fightEnds, e)
+			h.order = append(h.order, "fight:"+e.SubjectID)
 			return nil
 		})
 }
@@ -195,4 +202,84 @@ func (s *BoundaryTestSuite) TestTheInputIsCopied() {
 
 	s.Require().Len(h.ends, 1)
 	s.Equal("alice", h.ends[0].SubjectID)
+}
+
+// TestAFightEndingReachesEveryoneItEndedFor — the composition announces a
+// fight's ending once per member, and every one of those reaches the bus.
+//
+// The run is what a real dissolve produces: the last turn boundary the clock
+// crossed, then the ending, for everybody. A subscriber deciding whether an
+// ending is its own (dnd5e/conditions.RagingCondition.onCombatEnd) needs its
+// own name to arrive, which is what this asserts.
+func (s *BoundaryTestSuite) TestAFightEndingReachesEveryoneItEndedFor() {
+	out, h, err := s.runBoundary([]encounter.Boundary{
+		{Kind: encounter.CombatEnded, Subject: "alice", Round: 4},
+		{Kind: encounter.CombatEnded, Subject: "bob", Round: 4},
+		{Kind: encounter.CombatEnded, Subject: "goblin-7", Round: 4},
+	})
+	s.Require().NoError(err)
+
+	s.Equal([]string{"fight:alice", "fight:bob", "fight:goblin-7"}, h.order,
+		"one ending per member, in the order the composition crossed them")
+	s.Require().IsType(BoundaryOutcome{}, out.Outcome)
+	s.Equal(3, out.Outcome.(BoundaryOutcome).Announced)
+}
+
+// TestAFightEndingRidesTheSameRunAsTheTurnBoundaries — the kinds are not
+// separate mechanisms and must not become two.
+//
+// Mixed is the real case: nothing stops a composition from crossing a turn
+// boundary and a fight ending in one advance, and causal order across the
+// whole run is the promise BoundaryInput makes.
+func (s *BoundaryTestSuite) TestAFightEndingRidesTheSameRunAsTheTurnBoundaries() {
+	_, h, err := s.runBoundary([]encounter.Boundary{
+		{Kind: encounter.TurnEnded, Subject: "alice", Round: 2},
+		{Kind: encounter.CombatEnded, Subject: "alice", Round: 2},
+		{Kind: encounter.CombatEnded, Subject: "goblin-7", Round: 2},
+	})
+	s.Require().NoError(err)
+	s.Equal([]string{"end:alice", "fight:alice", "fight:goblin-7"}, h.order)
+}
+
+// TestAFightsEndingCarriesItsSubjectAndNothingElse pins the deliberate
+// asymmetry with the turn events.
+//
+// CombatEndEvent has no Round, and that is a decision rather than an oversight:
+// the round a fight ended on is not a coordinate anyone can use afterwards,
+// because play/clock's Turn.Dissolve sets the round back to zero and the next
+// fight starts again at 1. A subscriber storing it would be storing a number
+// from a clock that no longer exists — which is the exact bug the slice this
+// belongs to exists to make impossible.
+func (s *BoundaryTestSuite) TestAFightsEndingCarriesItsSubjectAndNothingElse() {
+	_, h, err := s.runBoundary([]encounter.Boundary{
+		{Kind: encounter.CombatEnded, Subject: "goblin-7", Round: 9},
+	})
+	s.Require().NoError(err)
+	s.Require().Len(h.fightEnds, 1)
+	s.Equal(dnd5eEvents.CombatEndEvent{SubjectID: "goblin-7"}, h.fightEnds[0],
+		"the whole event is the subject; a round here would outlive the clock it came from")
+}
+
+// TestTheTableCoversEveryKindThisBuildKnows guards the seal from the inside.
+//
+// boundaryTopics is a sealed lookup precisely so a kind it does not know is
+// refused at the door rather than silently publishing nothing
+// (TestAnUnknownKindIsRefusedRatherThanPublishedAsNothing is the other half).
+// This is the half that fails when the table falls BEHIND: a kind added to the
+// composition and not added here.
+//
+// Honest about its own limit: this cannot enumerate the composition's consts
+// from another module, so it will not fail the moment encounter grows a fourth
+// kind. What fails then is the refusal above, at the first announcement that
+// carries it — loudly, in the session suite, rather than silently forever.
+// This test's job is narrower and still worth doing: it stops the table being
+// trimmed.
+func (s *BoundaryTestSuite) TestTheTableCoversEveryKindThisBuildKnows() {
+	for _, kind := range []encounter.BoundaryKind{
+		encounter.TurnStarted, encounter.TurnEnded, encounter.CombatEnded,
+	} {
+		_, ok := boundaryTopics[kind]
+		s.True(ok, "boundaryTopics has no entry for %q, so announcing one would be refused", kind)
+	}
+	s.Len(boundaryTopics, 3, "a fourth entry here needs a fourth kind above and a test with it")
 }

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.1-0.20260827032507-bf39c5be72a1
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.1-0.20260827033225-4e24f4c40b47
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.104.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,8 +6,8 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.1-0.20260827032507-bf39c5be72a1
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.1-0.20260827033225-4e24f4c40b47
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1
 )

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,10 +16,10 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.1-0.20260827032507-bf39c5be72a1 h1:Z7PysVdEa5SzOxt/gcVhqm1+r5oy+5mTHoVzo+08Xx4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.1-0.20260827032507-bf39c5be72a1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.1-0.20260827033225-4e24f4c40b47 h1:1q18M5WMu/JOlHEF46fJVC6KpVIRuB7rrrwxxD110/0=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.1-0.20260827033225-4e24f4c40b47/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.104.0 h1:2jblZY0C1On+PtUgb02sQrPc2Jk8B6FIYjtLmGYKiZQ=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.104.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0 h1:t44TeeJm7Fkc8Ra72E2YH+OcvM2LC0PF6hHcrxNdq1g=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,10 +16,10 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.0 h1:atNifq4Wp4GLg43AwvvL0s0qT3xXFl3SlkGBRMYlPxY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.0 h1:kn+Xnipla3I6bDFbSfZGlZXSeIcX0mTjGvHofAQH8To=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.1-0.20260827032507-bf39c5be72a1 h1:Z7PysVdEa5SzOxt/gcVhqm1+r5oy+5mTHoVzo+08Xx4=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.103.1-0.20260827032507-bf39c5be72a1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.1-0.20260827033225-4e24f4c40b47 h1:1q18M5WMu/JOlHEF46fJVC6KpVIRuB7rrrwxxD110/0=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.36.1-0.20260827033225-4e24f4c40b47/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=


### PR DESCRIPTION
Third of five for **combat end** — KirkDiggler/rpg-project#295. Design: KirkDiggler/rpg-project#298.

> ✅ **Pins swapped to the real tags** (`rulebooks/dnd5e@v0.104.0`, `encounter@v0.37.0`) now that #1262 and #1263 are merged. Green against the released tags, not just the branch commits. Ready to merge.

One entry in the sealed `boundaryTopics` map. The machine, `Gather`, and `BoundaryOutcome.Announced` already did the right thing for N crossings of any kind, so nothing else in the package changes — which is what a sealed lookup plus a generic machine is *for*.

## No `Round` on the way out, deliberately

A fight ending is not a coordinate in a clock that no longer exists: `play/clock`'s `Turn.Dissolve` sets the round back to `0` because round numbers are per-fight. `Boundary.Round` still says **which** round it ended on, for the record; there is simply nothing on the event for it to become. Inventing a field so the mapping looks symmetrical would be inventing a number subscribers could compare against a *later* fight's — which is the exact bug this slice exists to make impossible.

## Tests

- a run of endings reaching everyone it ended for
- endings riding the **same run** as turn boundaries — they are not two mechanisms and must not become two
- the whole event being the subject and nothing else
- a table-covers-every-known-kind guard that is **honest about its own limit**: it cannot enumerate another module's consts, so a fourth kind is caught by the seal's refusal at the first announcement rather than here. Its job is narrower — stopping the table being *trimmed*.

---

Chain: events (#1262 ✅) → encounter (#1263 ✅) → **resolution** → session (#1265) → rpg-api

— platform agent, on behalf of KirkDiggler
