### PR TITLE
feat(conditions)!: rage anchors to a round instead of counting turns

### DIFF
--- a/rulebooks/dnd5e/character/conditions_test.go
+++ b/rulebooks/dnd5e/character/conditions_test.go
@@ -280,11 +280,22 @@ func (s *CharacterConditionsTestSuite) TestCharacterRemovesExpiredCondition() {
 	// Verify character has both Unarmored Defense (from grants) and Raging (from activation)
 	s.Len(char.GetConditions(), 2, "Character should have Unarmored Defense + Raging conditions")
 
-	// Simulate rage expiring by publishing turn end event without combat activity
+	// Simulate rage expiring by publishing turn end events without combat
+	// activity. TWO of them, because the turn a rage started is not checked
+	// (Kirk's ruling, rpg-project#295) -- and asserting the state in between is
+	// what makes this a test of the grace rather than of the count.
 	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
 	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
 		SubjectID: "char-1",
 		Round:     1,
+	})
+	s.Require().NoError(err)
+	s.Require().Len(char.GetConditions(), 2,
+		"the turn the rage started is graced -- it survives its own activation turn ending")
+
+	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		SubjectID: "char-1",
+		Round:     2,
 	})
 	s.Require().NoError(err)
 

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -28,6 +28,7 @@ type RagingData struct {
 	DamageBonus       int       `json:"damage_bonus"`
 	Level             int       `json:"level"`
 	Source            string    `json:"source"` // Ref string in "module:type:value" format (e.g., "dnd5e:features:rage")
+	SawTurnEnd        bool      `json:"saw_turn_end"`
 	RoundActivated    int       `json:"round_activated"`
 	TurnsActive       int       `json:"turns_active"`
 	WasHitThisTurn    bool      `json:"was_hit_this_turn"`
@@ -41,6 +42,7 @@ type RagingCondition struct {
 	DamageBonus       int
 	Level             int
 	Source            string // Ref string in "module:type:value" format (e.g., "dnd5e:features:rage")
+	SawTurnEnd        bool
 	RoundActivated    int
 	TurnsActive       int
 	WasHitThisTurn    bool
@@ -227,6 +229,7 @@ func (r *RagingCondition) ToJSON() (json.RawMessage, error) {
 		DamageBonus:       r.DamageBonus,
 		Level:             r.Level,
 		Source:            r.Source,
+		SawTurnEnd:        r.SawTurnEnd,
 		RoundActivated:    r.RoundActivated,
 		TurnsActive:       r.TurnsActive,
 		WasHitThisTurn:    r.WasHitThisTurn,
@@ -246,6 +249,7 @@ func (r *RagingCondition) loadJSON(data json.RawMessage) error {
 	r.DamageBonus = ragingData.DamageBonus
 	r.Level = ragingData.Level
 	r.Source = ragingData.Source
+	r.SawTurnEnd = ragingData.SawTurnEnd
 	r.RoundActivated = ragingData.RoundActivated
 	r.TurnsActive = ragingData.TurnsActive
 	r.WasHitThisTurn = ragingData.WasHitThisTurn
@@ -312,15 +316,47 @@ func (r *RagingCondition) onTurnEnd(ctx context.Context, event dnd5eEvents.TurnE
 		return nil
 	}
 
-	if r.RoundActivated == 0 {
-		// The first turn end this rage has seen: anchor it here, and let it
-		// pass unchecked. The grace and the anchor are the same event.
-		r.RoundActivated = event.Round
+	if !r.SawTurnEnd {
+		// The first turn end this rage has seen: it passes unchecked, and it
+		// anchors the duration if it carries a round to anchor to.
+		r.SawTurnEnd = true
+		if event.Round > 0 {
+			r.RoundActivated = event.Round
+		}
 	} else {
+		// The activity check needs no round at all, so it runs regardless of
+		// whether the duration below can be evaluated.
 		if !r.DidAttackThisTurn && !r.WasHitThisTurn {
 			return r.endRage(ctx, "no_combat_activity")
 		}
-		if event.Round-r.RoundActivated >= rageDurationRounds-1 {
+
+		switch {
+		case r.RoundActivated == 0:
+			// Never anchored, because no turn end has carried a round yet.
+			// Anchor late if this one finally does; the cap simply does not
+			// apply until there is something to measure from.
+			if event.Round > 0 {
+				r.RoundActivated = event.Round
+			}
+
+		case event.Round <= 0:
+			// A turn end that does not say which round it is. The cap cannot
+			// be evaluated and is skipped rather than evaluated against zero,
+			// which would read as a clock reset below and end the rage on a
+			// malformed event.
+
+		case event.Round < r.RoundActivated:
+			// The round went BACKWARDS, so this rage has outlived the clock
+			// its anchor came from -- rounds are per-fight and restart at 1.
+			// Combat end exists to make this unreachable (rpg-project#295
+			// part 1), so reaching it means that removal did not happen.
+			// Ending here is both the right rules answer -- the fight it
+			// belonged to is over -- and a net under the thing that should
+			// have caught it. Re-anchoring instead would silently hand out a
+			// fresh ten rounds and hide the regression.
+			return r.endRage(ctx, "clock_reset")
+
+		case event.Round-r.RoundActivated >= rageDurationRounds-1:
 			return r.endRage(ctx, "duration_expired")
 		}
 	}
@@ -334,7 +370,13 @@ func (r *RagingCondition) onTurnEnd(ctx context.Context, event dnd5eEvents.TurnE
 	// turn end is ever missed, and turn ends went missing for months.
 	//
 	// NO RULE READS THIS. Everything above decides on RoundActivated.
-	r.TurnsActive = event.Round - r.RoundActivated + 1
+	//
+	// Only recomputed when there is an anchor to recompute from. An unanchored
+	// rage keeps whatever it had rather than being handed a number derived
+	// from a zero it never agreed to.
+	if r.RoundActivated > 0 && event.Round >= r.RoundActivated {
+		r.TurnsActive = event.Round - r.RoundActivated + 1
+	}
 
 	// Reset for the next turn. On the graced turn too: RAW's window is "since
 	// your last turn", so the activation turn's swing must not pay for the next

--- a/rulebooks/dnd5e/conditions/raging.go
+++ b/rulebooks/dnd5e/conditions/raging.go
@@ -28,6 +28,7 @@ type RagingData struct {
 	DamageBonus       int       `json:"damage_bonus"`
 	Level             int       `json:"level"`
 	Source            string    `json:"source"` // Ref string in "module:type:value" format (e.g., "dnd5e:features:rage")
+	RoundActivated    int       `json:"round_activated"`
 	TurnsActive       int       `json:"turns_active"`
 	WasHitThisTurn    bool      `json:"was_hit_this_turn"`
 	DidAttackThisTurn bool      `json:"did_attack_this_turn"`
@@ -40,6 +41,7 @@ type RagingCondition struct {
 	DamageBonus       int
 	Level             int
 	Source            string // Ref string in "module:type:value" format (e.g., "dnd5e:features:rage")
+	RoundActivated    int
 	TurnsActive       int
 	WasHitThisTurn    bool
 	DidAttackThisTurn bool
@@ -225,6 +227,7 @@ func (r *RagingCondition) ToJSON() (json.RawMessage, error) {
 		DamageBonus:       r.DamageBonus,
 		Level:             r.Level,
 		Source:            r.Source,
+		RoundActivated:    r.RoundActivated,
 		TurnsActive:       r.TurnsActive,
 		WasHitThisTurn:    r.WasHitThisTurn,
 		DidAttackThisTurn: r.DidAttackThisTurn,
@@ -243,6 +246,7 @@ func (r *RagingCondition) loadJSON(data json.RawMessage) error {
 	r.DamageBonus = ragingData.DamageBonus
 	r.Level = ragingData.Level
 	r.Source = ragingData.Source
+	r.RoundActivated = ragingData.RoundActivated
 	r.TurnsActive = ragingData.TurnsActive
 	r.WasHitThisTurn = ragingData.WasHitThisTurn
 	r.DidAttackThisTurn = ragingData.DidAttackThisTurn
@@ -263,30 +267,81 @@ func (r *RagingCondition) onDamageReceived(_ context.Context, event dnd5eEvents.
 	return nil
 }
 
-// onTurnEnd handles turn end events to check if rage continues
+// rageDurationRounds is 2014's "1 minute": ten rounds, ending at the end of the
+// barbarian's own turn on the tenth.
+//
+// Named so the arithmetic below has something to be one less than. Rage spans
+// rounds RoundActivated through RoundActivated+9 inclusive, so the comparison is
+// against rageDurationRounds-1 rather than rageDurationRounds — the one place a
+// duration like this grows an off-by-one.
+const rageDurationRounds = 10
+
+// onTurnEnd decides, at the end of the barbarian's own turn, whether the rage
+// goes on.
+//
+// # 2014, with the activation turn graced
+//
+// RAW 2014: rage lasts 1 minute and ends early if you are knocked unconscious,
+// or if your turn ends and you have neither attacked a hostile creature since
+// your last turn nor taken damage since then.
+//
+// Kirk ruled 2026-08-27 that the turn a rage STARTED is not checked: "I cannot
+// imagine activating rage would end at the end of the turn activated so i think
+// it lasts 1 full turn... this game does not need to follow RAW to the letter."
+// By the letter, a barbarian who rages and then does nothing else drops it the
+// instant their turn ends, which is a bad moment rather than an interesting one.
+// The divergence is exactly this one branch.
+//
+// # The anchor comes from the CLOCK, never from the sheet
+//
+// event.Round is stamped by play/clock itself and is the only round in the
+// system that cannot be stale. The character also carries one --
+// ActionEconomy.TurnNumber -- and it is deliberately NOT used: that is a
+// sheet-local mirror with a documented staleness bug across fights
+// (rpg-project#253, a member starting a fight with the movement their previous
+// one left behind). Anchoring a duration to it would reintroduce the class of
+// defect combat end was built to close.
+//
+// So the rage DISCOVERS its anchor instead of being handed one: the first turn
+// end it hears both establishes RoundActivated and is the graced turn. Zero
+// means "not yet anchored", which is play/clock's own vocabulary for "no round"
+// rather than an invented sentinel -- a Turn clock holds round 0 only while
+// idle.
 func (r *RagingCondition) onTurnEnd(ctx context.Context, event dnd5eEvents.TurnEndEvent) error {
 	if event.SubjectID != r.CharacterID {
 		return nil
 	}
 
-	// Increment turns active
-	r.TurnsActive++
-	r.markDirty()
-
-	// Check if rage ends due to no combat activity
-	if !r.DidAttackThisTurn && !r.WasHitThisTurn {
-		return r.endRage(ctx, "no_combat_activity")
+	if r.RoundActivated == 0 {
+		// The first turn end this rage has seen: anchor it here, and let it
+		// pass unchecked. The grace and the anchor are the same event.
+		r.RoundActivated = event.Round
+	} else {
+		if !r.DidAttackThisTurn && !r.WasHitThisTurn {
+			return r.endRage(ctx, "no_combat_activity")
+		}
+		if event.Round-r.RoundActivated >= rageDurationRounds-1 {
+			return r.endRage(ctx, "duration_expired")
+		}
 	}
 
-	// Check if rage ends due to duration (10 rounds = 1 minute)
-	if r.TurnsActive >= 10 {
-		return r.endRage(ctx, "duration_expired")
-	}
+	// DERIVED, never incremented. TurnsActive is display state that the web
+	// client reads (rpg-dnd5e-web's ConditionBadge, and its isRagingData type
+	// guard, which duck-types on this key being present -- deleting the field
+	// would make every rage silently stop rendering as one). Recomputing it
+	// from the anchor keeps the values the client already shows while removing
+	// the reason it was wrong: an accumulated counter is only correct if no
+	// turn end is ever missed, and turn ends went missing for months.
+	//
+	// NO RULE READS THIS. Everything above decides on RoundActivated.
+	r.TurnsActive = event.Round - r.RoundActivated + 1
 
-	// Reset combat activity flags for next turn. Already marked dirty by the
-	// TurnsActive increment above, which changes on every turn end.
+	// Reset for the next turn. On the graced turn too: RAW's window is "since
+	// your last turn", so the activation turn's swing must not pay for the next
+	// turn's check.
 	r.DidAttackThisTurn = false
 	r.WasHitThisTurn = false
+	r.markDirty()
 
 	return nil
 }

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -1302,3 +1302,129 @@ func (s *RagingConditionTestSuite) TestTurnsActiveIsDerivedAndStillWhatTheClient
 	s.Contains(string(b), `"turns_active":6`, "and it survives the round trip the client reads")
 	s.Contains(string(b), `"round_activated":4`)
 }
+
+// ragingWithRemovalWatch builds an applied rage and a handle on whatever
+// removes it, which is the shape every duration test below needs.
+func (s *RagingConditionTestSuite) ragingWithRemovalWatch() (
+	*RagingCondition, func() *dnd5eEvents.ConditionRemovedEvent,
+) {
+	s.T().Helper()
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1", DamageBonus: 2, Level: 5, Source: "dnd5e:features:rage",
+	})
+	s.Require().NoError(raging.Apply(s.ctx, s.bus))
+
+	var removed *dnd5eEvents.ConditionRemovedEvent
+	_, err := dnd5eEvents.ConditionRemovedTopic.On(s.bus).Subscribe(s.ctx,
+		func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+			removed = &event
+			return nil
+		})
+	s.Require().NoError(err)
+	return raging, func() *dnd5eEvents.ConditionRemovedEvent { return removed }
+}
+
+// TestARoundlessTurnEndDoesNotGrantPerpetualGrace is Copilot's finding on
+// rpg-toolkit#1266, and it was a real one.
+//
+// The grace was originally keyed on RoundActivated == 0 -- "not yet anchored"
+// and "not yet checked" collapsed into one field. They only coincide while
+// rounds are valid. combat.TurnManager publishes TurnEndEvent{SubjectID} with
+// NO Round at all (turn_manager.go:177), so Round defaults to 0: under the old
+// shape the rage never anchored, therefore never left the graced branch, and
+// therefore never checked activity OR duration again. Immortal rage, silently.
+//
+// It has no callers today, which is exactly why it was worth fixing rather
+// than dismissing -- it is a public type this slice deliberately left in place
+// as documented debt, so the hazard belongs to whoever picks it up next.
+//
+// The fix un-collapses the two facts: SawTurnEnd is the grace, RoundActivated
+// is the anchor. The activity check needs no round, so it keeps working even
+// when the duration cannot be evaluated.
+func (s *RagingConditionTestSuite) TestARoundlessTurnEndDoesNotGrantPerpetualGrace() {
+	raging, removed := s.ragingWithRemovalWatch()
+	turnEnds := dnd5eEvents.TurnEndTopic.On(s.bus)
+
+	// A publisher that never stamps its rounds. The first is the graced turn.
+	s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{SubjectID: "barbarian-1"}))
+	s.Require().Nil(removed(), "the first turn end is graced whether or not it carries a round")
+	s.Require().True(raging.SawTurnEnd, "and the grace is spent, which is the thing the round cannot tell us")
+	s.Require().Zero(raging.RoundActivated, "with nothing to anchor to, it stays unanchored")
+
+	// The second is checked. No attack, no damage -- so it ends, exactly as it
+	// would with a well-formed round.
+	s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{SubjectID: "barbarian-1"}))
+	s.Require().NotNil(removed(),
+		"a rage must not become immortal because its publisher forgot to say which round it is")
+	s.Equal("no_combat_activity", removed().Reason)
+}
+
+// TestAnUnanchoredRageAnchorsAsSoonAsARoundArrives — recovery rather than a
+// permanent handicap. A rage that never anchored has no cap, so if the clock
+// starts telling the truth it takes the first round it is given.
+func (s *RagingConditionTestSuite) TestAnUnanchoredRageAnchorsAsSoonAsARoundArrives() {
+	raging, _ := s.ragingWithRemovalWatch()
+	turnEnds := dnd5eEvents.TurnEndTopic.On(s.bus)
+
+	s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{SubjectID: "barbarian-1"}))
+	s.Require().Zero(raging.RoundActivated)
+
+	s.Require().NoError(s.executePostAttackRoll("barbarian-1", "goblin-1", true))
+	s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		SubjectID: "barbarian-1", Round: 6,
+	}))
+	s.Equal(6, raging.RoundActivated, "the first round it is actually told becomes the anchor")
+}
+
+// TestARoundGoingBACKWARDSEndsTheRage is the net under combat end.
+//
+// Round numbers are PER-FIGHT -- clock.Turn.SetOrder starts every bubble at 1
+// and Dissolve sets it back to 0 -- so a round lower than the anchor can only
+// mean this rage outlived the clock its anchor came from. Part 1 of this slice
+// exists to make that unreachable by removing rage when the fight ends; if it
+// is ever reached, that removal did not happen.
+//
+// Ending is the right rules answer (the fight it belonged to is over) AND the
+// safe one: re-anchoring would silently hand out a fresh ten rounds, and doing
+// nothing leaves event.Round - RoundActivated negative, so the cap never fires
+// and the rage runs until someone rests.
+func (s *RagingConditionTestSuite) TestARoundGoingBACKWARDSEndsTheRage() {
+	_, removed := s.ragingWithRemovalWatch()
+	turnEnds := dnd5eEvents.TurnEndTopic.On(s.bus)
+
+	// Anchored deep into a long fight.
+	s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		SubjectID: "barbarian-1", Round: 7,
+	}))
+	s.Require().Nil(removed())
+
+	// A new fight's round 1, with the rage still attached: combat end did not
+	// fire. Activity is present, so only the backwards check can end it.
+	s.Require().NoError(s.executePostAttackRoll("barbarian-1", "goblin-1", true))
+	s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		SubjectID: "barbarian-1", Round: 1,
+	}))
+
+	s.Require().NotNil(removed(), "a rage cannot outlive the clock its duration is measured against")
+	s.Equal("clock_reset", removed().Reason)
+}
+
+// TestARoundlessTurnEndDoesNotREADAsAClockReset — the two degraded cases are
+// different and must not be collapsed either.
+//
+// Zero is "this event does not say", not "the round went backwards". Comparing
+// it as a round would satisfy `event.Round < RoundActivated` and end an
+// otherwise healthy rage on a malformed event.
+func (s *RagingConditionTestSuite) TestARoundlessTurnEndDoesNotREADAsAClockReset() {
+	raging, removed := s.ragingWithRemovalWatch()
+	turnEnds := dnd5eEvents.TurnEndTopic.On(s.bus)
+
+	s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		SubjectID: "barbarian-1", Round: 3,
+	}))
+	s.Require().NoError(s.executePostAttackRoll("barbarian-1", "goblin-1", true))
+	s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{SubjectID: "barbarian-1"}))
+
+	s.Nil(removed(), "a turn end with no round is unevaluable, not a reset")
+	s.Equal(3, raging.RoundActivated, "and it does not disturb the anchor")
+}

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -1428,3 +1428,36 @@ func (s *RagingConditionTestSuite) TestARoundlessTurnEndDoesNotREADAsAClockReset
 	s.Nil(removed(), "a turn end with no round is unevaluable, not a reset")
 	s.Equal(3, raging.RoundActivated, "and it does not disturb the anchor")
 }
