### PR TITLE
feat(resolution): NewActivation — using what a character already carries

### DIFF
--- a/rulebooks/dnd5e/resolution/activation.go
+++ b/rulebooks/dnd5e/resolution/activation.go
@@ -122,12 +122,20 @@ func NewActivation(in *ActivationInput) (Machine, error) {
 			ErrBadActivation, in.MemberID, err)
 	}
 
+	// BOTH pieces of caller-owned material are copied, not just the obvious
+	// one. core.Ref is a mutable struct, so keeping the caller's pointer would
+	// let a reused ref change WHICH ABILITY this machine activates after it was
+	// constructed — a worse version of the observer-slice hazard, and one that
+	// is easy to miss precisely because the slice copy right beside it looks
+	// like the defence was already made.
+	ability := *in.Ability
+
 	observers := make([]int, len(in.ObserverPassivePerceptions))
 	copy(observers, in.ObserverPassivePerceptions)
 
 	return &activationMachine{
 		member:    in.MemberID,
-		ability:   in.Ability,
+		ability:   &ability,
 		targetID:  in.TargetID,
 		observers: observers,
 	}, nil
@@ -162,6 +170,10 @@ func (m *activationMachine) Start(_ context.Context, cast *Participants) (Step, 
 		return nil, fmt.Errorf("%w: %q is not a participant", ErrBadActivation, m.member)
 	}
 
