### PR TITLE
fix(dnd5e): the two defects on the way into feature activation

### DIFF
--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -247,7 +247,7 @@ func (c *Character) HasGranted(key GrantedActionKey) bool {
 // An unknown ref returns TargetKindUnspecified so a new ref surfaces as a
 // visible defect rather than silently defaulting.
 //
-// # It answers for features too, and did not used to
+// # It answers for features too, and until now it did not
 //
 // The table was written when only combat abilities reached a menu, so every
 // FEATURE fell to the default and came back Unspecified. That defaulting did

--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -168,7 +168,29 @@ func (c *Character) AvailableAbilities() []AvailableAbility {
 // ActivateAbility activates a combat ability or feature by ref.
 // Routes to the appropriate handler based on whether the ref matches a combat ability or feature.
 // Returns success=false with an error message if activation fails.
+//
+// # A call with nothing in it is refused, not answered
+//
+// "Not in combat" and "unknown ability" are ANSWERS: a question was asked and
+// the sheet has a reply. A nil input, or one naming no ability, is not a
+// question — the caller has a bug, and handing it back a well-formed
+// Success:false would report that bug as a barbarian who cannot rage. So it is
+// an error by name at the door, the same door [Character.StartTurn] and
+// [Character.RefreshForTurn] keep over the same state (rpg-toolkit#1093).
+//
+// The refusal PRECEDES the combat check, and that ordering is the fix rather
+// than incidental to it. Before this, a nil input from a character out of
+// combat came back "not in combat" — true about the world, false about what
+// went wrong — and the same nil from a character IN combat panicked. One
+// mistake, two behaviours, neither of them the truth.
 func (c *Character) ActivateAbility(_ context.Context, input *ActivateAbilityInput) (*ActivateAbilityOutput, error) {
+	if input == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "no ability to activate")
+	}
+	if input.AbilityRef == nil {
+		return nil, rpgerr.New(rpgerr.CodeInvalidArgument, "no ability ref to activate")
+	}
+
 	if !c.InCombat() {
 		return &ActivateAbilityOutput{
 			Success: false,

--- a/rulebooks/dnd5e/character/action_economy.go
+++ b/rulebooks/dnd5e/character/action_economy.go
@@ -246,6 +246,16 @@ func (c *Character) HasGranted(key GrantedActionKey) bool {
 // owns "what does this action target") — the game server never computes it.
 // An unknown ref returns TargetKindUnspecified so a new ref surfaces as a
 // visible defect rather than silently defaulting.
+//
+// # It answers for features too, and did not used to
+//
+// The table was written when only combat abilities reached a menu, so every
+// FEATURE fell to the default and came back Unspecified. That defaulting did
+// exactly what it was designed to do — it stayed silent while nothing read the
+// answer, and it surfaced the moment something did (rpg-project#300). Rage and
+// Second Wind are here because they are the level-1 features a player can
+// activate; the rest of the module's features are deliberately absent rather
+// than guessed, and arrive with the slice that makes each of them reachable.
 func targetKindForRef(ref *core.Ref) TargetKind {
 	if ref == nil {
 		return TargetKindUnspecified
@@ -264,6 +274,12 @@ func targetKindForRef(ref *core.Ref) TargetKind {
 	// Deliberately untargeted (fire without a prompt).
 	case refs.CombatAbilities.Dash().ID:
 		return TargetKindNone
+	// Features that act on the character who used them. Self rather than None:
+	// both mean "do not prompt", and only Self also says whose sheet the effect
+	// lands on — which is the half a caller other than a prompt cares about.
+	case refs.Features.Rage().ID,
+		refs.Features.SecondWind().ID:
+		return TargetKindSelf
 	default:
 		return TargetKindUnspecified
 	}

--- a/rulebooks/dnd5e/character/action_economy_test.go
+++ b/rulebooks/dnd5e/character/action_economy_test.go
@@ -443,3 +443,40 @@ func (s *ActionEconomyTestSuite) TestAnUnknownAbilityIsStillAnAnswer() {
 	s.False(out.Success)
 	s.Equal("unknown ability", out.Error)
 }
+
+// --- rpg-project#300: the target table has to answer for features too ---
+
+// The behavioural half: a fighter's Second Wind reaches a caller with a target
+// kind, not with the blank that means "the producer forgot to say".
+func (s *ActionEconomyTestSuite) TestAFeatureCarriesItsTargetKind() {
+	char := createTestFighterCharacter(s.T(), s.bus)
+	_, err := char.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+
+	var secondWind *AvailableAbility
+	for i, a := range char.AvailableAbilities() {
+		if a.Ref != nil && a.Ref.ID == refs.Features.SecondWind().ID {
+			secondWind = &char.AvailableAbilities()[i]
+		}
+	}
+
+	s.Require().NotNil(secondWind, "the fighter should offer Second Wind")
+	s.Equal(TargetKindSelf, secondWind.TargetKind)
+}
+
+// The table half. Rage has no helper on this suite, and the point being pinned
+// is the table rather than the barbarian, so it is asked directly.
+func (s *ActionEconomyTestSuite) TestTheTargetTableKnowsTheLevelOneFeatures() {
+	s.Equal(TargetKindSelf, targetKindForRef(refs.Features.Rage()))
+	s.Equal(TargetKindSelf, targetKindForRef(refs.Features.SecondWind()))
+}
+
+// AND THE DEFAULT IS STILL A DEFAULT. Teaching the table two refs must not
+// turn its safety net into a guess: a feature nobody has ruled on yet still
+// comes back Unspecified, which is what makes the next gap visible the way
+// this one was.
+func (s *ActionEconomyTestSuite) TestAnUnruledFeatureStillSurfacesAsUnspecified() {
+	s.Equal(TargetKindUnspecified, targetKindForRef(refs.Features.ActionSurge()))
+	s.Equal(TargetKindUnspecified, targetKindForRef(refs.Features.FlurryOfBlows()))
+	s.Equal(TargetKindUnspecified, targetKindForRef(nil))
+}

--- a/rulebooks/dnd5e/character/action_economy_test.go
+++ b/rulebooks/dnd5e/character/action_economy_test.go
@@ -373,3 +373,73 @@ func (s *ActionEconomyTestSuite) TestEndTurn_ResetsButStaysInCombat() {
 	// But still in combat
 	s.True(char.InCombat())
 }
+
+// --- rpg-toolkit#1093: a call with nothing in it is refused, not answered ---
+
+// The panic case. In combat, the ref lookup dereferenced the input directly.
+func (s *ActionEconomyTestSuite) TestActivatingWithoutInputIsRefused() {
+	char := createTestFighterCharacter(s.T(), s.bus)
+	_, err := char.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+	char.MarkClean()
+
+	out, err := char.ActivateAbility(s.ctx, nil)
+
+	s.Require().Error(err)
+	s.Nil(out)
+	// A refusal spends nothing: the action is still there to take once the
+	// caller passes an ability.
+	s.Equal(1, char.GetActionEconomy().ActionsRemaining)
+	s.False(char.IsDirty())
+}
+
+// THE ORDERING TEST, and the reason the nil check sits above the combat check
+// rather than below it. Out of combat, a nil input never reached the
+// dereference — it came back Success:false, "not in combat", which is a true
+// statement about the world and a false one about what the caller did wrong.
+// A test that only ever passed nil to a character IN combat cannot tell the
+// two orderings apart, because both panic-free versions look identical there.
+func (s *ActionEconomyTestSuite) TestActivatingWithoutInputIsRefusedEvenOutOfCombat() {
+	char := createTestFighterCharacter(s.T(), s.bus)
+	s.Require().False(char.InCombat())
+
+	out, err := char.ActivateAbility(s.ctx, nil)
+
+	s.Require().Error(err)
+	s.Nil(out)
+	s.NotContains(err.Error(), "not in combat")
+}
+
+// The other half of the same mistake: an input that exists but names nothing.
+// It dereferences one field further in, so it survives a fix that only guards
+// the outer pointer.
+func (s *ActionEconomyTestSuite) TestActivatingWithoutARefIsRefused() {
+	char := createTestFighterCharacter(s.T(), s.bus)
+	_, err := char.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+	char.MarkClean()
+
+	out, err := char.ActivateAbility(s.ctx, &ActivateAbilityInput{})
+
+	s.Require().Error(err)
+	s.Nil(out)
+	s.Equal(1, char.GetActionEconomy().ActionsRemaining)
+	s.False(char.IsDirty())
+}
+
+// The refusals are refusals and not a new way to fail an ordinary call: an
+// ability this character does not have is still an ANSWER, not an error.
+func (s *ActionEconomyTestSuite) TestAnUnknownAbilityIsStillAnAnswer() {
+	char := createTestFighterCharacter(s.T(), s.bus)
+	_, err := char.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+
+	out, err := char.ActivateAbility(s.ctx, &ActivateAbilityInput{
+		AbilityRef: refs.Features.Rage(),
+	})
+
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+	s.False(out.Success)
+	s.Equal("unknown ability", out.Error)
+}

--- a/rulebooks/dnd5e/character/action_economy_test.go
+++ b/rulebooks/dnd5e/character/action_economy_test.go
@@ -453,10 +453,16 @@ func (s *ActionEconomyTestSuite) TestAFeatureCarriesItsTargetKind() {
 	_, err := char.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
 	s.Require().NoError(err)
 
+	// One call, held. AvailableAbilities builds a fresh slice every time, so
+	// indexing a second call would take a pointer into a different slice than
+	// the one being ranged over — harmless here and a trap the moment the
+	// builder does anything order- or state-dependent.
+	abilities := char.AvailableAbilities()
+
 	var secondWind *AvailableAbility
-	for i, a := range char.AvailableAbilities() {
-		if a.Ref != nil && a.Ref.ID == refs.Features.SecondWind().ID {
-			secondWind = &char.AvailableAbilities()[i]
+	for i := range abilities {
+		if abilities[i].Ref != nil && abilities[i].Ref.ID == refs.Features.SecondWind().ID {
+			secondWind = &abilities[i]
 		}
 	}
 


### PR DESCRIPTION
The two defects on the path into **rpg-project#300**, fixed before that slice walks into them rather than during it. Both live in `character/action_economy.go`, and both are the same class of thing: a code path nothing has ever called, whose inputs and whose data were therefore never exercised.

## 1. `ActivateAbility` refuses a call with nothing in it

Closes #1093. `ExecuteAction`, the other verb named in that issue, no longer exists — this is what remains of it.

**The ordering is the fix, not incidental to it.** The dereference sat *below* the combat check, so one caller mistake had two behaviours and neither was the truth:

| caller passes nil | before | now |
|---|---|---|
| …to a character **out** of combat | `Success:false, "not in combat"` — true about the world, false about what went wrong | error |
| …to a character **in** combat | panic | error |

Both now refuse by name at the door, the way `StartTurn` and `RefreshForTurn` already do over the same state.

`"not in combat"` and `"unknown ability"` stay **answers** — a question was asked and the sheet has a reply. A pinned test says so, because a fix that turned an ordinary negative reply into an error would pass every test written for the panic.

## 2. The target table did not answer for features

`targetKindForRef` switched on `refs.CombatAbilities.*` only, so every **feature** fell through to the default and came back `TargetKindUnspecified` — which the session proto calls a producer defect.

The default was doing its job. Its own doc says it is there *"so a new ref surfaces as a visible defect rather than silently defaulting"*, and it stayed quiet for exactly as long as nothing read the answer. #300 reads it.

Rage and Second Wind get `TargetKindSelf` — self rather than none because both mean "do not prompt", and only `Self` also says whose sheet the effect lands on. The module's other six features are **deliberately absent rather than guessed**: they are level 2+ and none is reachable yet. A pinned test asserts the default is still a default, so the next gap surfaces the way this one did.

## Evidence

Both changes were mutation-checked, and the interesting result is the ordering one:

| mutant | killed by |
|---|---|
| both nil guards removed | 3 tests (two panic, one on the wrong reply) |
| guards moved **below** the combat check | **exactly one test** — the out-of-combat case |
| feature cases removed from the table | 2 tests |

The middle row is why there is a test that passes nil to a character who is *not* in combat. A test that only ever passed nil to a character in combat cannot tell the two orderings apart — both panic-free versions look identical there.

Full `rulebooks/dnd5e` suite green.

— platform agent, on behalf of KirkDiggler