+
+// TestANegativeRoundNeverBecomesTheAnchor pins the `event.Round > 0` guard on
+// the initial anchor, which mutation testing showed was otherwise asserting
+// nothing.
+//
+// Zero cannot distinguish it: assigning 0 to a field that is already 0 is a
+// no-op, so removing the guard passes every test above. Only a NEGATIVE round
+// tells the two apart -- and it matters, because a negative anchor poisons the
+// arithmetic rather than merely disabling it. Anchored at -5, a later round 1
+// computes 1 - (-5) == 6 and the rage silently runs six rounds' worth of
+// duration it never earned, while the backwards-check (1 < -5) never fires.
+//
+// play/clock cannot produce one. TurnEndEvent.Round is a plain int with no
+// validation, so nothing between a publisher and here says it may not.
+func (s *RagingConditionTestSuite) TestANegativeRoundNeverBecomesTheAnchor() {
+	raging, removed := s.ragingWithRemovalWatch()
+	turnEnds := dnd5eEvents.TurnEndTopic.On(s.bus)
+
+	s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		SubjectID: "barbarian-1", Round: -5,
+	}))
+	s.Require().Zero(raging.RoundActivated, "a negative round is not a round to measure from")
+	s.Require().True(raging.SawTurnEnd, "though it does spend the grace, like any other turn end")
+
+	// And the rage recovers: the next real round anchors it honestly.
+	s.Require().NoError(s.executePostAttackRoll("barbarian-1", "goblin-1", true))
+	s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		SubjectID: "barbarian-1", Round: 2,
+	}))
+	s.Require().Nil(removed())
+	s.Equal(2, raging.RoundActivated)
+	s.Equal(1, raging.TurnsActive, "and its first counted turn is that one, not a number derived from -5")
+}