+	if err := m.checkTargetContract(actor); err != nil {
+		return nil, err
+	}
+
 	var target core.Entity
 	if m.targetID != "" {
 		found, err := memberEntity(cast, m.targetID)
@@ -172,6 +184,53 @@ func (m *activationMachine) Start(_ context.Context, cast *Participants) (Step, 
 	}
 
 	return m.step(actor, target), nil
+}
+
+// checkTargetContract enforces what ActivationInput.TargetID promises: required
+// when the ability takes somebody, empty when it does not.
+//
+// # The rulebook answers, this does not decide
+//
+// Which abilities take a target is rules knowledge, and re-stating it here
+// would be a second table to disagree with the first. So it ASKS: the sheet's
+// own AvailableAbilities carries each ability's TargetKind, authored by the
+// same table Afford projects into a declaration. This reads that answer and
+// enforces it; it does not have an opinion about Help.
+//
+// # It stays quiet when the sheet cannot answer
+//
+// AvailableAbilities is empty for a character who is not in combat, and an
+// ability this character does not carry is simply absent. NEITHER is a
+// malformed call — the first is an actor-state refusal and the second is
+// "unknown ability", and both belong to ErrActivationRefused. Refusing them
+// here would report a barbarian out of combat as a caller defect, which is the
+// exact confusion the two sentinels exist to prevent.
+func (m *activationMachine) checkTargetContract(actor *character.Character) error {
+	var kind character.TargetKind
+	found := false
+	for _, available := range actor.AvailableAbilities() {
+		if available.Ref != nil && available.Ref.ID == m.ability.ID {
+			kind, found = available.TargetKind, true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+
+	wantsTarget := kind == character.TargetKindSingleEntity
+	switch {
+	case wantsTarget && m.targetID == "":
+		return fmt.Errorf("%w: %s needs a target and none was named",
+			ErrBadActivation, m.ability.String())
+	case !wantsTarget && m.targetID != "":
+		// Refused rather than ignored. A target quietly dropped is a client
+		// that believes it aimed Dodge at somebody and a server that knows
+		// better, which is a disagreement nobody finds until it matters.
+		return fmt.Errorf("%w: %s takes no target, but %q was named",
+			ErrBadActivation, m.ability.String(), m.targetID)
+	}
+	return nil
 }
 
 // step is the one thing this machine does.

--- a/rulebooks/dnd5e/resolution/activation.go
+++ b/rulebooks/dnd5e/resolution/activation.go
@@ -1,0 +1,242 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+)
+
+// ActivationInput names one member using something they already carry.
+type ActivationInput struct {
+	// MemberID is who is activating. Required, and must be a CHARACTER in the
+	// cast: a monster's abilities are driven by its behaviour, not declared by
+	// a player, and its economy belongs to whoever runs its turn rather than
+	// to its sheet — the same line [ErrNoPayer] draws.
+	MemberID string
+
+	// Ability is which of the things they carry. Required. A ref rather than
+	// an index or a name, because the sheet's own lookup is by ref and a
+	// second addressing scheme would be a second place for the two to
+	// disagree.
+	Ability *core.Ref
+
+	// TargetID is who it lands on, for the one ability of the seven that takes
+	// somebody: Help. Empty for Dodge, Dash, Disengage, Hide, Rage and Second
+	// Wind, and a populated ID for one of those is a caller defect rather than
+	// a value quietly ignored.
+	TargetID string
+
+	// ObserverPassivePerceptions is the passive Perception of everyone who
+	// could notice this, which Hide's Stealth check is rolled against.
+	//
+	// Carried rather than computed, for [ErrNoSight]'s reason: who can see
+	// whom is the composition's question, and a package that answered it here
+	// would be deciding a rule about light it cannot see. Empty for six of the
+	// seven — and empty is a legitimate answer for Hide too (nobody is
+	// watching), so this cannot be validated by presence.
+	ObserverPassivePerceptions []int
+}
+
+// ActivationOutcome is what an activation produced.
+//
+// Deliberately thin, for [BoundaryOutcome]'s reason: an activation's real
+// output is the DIRTY SHEETS that come back on [Output], because everything it
+// does happens inside a condition being applied to its owner or an economy
+// being spent. What is here is the part a caller cannot recover from a sheet.
+type ActivationOutcome struct {
+	// Ability is the ref that ran, echoed back. A caller that dispatched by
+	// selector rather than by ref gets to learn what the selector meant
+	// without parsing it.
+	Ability string
+
+	// GrantedCapacity is the ability's own description of what it banked —
+	// "1 attack", "30ft movement" — or empty when it banked nothing. Display
+	// text authored by the ability, never parsed: Dash's effect on the ledger
+	// is already in the ledger.
+	GrantedCapacity string
+}
+
+func (ActivationOutcome) isOutcome() {}
+
+// NewActivation returns the machine that uses one thing a character carries.
+//
+// # It is a sibling of NewBoundary, not an arm of NewAction
+//
+// [NewAction] dispatches on a populated profile of an authored
+// actions.Definition, and validates one before it does anything else. The
+// abilities and features a character carries have no such definition and do
+// not need one: each already declares its own ActionType and enforces its own
+// resources, which is the price the door actually charges. Minting a
+// Definition for Dodge purely so a dispatcher recognised it would be a
+// compiled price nothing charges — the exact fiction Afford's "read the price
+// off the same profile" rule exists to prevent (rpg-project#300 §4).
+//
+// What it shares with [NewBoundary] is the shape that matters: attach
+// everyone, do ONE thing on the interaction's own bus, collect dirty sheets.
+//
+// # Why the bus is the whole point
+//
+// A feature does not attach its own condition. Rage builds a RagingCondition
+// and PUBLISHES it on ConditionAppliedTopic; the owner's SheetKeeper is
+// subscribed and applies it. Dodge, Disengage, Hide, Help and Reckless Attack
+// all take the same path.
+//
+// So an activation run off the bus is not an error — it is worse. The publish
+// succeeds, returns nil, and the sheet is persisted with no condition on it.
+// EffectiveAC silently falls back to base and nothing in the call stack says
+// anything happened (the shape that bit the equip path, rpg-api#842). Running
+// here means the actor was attached by [attachAll] through
+// [character.Attach], so the subscription that applies the condition is live
+// for exactly as long as the activation is.
+//
+// # It charges nothing at the door
+//
+// [Input.Cost] must stay NIL for an activation, and that is a real constraint
+// rather than an omission. The ability spends its own slot — activateFeature
+// calls consumeActionType, and a combat ability spends through the toolkit
+// economy it is handed — so a Cost passed alongside would charge the same
+// ledger twice and the second charge would look exactly like the first.
+// "Free action" in Cost's own doc means "this package charges nothing", not
+// "this costs nothing".
+//
+// Refuses a nil input, a member with no ID, and a missing or invalid ability
+// ref, all before the world is loaded.
+func NewActivation(in *ActivationInput) (Machine, error) {
+	if in == nil {
+		return nil, ErrNilInput
+	}
+	if in.MemberID == "" {
+		return nil, fmt.Errorf("%w: no member is activating", ErrBadActivation)
+	}
+	if in.Ability == nil {
+		return nil, fmt.Errorf("%w: member %q named no ability", ErrBadActivation, in.MemberID)
+	}
+	if err := in.Ability.IsValid(); err != nil {
+		return nil, fmt.Errorf("%w: member %q named an unusable ability: %w",
+			ErrBadActivation, in.MemberID, err)
+	}
+
+	observers := make([]int, len(in.ObserverPassivePerceptions))
+	copy(observers, in.ObserverPassivePerceptions)
+
+	return &activationMachine{
+		member:    in.MemberID,
+		ability:   in.Ability,
+		targetID:  in.TargetID,
+		observers: observers,
+	}, nil
+}
+
+type activationMachine struct {
+	member    string
+	ability   *core.Ref
+	targetID  string
+	observers []int
+}
+
+// Start is pure preflight and runs before payment: it finds the actor and the
+// target in the cast and yields the step that does the work, without touching
+// either.
+//
+// The cast lookups happen HERE rather than inside the step for the reason
+// Start exists — a member who was never passed in is a caller defect, and
+// discovering it after the door has been paid at would charge somebody for an
+// interaction that cannot run. It is the same preflight [strikeMachine] does
+// for a combatant it was never handed.
+func (m *activationMachine) Start(_ context.Context, cast *Participants) (Step, error) {
+	actor, ok := cast.Character(m.member)
+	if !ok {
+		// Named separately from "not in the cast at all" because a monster IS
+		// in the cast and still cannot be here: its abilities are driven, not
+		// declared, and its economy is not on its sheet.
+		if _, isMonster := cast.Monster(m.member); isMonster {
+			return nil, fmt.Errorf("%w: %q is a monster; its abilities are driven, not declared",
+				ErrBadActivation, m.member)
+		}
+		return nil, fmt.Errorf("%w: %q is not a participant", ErrBadActivation, m.member)
+	}
+
+	var target core.Entity
+	if m.targetID != "" {
+		found, err := memberEntity(cast, m.targetID)
+		if err != nil {
+			return nil, err
+		}
+		target = found
+	}
+
+	return m.step(actor, target), nil
+}
+
+// step is the one thing this machine does.
+//
+// A Gather rather than a new Step kind: "do this on the bus and hand me the
+// next step" is what Gather already means, and adding a case against one
+// example is the mistake this package's own step vocabulary keeps refusing to
+// make.
+func (m *activationMachine) step(actor *character.Character, target core.Entity) Step {
+	return Gather{
+		name: fmt.Sprintf("activate %s for %s", m.ability.String(), m.member),
+		run: func(ctx context.Context, _ events.EventBus) (Step, error) {
+			// The bus is not passed in, and that is not an oversight. The
+			// sheet was handed its own view of this interaction's bus when
+			// attachAll applied its keeper, and every verb on it publishes
+			// through that. Handing a second reference to the same bus would
+			// invite a caller to believe there was a choice.
+			out, err := actor.ActivateAbility(ctx, &character.ActivateAbilityInput{
+				AbilityRef:                 m.ability,
+				TargetID:                   m.targetID,
+				Target:                     target,
+				ObserverPassivePerceptions: m.observers,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("activate %s for %q: %w", m.ability.String(), m.member, err)
+			}
+
+			// THE TRANSLATION, and it happens here rather than three layers
+			// up. The sheet answers a refusal as (output{Success:false}, nil):
+			// "not in combat", "unknown ability", "no rage charges left", and
+			// every feature's own precondition come back as a SUCCESSFUL call
+			// carrying a false. A machine that returned Done on that would
+			// hand its caller a finished interaction that did nothing, and the
+			// dirty sheets would be saved to prove it.
+			//
+			// Distinct sentinel from ErrBadActivation for ErrCannotPay's
+			// reason: one is an actor who cannot do this right now and wants a
+			// different verb, the other is content or wiring being wrong and
+			// wants a developer. A single sentinel would send the first one
+			// looking at the wrong sheet.
+			if !out.Success {
+				return nil, fmt.Errorf("%w: %s", ErrActivationRefused, out.Error)
+			}
+
+			return Done{Outcome: ActivationOutcome{
+				Ability:         m.ability.String(),
+				GrantedCapacity: out.GrantedCapacity,
+			}}, nil
+		},
+	}
+}
+
+// memberEntity finds one member of the cast as an entity, character or monster.
+//
+// Help is the only one of the seven that takes a target, and it aids an ally —
+// which in a dungeon can be a summoned or allied monster as easily as another
+// character, so this does not assume the party. An ID that is neither is a
+// caller defect and says so rather than passing a nil Target into an ability
+// that will dereference it.
+func memberEntity(cast *Participants, id string) (core.Entity, error) {
+	if ch, ok := cast.Character(id); ok {
+		return ch, nil
+	}
+	if mon, ok := cast.Monster(id); ok {
+		return mon, nil
+	}
+	return nil, fmt.Errorf("%w: target %q is not a participant", ErrBadActivation, id)
+}

--- a/rulebooks/dnd5e/resolution/activation_test.go
+++ b/rulebooks/dnd5e/resolution/activation_test.go
@@ -356,3 +356,69 @@ func (s *ActivationTestSuite) TestOffTheBusTheSameCallSucceedsAndAppliesNothing(
 	// ...and the barbarian is not raging.
 	s.NotContains(conditionRefs(data), "dnd5e:conditions:raging")
 }
+
+// --- The target contract, which the doc promised before the code kept it ---
+
+// Help takes somebody. A Help with nobody named is a malformed call, not an
+// ability refusing.
+func (s *ActivationTestSuite) TestAnAbilityThatNeedsATargetRefusesWithoutOne() {
+	_, err := s.run(
+		&ActivationInput{MemberID: heroID, Ability: refs.CombatAbilities.Help()},
+		s.world(),
+		[]Participant{{Character: s.barbarian(2)}},
+	)
+
+	s.Require().ErrorIs(err, ErrBadActivation)
+	s.Contains(err.Error(), "needs a target")
+}
+
+// And the other way: a target on Dodge is REFUSED rather than ignored. A
+// target quietly dropped is a client that believes it aimed Dodge at somebody
+// and a server that knows better — a disagreement nobody finds until it
+// matters.
+func (s *ActivationTestSuite) TestAnUntargetedAbilityRefusesATarget() {
+	_, err := s.run(
+		&ActivationInput{
+			MemberID: heroID, Ability: refs.CombatAbilities.Dodge(), TargetID: heroID,
+		},
+		s.world(),
+		[]Participant{{Character: s.barbarian(2)}},
+	)
+
+	s.Require().ErrorIs(err, ErrBadActivation)
+	s.Contains(err.Error(), "takes no target")
+}
+
+// THE CONTRACT CHECK STAYS QUIET WHEN THE SHEET CANNOT ANSWER.
+//
+// AvailableAbilities is empty out of combat, so nothing can be looked up. That
+// is an actor-state refusal, not a caller defect, and reporting it as
+// ErrBadActivation would send somebody hunting a malformed request that does
+// not exist — the confusion the two sentinels are there to prevent.
+func (s *ActivationTestSuite) TestOutOfCombatIsARefusalNotAMalformedCall() {
+	cold := s.barbarian(2)
+	cold.ActionEconomy = nil
+
+	_, err := s.run(
+		&ActivationInput{MemberID: heroID, Ability: refs.CombatAbilities.Help()},
+		s.world(),
+		[]Participant{{Character: cold}},
+	)
+
+	s.Require().ErrorIs(err, ErrActivationRefused)
+	s.False(errors.Is(err, ErrBadActivation))
+	s.Contains(err.Error(), "not in combat")
+}
+
+// The ability ref is copied too, not just the observer slice. core.Ref is a
+// mutable struct, so keeping the caller's pointer would let a reused ref change
+// WHICH ABILITY this machine activates after it was built.
+func (s *ActivationTestSuite) TestTheAbilityRefIsCopied() {
+	ref := *refs.Features.Rage()
+	machine, err := NewActivation(&ActivationInput{MemberID: heroID, Ability: &ref})
+	s.Require().NoError(err)
+
+	ref.ID = "second_wind"
+
+	s.Equal("rage", machine.(*activationMachine).ability.ID)
+}

--- a/rulebooks/dnd5e/resolution/activation_test.go
+++ b/rulebooks/dnd5e/resolution/activation_test.go
@@ -1,0 +1,321 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster/monsters"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+	"github.com/stretchr/testify/suite"
+)
+
+type ActivationTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func TestActivationSuite(t *testing.T) { suite.Run(t, new(ActivationTestSuite)) }
+
+func (s *ActivationTestSuite) SetupTest() { s.ctx = context.Background() }
+
+// barbarian is a level-1 barbarian with rage charges, in combat.
+//
+// IN COMBAT MATTERS: ActivateAbility answers "not in combat" to a sheet with a
+// nil action economy, so a fixture without one would exercise the refusal path
+// while looking like it exercised the ability.
+func (s *ActivationTestSuite) barbarian(charges int) *character.Data {
+	return &character.Data{
+		ID: heroID, PlayerID: "player-1", Name: "Standre", Level: 1,
+		ClassID: classes.Barbarian, RaceID: races.Human,
+		ProficiencyBonus: 2,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, abilities.DEX: 14, abilities.CON: 16,
+			abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 8,
+		},
+		HitPoints: 15, MaxHitPoints: 15, ArmorClass: 15,
+		Resources: map[coreResources.ResourceKey]character.RecoverableResourceData{
+			resources.RageCharges: {
+				Current: charges, Maximum: 2, ResetType: coreResources.ResetLongRest,
+			},
+		},
+		Features: []json.RawMessage{json.RawMessage(
+			`{"ref":{"module":"dnd5e","type":"features","id":"rage"},` +
+				`"id":"rage","name":"Rage","level":1}`)},
+		ActionEconomy: &character.ActionEconomyData{
+			TurnNumber: 1, ActionsRemaining: 1, BonusActionsRemaining: 1,
+			ReactionsRemaining: 1, MovementRemaining: 30,
+		},
+	}
+}
+
+func (s *ActivationTestSuite) world(members ...encounter.MemberInput) encounter.EncounterData {
+	if len(members) == 0 {
+		members = []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
+		}
+	}
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{},
+		Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Field: encounter.FieldInput{
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
+		},
+		Members: members,
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+	return enc.ToData()
+}
+
+func (s *ActivationTestSuite) run(
+	in *ActivationInput, world encounter.EncounterData, participants []Participant,
+) (*Output, error) {
+	machine, err := NewActivation(in)
+	s.Require().NoError(err)
+
+	return Resolve(s.ctx, &Input{
+		World:        world,
+		Participants: participants,
+		Initiative:   orderAsGiven{}, TurnDriver: passDriver{},
+		Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Roller:  dice.NewRoller(),
+		Machine: machine,
+		// Cost stays nil ON PURPOSE — see NewActivation's doc. The ability
+		// spends its own slot, and a Cost here would charge the same ledger
+		// twice.
+	})
+}
+
+// conditionRefs reads the condition refs off a sheet as it would be WRITTEN,
+// not as it sits in memory.
+//
+// This is the whole point of the test below. Character.Load rebuilds conditions
+// from these blobs, so a condition that never reached Data is a condition that
+// does not survive the next load — and the in-memory object would have told us
+// nothing about that.
+func conditionRefs(data *character.Data) []string {
+	out := make([]string, 0, len(data.Conditions))
+	for _, raw := range data.Conditions {
+		var envelope struct {
+			Ref string `json:"ref"`
+		}
+		if err := json.Unmarshal(raw, &envelope); err != nil {
+			continue
+		}
+		out = append(out, envelope.Ref)
+	}
+	return out
+}
+
+func dirty(out *Output, id string) *character.Data {
+	for _, d := range out.DirtyCharacters {
+		if d != nil && d.ID == id {
+			return d
+		}
+	}
+	return nil
+}
+
+// THE TEST THIS MACHINE EXISTS FOR.
+//
+// Rage does not attach its own condition: it publishes one on
+// ConditionAppliedTopic and the owner's SheetKeeper applies it. Off the bus
+// that publish SUCCEEDS and applies nothing, so the assertion has to be about
+// the sheet that would be saved rather than about the call returning nil.
+func (s *ActivationTestSuite) TestRagingReachesTheSheetThatWouldBeSaved() {
+	out, err := s.run(
+		&ActivationInput{MemberID: heroID, Ability: refs.Features.Rage()},
+		s.world(),
+		[]Participant{{Character: s.barbarian(2)}},
+	)
+
+	s.Require().NoError(err)
+	s.Require().NotNil(out)
+
+	sheet := dirty(out, heroID)
+	s.Require().NotNil(sheet, "the barbarian should come back dirty")
+	s.Contains(conditionRefs(sheet), "dnd5e:conditions:raging")
+}
+
+// The charge is spent on the sheet too, and from the same run. A rage that
+// applied its condition without spending a use would be free forever.
+func (s *ActivationTestSuite) TestTheChargeIsSpentOnTheSameSheet() {
+	out, err := s.run(
+		&ActivationInput{MemberID: heroID, Ability: refs.Features.Rage()},
+		s.world(),
+		[]Participant{{Character: s.barbarian(2)}},
+	)
+
+	s.Require().NoError(err)
+	sheet := dirty(out, heroID)
+	s.Require().NotNil(sheet)
+	s.Equal(1, sheet.Resources[resources.RageCharges].Current)
+}
+
+// And the bonus action goes with it — the ability charging its own slot, which
+// is why Input.Cost stays nil.
+func (s *ActivationTestSuite) TestTheAbilitySpendsItsOwnSlot() {
+	out, err := s.run(
+		&ActivationInput{MemberID: heroID, Ability: refs.Features.Rage()},
+		s.world(),
+		[]Participant{{Character: s.barbarian(2)}},
+	)
+
+	s.Require().NoError(err)
+	sheet := dirty(out, heroID)
+	s.Require().NotNil(sheet)
+	s.Require().NotNil(sheet.ActionEconomy)
+	s.Equal(0, sheet.ActionEconomy.BonusActionsRemaining, "rage costs the bonus action")
+	s.Equal(1, sheet.ActionEconomy.ActionsRemaining, "and nothing else")
+}
+
+// Dodge is the same journey with no resource in it: a combat ability rather
+// than a feature, reached through the other arm of ActivateAbility's lookup.
+func (s *ActivationTestSuite) TestDodgeReachesTheSheetTheSameWay() {
+	out, err := s.run(
+		&ActivationInput{MemberID: heroID, Ability: refs.CombatAbilities.Dodge()},
+		s.world(),
+		[]Participant{{Character: s.barbarian(2)}},
+	)
+
+	s.Require().NoError(err)
+	sheet := dirty(out, heroID)
+	s.Require().NotNil(sheet)
+	s.Contains(conditionRefs(sheet), "dnd5e:conditions:dodging")
+	s.Equal(0, sheet.ActionEconomy.ActionsRemaining, "dodge costs the action")
+}
+
+// A REFUSAL IS AN ERROR, AND NOTHING COMES BACK TO SAVE.
+//
+// The sheet answers "no rage uses remaining" as (output{Success:false}, nil) —
+// a successful call carrying a false. Without the translation the interaction
+// would finish, report Done, and hand back dirty sheets for something that
+// never happened.
+func (s *ActivationTestSuite) TestAnAbilityThatRefusesIsAnErrorNotADoneInteraction() {
+	out, err := s.run(
+		&ActivationInput{MemberID: heroID, Ability: refs.Features.Rage()},
+		s.world(),
+		[]Participant{{Character: s.barbarian(0)}},
+	)
+
+	s.Require().Error(err)
+	s.Require().ErrorIs(err, ErrActivationRefused)
+	s.Nil(out, "a refused activation saves nothing")
+	// The ability's own words survive the crossing, the way a shortfall's
+	// currency does.
+	s.Contains(err.Error(), "no rage uses remaining")
+}
+
+// A refusal is NOT a malformed activation, and the two sentinels must not be
+// reachable from one another — the ErrBadCost/ErrCannotPay line, applied to the
+// same problem: a developer chasing ErrBadActivation must never be handed a
+// barbarian who is simply out of rages.
+func (s *ActivationTestSuite) TestARefusalIsNotAMalformedActivation() {
+	_, err := s.run(
+		&ActivationInput{MemberID: heroID, Ability: refs.Features.Rage()},
+		s.world(),
+		[]Participant{{Character: s.barbarian(0)}},
+	)
+
+	s.Require().Error(err)
+	s.False(errors.Is(err, ErrBadActivation))
+}
+
+func (s *ActivationTestSuite) TestAMemberWhoIsNotInTheCastIsRefused() {
+	_, err := s.run(
+		&ActivationInput{MemberID: "nobody", Ability: refs.Features.Rage()},
+		s.world(),
+		[]Participant{{Character: s.barbarian(2)}},
+	)
+
+	s.Require().ErrorIs(err, ErrBadActivation)
+	s.Contains(err.Error(), "not a participant")
+}
+
+// A monster is IN the cast and still cannot declare: its abilities are driven
+// by behaviour and its economy is not on its sheet. The refusal says which of
+// the two problems it is, because "not a participant" would send somebody
+// looking for a missing sheet that is right there.
+func (s *ActivationTestSuite) TestAMonsterCannotDeclareAnActivation() {
+	wolf := monsters.NewWolf(wolfID).ToData()
+	world := s.world(
+		encounter.MemberInput{ID: heroID, Kind: encounter.KindPlayer,
+			Position: spatial.Position{X: 1, Y: 1}},
+		encounter.MemberInput{ID: wolfID, Kind: encounter.KindMonster,
+			Position: spatial.Position{X: 3, Y: 3}},
+	)
+
+	_, err := s.run(
+		&ActivationInput{MemberID: wolfID, Ability: refs.CombatAbilities.Dodge()},
+		world,
+		[]Participant{{Character: s.barbarian(2)}, {Monster: wolf}},
+	)
+
+	s.Require().ErrorIs(err, ErrBadActivation)
+	s.Contains(err.Error(), "driven, not declared")
+}
+
+func (s *ActivationTestSuite) TestATargetWhoIsNotInTheCastIsRefused() {
+	_, err := s.run(
+		&ActivationInput{
+			MemberID: heroID, Ability: refs.CombatAbilities.Help(), TargetID: "ghost",
+		},
+		s.world(),
+		[]Participant{{Character: s.barbarian(2)}},
+	)
+
+	s.Require().ErrorIs(err, ErrBadActivation)
+	s.Contains(err.Error(), "target")
+}
+
+// --- Door refusals: before the world is loaded ---
+
+func (s *ActivationTestSuite) TestTheDoorRefusesWhatNobodyCouldRun() {
+	_, err := NewActivation(nil)
+	s.Require().ErrorIs(err, ErrNilInput)
+
+	_, err = NewActivation(&ActivationInput{Ability: refs.Features.Rage()})
+	s.Require().ErrorIs(err, ErrBadActivation)
+
+	_, err = NewActivation(&ActivationInput{MemberID: heroID})
+	s.Require().ErrorIs(err, ErrBadActivation)
+
+	// A ref that exists but names nothing — the shape a caller building one
+	// from wire strings can actually produce.
+	_, err = NewActivation(&ActivationInput{MemberID: heroID, Ability: &core.Ref{}})
+	s.Require().ErrorIs(err, ErrBadActivation)
+}
+
+// The input is copied, so a caller that reuses its observer slice cannot change
+// what this machine will roll against after it was constructed. Mirrors
+// NewBoundary's own copy and the test that holds it.
+func (s *ActivationTestSuite) TestTheInputIsCopied() {
+	observers := []int{10, 12}
+	in := &ActivationInput{
+		MemberID: heroID, Ability: refs.CombatAbilities.Hide(),
+		ObserverPassivePerceptions: observers,
+	}
+	machine, err := NewActivation(in)
+	s.Require().NoError(err)
+
+	observers[0] = 99
+
+	s.Equal([]int{10, 12}, machine.(*activationMachine).observers)
+}

