### PR TITLE
chore(session): adopt rage's anchor

### DIFF
--- a/rulebooks/dnd5e/session/clockboundary_test.go
+++ b/rulebooks/dnd5e/session/clockboundary_test.go
@@ -150,16 +150,32 @@ func (s *ClockBoundaryTestSuite) TestSneakAttackForgetsItsDiceWhenTheTurnEnds() 
 // This is also the case Kirk used to rule out round boundaries: rage runs from
 // your turn to your turn, so ending ALICE's turn is what decides it, whatever
 // the round is doing.
+//
+// TWO turn ends, since rpg-project#295 part 2: the turn a rage STARTED is not
+// checked (Kirk's ruling — "I cannot imagine activating rage would end at the
+// end of the turn activated"). The intermediate assertion is what makes this a
+// test of the grace rather than of a count, and it is the acceptance for that
+// ruling from the far end of the chain: the grace has to survive the trip
+// through resolution, the announcer seam, and the persisted sheet, not just
+// the condition's own unit test.
 func (s *ClockBoundaryTestSuite) TestRageLapsesWhenTheBarbarianDidNothing() {
 	mgr := s.fight(s.raw(&conditions.RagingCondition{
 		CharacterID: "alice", DamageBonus: 2, Level: 1, Source: "dnd5e:features:rage",
 	}))
 	s.Require().Len(s.storedConditions("alice"), 1, "alice starts raging")
 
+	// Alice's own turn ends: graced, and anchored to the round the clock says.
+	s.endTurn(mgr, "alice")
+	s.Require().Len(s.storedConditions("alice"), 1,
+		"the turn a rage started is not checked — it survives its own activation turn ending")
+
+	// Round the order back to alice so she gets a SECOND turn end, this one
+	// checked. Still no attack and no damage taken.
+	s.endTurn(mgr, "bob")
 	s.endTurn(mgr, "alice")
 
 	s.Empty(s.storedConditions("alice"),
-		"a barbarian who neither swung nor was hit stops raging when their turn ends")
+		"a barbarian who neither swung nor was hit stops raging when their NEXT turn ends")
 }
 
 // TestOneAdvanceReachesEveryoneAndEachDecidesForItself.

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.104.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.16.0

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.104.0 h1:2jblZY0C1On+PtUgb02sQrPc2Jk8B6FIYjtLmGYKiZQ=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.104.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.0 h1:HuemqoSeObvN+wFdmPurNqdPTGJa0pIkLTpLc4FpIyc=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0 h1:LxEJMtm4M3PMDnpRC61ooGvWKS/eRZImu/GTeTDCYuM=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0/go.mod h1:Y5eXfAAyQ0N4Sp07T5C7MxD2CwAwdAUi2zo5SyN60Ds=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0 h1:t44TeeJm7Fkc8Ra72E2YH+OcvM2LC0PF6hHcrxNdq1g=


### PR DESCRIPTION
Promotes #1266 into `session`. KirkDiggler/rpg-project#295 part 2.

```
rulebooks/dnd5e  v0.104.0 → v0.105.0
```

**Not a bare pin bump — the bump failed the suite, which is the promotion doing its job.**

`TestRageLapsesWhenTheBarbarianDidNothing` published one turn end and expected the rage gone. That's the RAW reading #295 part 2 deliberately overrode: *"the turn a rage started is not checked."* The failure output names the new fields on the persisted blob — `saw_turn_end:true`, `round_activated:1` — so the grace **and** the anchor both survive the trip through resolution, the announcer seam and onto the sheet. That's the end-to-end evidence a unit test on the condition structurally cannot give.

The test now drives `alice → bob → alice` and asserts the state **in between**, which makes it a test of the grace rather than of a count.

Green after.

---

Chain: dnd5e #1266 ✅ → **session** → rpg-api

— platform agent, on behalf of KirkDiggler