--- a/rulebooks/dnd5e/conditions/raging_test.go
+++ b/rulebooks/dnd5e/conditions/raging_test.go
@@ -187,6 +187,47 @@ func (s *RagingConditionTestSuite) TestRagingConditionTracksDamage() {
 	s.True(raging.WasHitThisTurn)
 }
 
+// TestTheTurnARageStartedIsNotChecked is the house rule, and it is deliberately
+// the test that FAILS against RAW 2014.
+//
+// By the letter, a barbarian who rages and then ends their turn without
+// swinging drops it immediately -- they have not attacked since their last turn
+// and have not been hit. Kirk ruled against that 2026-08-27: "I cannot imagine
+// activating rage would end at the end of the turn activated so i think it
+// lasts 1 full turn."
+//
+// Kept as its own named test rather than folded into the one below, so that the
+// divergence from the printed rule is something a reader trips over on purpose.
+func (s *RagingConditionTestSuite) TestTheTurnARageStartedIsNotChecked() {
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1",
+		DamageBonus: 2,
+		Level:       5,
+		Source:      "dnd5e:features:rage",
+	})
+	s.Require().NoError(raging.Apply(s.ctx, s.bus))
+
+	var removedEvent *dnd5eEvents.ConditionRemovedEvent
+	_, err := dnd5eEvents.ConditionRemovedTopic.On(s.bus).Subscribe(s.ctx,
+		func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+			removedEvent = &event
+			return nil
+		})
+	s.Require().NoError(err)
+
+	// The barbarian rages and does nothing else. Their turn ends.
+	s.Require().NoError(dnd5eEvents.TurnEndTopic.On(s.bus).Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		SubjectID: "barbarian-1",
+		Round:     4,
+	}))
+
+	s.Nil(removedEvent, "the turn a rage started is not checked -- RAW would have ended it here")
+	s.Equal(4, raging.RoundActivated,
+		"and that same turn end is what anchors the duration, from the clock's own round")
+}
+
+// TestRagingConditionEndsWithoutCombatActivity is the 2014 activity check
+// itself, which the grace above delays by exactly one turn rather than removes.
 func (s *RagingConditionTestSuite) TestRagingConditionEndsWithoutCombatActivity() {
 	// Create a raging condition
 	raging := newRagingCondition(ragingConditionInput{
@@ -209,12 +250,16 @@ func (s *RagingConditionTestSuite) TestRagingConditionEndsWithoutCombatActivity(
 	})
 	s.Require().NoError(err)
 
-	// Publish turn end event without any combat activity
 	turnEndTopic := dnd5eEvents.TurnEndTopic.On(s.bus)
-	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
-		SubjectID: "barbarian-1",
-		Round:     1,
-	})
+
+	// The activation turn: graced, and the anchor.
+	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{SubjectID: "barbarian-1", Round: 1})
+	s.Require().NoError(err)
+	s.Require().Nil(removedEvent, "precondition: the first turn end is the graced one")
+
+	// The next turn, equally quiet -- no attack, no damage taken. This one is
+	// checked, and the grace does not extend to it.
+	err = turnEndTopic.Publish(s.ctx, dnd5eEvents.TurnEndEvent{SubjectID: "barbarian-1", Round: 2})
 	s.Require().NoError(err)
 
 	// Verify condition published removal event