--- a/rulebooks/dnd5e/resolution/activation_test.go
+++ b/rulebooks/dnd5e/resolution/activation_test.go
@@ -319,3 +319,40 @@ func (s *ActivationTestSuite) TestTheInputIsCopied() {
 
 	s.Equal([]int{10, 12}, machine.(*activationMachine).observers)
 }
+
+// THE TRAP, MADE EXECUTABLE.
+//
+// This is the failure NewActivation exists to prevent, run deliberately: the
+// same barbarian, the same ability, the same call — on a sheet that was LOADED
+// but never ATTACHED. Rage's Activate guards its publish with
+// `if input.Bus != nil`, so with no bus it skips the publish, spends the
+// charge, and RETURNS NIL.
+//
+// Every signal a caller has says it worked. The call succeeded. Success is
+// true. The charge came off. And the sheet that would be written carries no
+// condition at all — which is the shape that bit the equip path (rpg-api#842)
+// and the reason the assertions above are about Data rather than about the
+// object in hand.
+//
+// If this test ever starts finding the condition, one of two good things
+// happened — Rage learned to attach its own, or something else did — and the
+// machine's whole justification needs re-reading. That is worth being told
+// about, which is why this is a test and not a comment.
+func (s *ActivationTestSuite) TestOffTheBusTheSameCallSucceedsAndAppliesNothing() {
+	sheet, err := character.Load(s.ctx, s.barbarian(2))
+	s.Require().NoError(err)
+
+	out, err := sheet.ActivateAbility(s.ctx, &character.ActivateAbilityInput{
+		AbilityRef: refs.Features.Rage(),
+	})
+
+	// Nothing complained.
+	s.Require().NoError(err)
+	s.Require().True(out.Success, "the sheet reports success with no bus to publish on")
+
+	data := sheet.ToData()
+	// The charge is gone, so something definitely happened...
+	s.Equal(1, data.Resources[resources.RageCharges].Current)
+	// ...and the barbarian is not raging.
+	s.NotContains(conditionRefs(data), "dnd5e:conditions:raging")
+}