@@ -1133,4 +1178,127 @@ func (s *RagingConditionTestSuite) TestRagingConditionGrantsAdvantageOnSTRChecks
 		s.Require().NoError(err)
 		s.Empty(finalEvent.AdvantageSources)
 	})
+}
+
+// TestARageThatMISSESATurnEndStillExpiresOnTime is the whole reason the counter
+// became an anchor, and it is the test the old implementation could not pass.
+//
+// TurnsActive was INCREMENTED once per turn end, so it was only ever correct if
+// no turn end was missed. Turn ends went missing for months (rpg-project#294),
+// and they can still go missing for one member in ordinary play -- a body
+// spliced out of the order and back, a fight that re-forms around somebody.
+// A counter that has lost a tick under-counts forever after, and the rage runs
+// long by exactly the number it dropped.
+//
+// event.Round - RoundActivated is recomputed from two facts every time, so a
+// gap costs nothing: the rage still ends on the round it was always going to.
+//
+// Here the barbarian's turn ends are heard in rounds 1..4, then rounds 8..10 --
+// three turn ends never arrive. The old arithmetic would have reached
+// TurnsActive == 7 and kept going; this ends on round 10, as it should.
+func (s *RagingConditionTestSuite) TestARageThatMISSESATurnEndStillExpiresOnTime() {
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1", DamageBonus: 2, Level: 5, Source: "dnd5e:features:rage",
+	})
+	s.Require().NoError(raging.Apply(s.ctx, s.bus))
+
+	var removedEvent *dnd5eEvents.ConditionRemovedEvent
+	_, err := dnd5eEvents.ConditionRemovedTopic.On(s.bus).Subscribe(s.ctx,
+		func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+			removedEvent = &event
+			return nil
+		})
+	s.Require().NoError(err)
+
+	turnEnds := dnd5eEvents.TurnEndTopic.On(s.bus)
+	heard := []int{1, 2, 3, 4, 8, 9, 10} // rounds 5, 6 and 7 never reach this rage
+	for _, round := range heard {
+		s.Require().NoError(s.executePostAttackRoll("barbarian-1", "goblin-1", true))
+		s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+			SubjectID: "barbarian-1", Round: round,
+		}))
+		if round < 10 {
+			s.Require().Nil(removedEvent, "rage must still be running at round %d", round)
+		}
+	}
+
+	s.Require().NotNil(removedEvent,
+		"only SEVEN turn ends were heard, but ten rounds elapsed -- the anchor knows that and a counter could not")
+	s.Equal("duration_expired", removedEvent.Reason)
+}
+
+// TestTheDurationIsRelativeToWhenTheRageStarted catches the implementation that
+// quietly assumes a fight begins when the rage does.
+//
+// A barbarian who rages in round 4 gets rounds 4 through 13, not 4 through 10.
+// Anchoring at 1 -- or comparing event.Round directly against the duration --
+// passes every test that happens to start raging in round 1, which is most of
+// them.
+func (s *RagingConditionTestSuite) TestTheDurationIsRelativeToWhenTheRageStarted() {
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1", DamageBonus: 2, Level: 5, Source: "dnd5e:features:rage",
+	})
+	s.Require().NoError(raging.Apply(s.ctx, s.bus))
+
+	var removedEvent *dnd5eEvents.ConditionRemovedEvent
+	_, err := dnd5eEvents.ConditionRemovedTopic.On(s.bus).Subscribe(s.ctx,
+		func(_ context.Context, event dnd5eEvents.ConditionRemovedEvent) error {
+			removedEvent = &event
+			return nil
+		})
+	s.Require().NoError(err)
+
+	turnEnds := dnd5eEvents.TurnEndTopic.On(s.bus)
+	for round := 4; round <= 12; round++ {
+		s.Require().NoError(s.executePostAttackRoll("barbarian-1", "goblin-1", true))
+		s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+			SubjectID: "barbarian-1", Round: round,
+		}))
+		s.Require().Nil(removedEvent,
+			"a rage begun in round 4 is still running in round %d", round)
+	}
+
+	// Round 13 is the tenth round of THIS rage: 13 - 4 == 9.
+	s.Require().NoError(s.executePostAttackRoll("barbarian-1", "goblin-1", true))
+	s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+		SubjectID: "barbarian-1", Round: 13,
+	}))
+	s.Require().NotNil(removedEvent, "and ends at the end of its tenth round, round 13")
+	s.Equal("duration_expired", removedEvent.Reason)
+}
+
+// TestTurnsActiveIsDerivedAndStillWhatTheClientRenders pins a cross-repo
+// contract from the side that can break it.
+//
+// rpg-dnd5e-web's isRagingData duck-types on 'turns_active' being present
+// (src/types/conditionData.ts), and ConditionBadge renders "Active for N turns"
+// from it. Deleting the field -- the obvious move, since no rule reads it any
+// more -- would make every rage silently stop being recognised as a rage: the
+// guard returns false, no error is raised, and the tooltip quietly loses its
+// damage bonus, duration and resistance line.
+//
+// So it stays, DERIVED from the anchor rather than incremented, and these are
+// the numbers the client already shows.
+func (s *RagingConditionTestSuite) TestTurnsActiveIsDerivedAndStillWhatTheClientRenders() {
+	raging := newRagingCondition(ragingConditionInput{
+		CharacterID: "barbarian-1", DamageBonus: 2, Level: 5, Source: "dnd5e:features:rage",
+	})
+	s.Require().NoError(raging.Apply(s.ctx, s.bus))
+
+	turnEnds := dnd5eEvents.TurnEndTopic.On(s.bus)
+	for _, tc := range []struct{ round, want int }{{4, 1}, {5, 2}, {6, 3}, {9, 6}} {
+		s.Require().NoError(s.executePostAttackRoll("barbarian-1", "goblin-1", true))
+		s.Require().NoError(turnEnds.Publish(s.ctx, dnd5eEvents.TurnEndEvent{
+			SubjectID: "barbarian-1", Round: tc.round,
+		}))
+		s.Equal(tc.want, raging.TurnsActive,
+			"round %d of a rage anchored at 4 is its turn %d", tc.round, tc.want)
+	}
+
+	// The last row is the one an incrementing counter gets wrong: rounds 7 and
+	// 8 were never heard, so a counter would say 4 where the anchor says 6.
+	b, err := raging.ToJSON()
+	s.Require().NoError(err)
+	s.Contains(string(b), `"turns_active":6`, "and it survives the round trip the client reads")
+	s.Contains(string(b), `"round_activated":4`)
 }


### PR DESCRIPTION
**Part 2 of** KirkDiggler/rpg-project#295 — rage. Part 1 (combat end) shipped in #1262–#1265. Design: KirkDiggler/rpg-project#298.

`TurnsActive` was **incremented** once per turn end, so it was only ever correct if no turn end was missed — and turn ends went missing for months (#294). `event.Round - RoundActivated` is recomputed from two facts and cannot drift.

## 2014, with the activation turn graced

Kirk ruled it 2026-08-27: *"I cannot imagine activating rage would end at the end of the turn activated so i think it lasts 1 full turn… this game does not need to follow RAW to the letter."*

By the letter, a barbarian who rages and then does nothing else drops it the instant their turn ends. The divergence is **exactly one branch**, and it has its own named test — `TestTheTurnARageStartedIsNotChecked` — which **fails against RAW on purpose**, so a reader trips over the house rule rather than mistaking it for a bug.

## The anchor comes from the clock, never the sheet

The character *does* carry a round: `ActionEconomy.TurnNumber`. It is deliberately **not** used. That's a sheet-local mirror with a documented staleness bug across fights — rpg-project#253, where a member recruited into a running fight began their turn with 5 of 30 feet left, the number their *previous* fight left behind. Anchoring a duration to it would reintroduce the exact class of defect combat end just closed.

`event.Round` is stamped by `play/clock` and cannot be stale. So the rage **discovers** its anchor: the first turn end it hears both establishes `RoundActivated` and *is* the graced turn. The grace and the anchor are the same event, which is why this needs no round threaded through `FeatureInput`. Zero means "not yet anchored" — `play/clock`'s own vocabulary for "no round", not an invented sentinel.

## The cap is the same threshold, not a corrected one

Worth stating plainly because I flagged it to Kirk as an off-by-one and that was imprecise. Old code did `TurnsActive++` **then** `>= 10`. With `TurnsActive == event.Round - RoundActivated + 1`, that is exactly `event.Round - RoundActivated >= 9`. **Identical.** The old number was right whenever it counted right.

The risk isn't that it was wrong — it's that **changing representation is where an off-by-one gets introduced**. So `rageDurationRounds = 10` is named and the comparison is written against it minus one.

## `turns_active` stays, and deleting it would have broken the client silently

`rpg-dnd5e-web/src/types/conditionData.ts:108`:

```ts
export function isRagingData(data: ConditionData): data is RagingData {
  return 'damage_bonus' in data && 'turns_active' in data;
}
```

A **duck-typed discriminator**. Remove the field — the obvious move, since no rule reads it any more — and the guard returns false for every rage. No error, no crash: `ConditionBadge` falls through to its generic branch and the tooltip quietly loses its damage bonus, duration and resistance line.

So it stays, **derived**: set from the anchor each turn end, never incremented. Same numbers the client already renders, and it can no longer drift. One source of truth with one projection — the distinction being that a projection has a single writer and is recomputed rather than maintained.

*(Better long-term: the client should discriminate on `ref`, which every condition blob carries. Filed as follow-up — changing the toolkit and the client's guard in one breath is how a silent break becomes two.)*

## Tests

- the grace, as its own named test that fails against RAW
- the activity check still firing on the **next** quiet turn — the grace delays it by one turn, it doesn't remove it
- **a rage that misses three turn ends still expires on the right round** — the test the old implementation structurally could not pass
- a duration relative to a rage begun in **round 4**, not round 1 — catches an implementation that assumes the fight starts when the rage does
- `turns_active` pinned to the client's numbers, through `ToJSON`
- `TestCharacterRemovesExpiredCondition` now drives two turn ends through the real `Rage.Activate` path and **asserts the state in between**, making it a test of the grace rather than of the count

**Mutation-checked, four mutants, all killed**: removing the grace, the cap off by one, `TurnsActive` accumulating again, and the anchor hardcoded to round 1. The off-by-one is killed by three tests including the pre-existing 10-round one, so the threshold is pinned in both representations.

27 packages green, build and vet clean.

---

Chain: **rulebooks/dnd5e** → session → rpg-api

— platform agent, on behalf of KirkDiggler