--- a/rulebooks/dnd5e/resolution/errors.go
+++ b/rulebooks/dnd5e/resolution/errors.go
@@ -131,6 +131,29 @@ var (
 	// replaced, so which currency ran out survives the crossing.
 	ErrCannotPay = errors.New("resolution: cost cannot be paid")
 
+	// ErrBadActivation indicates an activation nobody could run: no member, no
+	// ability ref or an unusable one, a member who is not in the cast, a
+	// monster (whose abilities are driven rather than declared), or a target
+	// that was never passed in. Content or wiring being wrong.
+	//
+	// Kept distinct from [ErrActivationRefused] for [ErrBadCost]'s reason, and
+	// it is the same failure wearing a different hat: A MALFORMED ACTIVATION
+	// MUST NOT REACH A PLAYER AS "YOU ARE ALREADY RAGING". One wants a
+	// developer; the other wants the player to pick a different verb.
+	ErrBadActivation = errors.New("resolution: invalid activation")
+
+	// ErrActivationRefused indicates an ability that could have run and said
+	// no: the slot is spent, the charges are gone, the barbarian is already
+	// raging, the fighter is at full hit points.
+	//
+	// It exists because the sheet does not raise one. Character.ActivateAbility
+	// answers every refusal as (output{Success:false}, nil) — a SUCCESSFUL call
+	// carrying a false — so without this the interaction would finish, report
+	// Done, and save dirty sheets for something that never happened. The
+	// ability's own words are wrapped rather than replaced, so "no rage charges
+	// remaining" survives the crossing the way a shortfall's currency does.
+	ErrActivationRefused = errors.New("resolution: ability refused to activate")
+
 	// ErrRecurrenceUnsupported indicates a gate asking for a repeat save this
 	// package cannot yet run. Refusing is the point: treating "save again at
 	// the end of each of your turns" as a single save would produce a


### PR DESCRIPTION
The interaction machine behind rpg-project#300's Activate verb. Design: rpg-project#301 §6.

`session` will call this; nothing does yet, so this is additive and inert on merge.

## It is a sibling of `NewBoundary`, not an arm of `NewAction`

The design originally said `NewAction`'s second profile arm. It cannot be, and catching that before writing code is the reason the design document exists:

- `NewAction`'s first act is `in.Definition.Validate()`.
- §4 ruled the seven level-1 activatables get **no authored `Definition`** — each already declares its own `ActionType` and enforces its own resources, which is the price the door actually charges.
- Minting a `Definition` for Dodge purely so a dispatcher recognised it would be a compiled price nothing charges — the exact fiction Afford's *"read the price off the same profile"* rule exists to prevent.

What it shares with `NewBoundary` is the shape that matters: **attach everyone, do one thing on the interaction's own bus, collect dirty sheets.**

## The bus is the whole point, and this PR proves it two ways

Rage does not attach its own condition. It builds a `RagingCondition` and **publishes** it on `ConditionAppliedTopic`; the owner's `SheetKeeper` is subscribed and applies it. Dodge, Disengage, Hide, Help and Reckless Attack all take the same path.

So an activation run off the bus is not an error — it is worse. **`TestOffTheBusTheSameCallSucceedsAndAppliesNothing`** runs that failure deliberately, on a sheet that was `Load`-ed but never `Attach`-ed:

| signal a caller has | says |
|---|---|
| returned error | `nil` |
| `out.Success` | **`true`** |
| rage charges | 2 → 1, so *something* happened |
| the sheet that would be written | **no condition at all** |

That is the shape that bit the equip path (rpg-api#842), and it is why every other assertion in the file is about `Data.Conditions` — the sheet as it would be **written** — rather than about the object in hand. An assertion on the in-memory object would have passed either way, because `Rage.Activate` mutates resource state regardless.

If that test ever starts *finding* the condition, something good happened and this machine's justification needs re-reading. That is worth being told about, which is why it is a test and not a comment.

## Two sentinels, on the `ErrBadCost` / `ErrCannotPay` line

`ErrActivationRefused` exists because **the sheet does not raise one**. `Character.ActivateAbility` answers every refusal — "not in combat", "unknown ability", "no rage uses remaining", every feature precondition — as `(output{Success:false}, nil)`: a successful call carrying a false. Without the translation the interaction would report `Done` and hand back dirty sheets for something that never happened.

`ErrBadActivation` is the other half, and the reason there are two is the one `ErrBadCost` already gives: *a malformed activation must not reach a player as "you are already raging."* One wants a developer; the other wants the player to pick a different verb. A test asserts the refusal is **not** `errors.Is(err, ErrBadActivation)`.

## `Input.Cost` stays nil, deliberately

The ability spends its own slot — `activateFeature` calls `consumeActionType`, and a combat ability spends through the economy it is handed. A `Cost` passed alongside would charge the same ledger twice, and the second charge would look exactly like the first. `Cost`'s own doc calling nil "a free action" means *this package charges nothing*, not *this costs nothing*. Said in the constructor's doc so the next person does not helpfully add one.

## Evidence

12 tests. Three mutants, each killed by exactly the tests that should kill it:

| mutant | killed by |
|---|---|
| the `!out.Success` translation removed | 2 — the refusal tests |
| the monster distinction removed | 1 — `TestAMonsterCannotDeclareAnActivation` |
| the input copy removed | 1 — `TestTheInputIsCopied` |

Full `resolution` module green.

— platform agent, on behalf of KirkDiggler
