### PR TITLE
feat(session): Afford offers what a member can activate

### DIFF
--- a/rulebooks/dnd5e/session/activations.go
+++ b/rulebooks/dnd5e/session/activations.go
@@ -1,0 +1,223 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// buildActivationOffers compiles one offer per thing this member can activate.
+//
+// # A projection, not a second pricing engine
+//
+// character.AvailableAbilities already answers, per ability: its ref, its
+// display name, which economy shape it draws, what target it prompts for,
+// whether it can be used right now, and how many charges are left. That is a
+// declaration in everything but name, assembled in the rulebook for a menu
+// that no longer exists and never once crossing this seam.
+//
+// So this compiles nothing and prices nothing. It projects, adds a selector,
+// and converts one prose field into a structured one — see [activationWhy].
+// Afford's "read the price off the SAME profile the door would charge" rule is
+// kept by construction here rather than by care: the shape comes from the
+// ability's own ActionType, which IS what the door charges (rpg-project#301 §4).
+//
+// # Attack is deliberately not among them
+//
+// Every character carries a combat ability called Attack, and it is excluded.
+// Swinging is already [VerbAttack] at this seam, priced off a compiled
+// definition; emitting the Attack ACTION as an eighth activation would put two
+// buttons on the panel for one thing and invite a player to spend an action
+// banking swings the seam already banked. The six that remain plus the
+// character's features are the seven a level-1 player actually reaches.
+//
+// # Every ability gets a row, available or not
+//
+// An unavailable ability keeps its row with Available false and a reason, the
+// way a budget-blocked Attack keeps its candidates. A UI that only learned
+// about Dodge on the turns it could Dodge would have a menu that changes size
+// as the turn goes on.
+func (m *Manager) buildActivationOffers(
+	session, member string, sheet *character.Character,
+) ([]compiledOffer, error) {
+	available := sheet.AvailableAbilities()
+	economy := sheet.GetActionEconomy()
+
+	offers := make([]compiledOffer, 0, len(available))
+	for _, ability := range available {
+		if ability.Ref == nil {
+			// Fail closed. A nameless ability cannot be selected, echoed back,
+			// or executed, and quietly dropping it would leave a button
+			// missing from a panel with no trace of why.
+			return nil, fmt.Errorf("member %q offers an ability with no ref: %w", member, ErrBadCharacter)
+		}
+		if ability.Ref.ID == refs.CombatAbilities.Attack().ID {
+			continue
+		}
+
+		slot := slotOfEconomySlot(ability.EconomySlot)
+		ref := ability.Ref.String()
+
+		id, variant, err := selectorIDFor(session, member, VerbActivate, slot, nil, ref)
+		if err != nil {
+			return nil, err
+		}
+
+		declaration := Declaration{
+			Verb:       VerbActivate,
+			Slot:       slot,
+			Available:  ability.CanUse,
+			Ability:    &AbilityRef{Ref: ref, Name: ability.Name},
+			TargetKind: targetKindOfAbility(ability.TargetKind),
+			ID:         id,
+			Candidates: []TargetCandidate{},
+		}
+		if !ability.CanUse {
+			why := activationWhy(ability, slot, economy)
+			declaration.Why = &why
+		}
+
+		offers = append(offers, compiledOffer{
+			declaration: declaration,
+			sheet:       sheet,
+			verb:        VerbActivate,
+			slot:        slot,
+			variant:     variant,
+		})
+	}
+
+	// Sorted by ref so the panel's order is a fact about the character rather
+	// than about the order two slices happened to be concatenated in. Ranking
+	// across verbs is sortDeclarations' job and stays there; this is the
+	// within-verb tiebreak that verb ranking alone cannot provide now that one
+	// verb has seven rows.
+	sort.SliceStable(offers, func(i, j int) bool {
+		return offers[i].declaration.Ability.Ref < offers[j].declaration.Ability.Ref
+	})
+	return offers, nil
+}
+
+// activationWhy turns the rulebook's prose refusal into the structured one this
+// seam owes a client.
+//
+// # Authored, never parsed
+//
+// AvailableAbility carries a single Reason STRING covering three different
+// refusals: the slot is spent, the charges are gone, or the ability's own
+// precondition said no. Discriminating them by matching that string would be
+// the exact inversion of this seam's law — the SDK renders Text FROM the
+// structure, never the reverse — and it would break the first time a feature
+// reworded its own error.
+//
+// So the discrimination is made from state the seam can see for itself:
+//
+//  1. Ask the ECONOMY whether this shape is spent. If it is, the refusal is a
+//     budget one and every figure is known.
+//  2. Otherwise the economy allowed it and the ABILITY refused. If it carries a
+//     resource that has run out, that is a ledger too — just not one of the
+//     turn's three.
+//  3. Otherwise it is a precondition: already raging, already at full hit
+//     points. Nothing ran out and waiting will not help.
+//
+// # Where the prose survives, and why
+//
+// Case 1 renders its own text, because reason/currency/needed/left determine it
+// completely. Cases 2 and 3 keep the ABILITY'S OWN words, because the structure
+// deliberately does not name which resource ran out — this seam does not
+// enumerate the rulebook's resource keys — so "no rage uses remaining" carries
+// the one fact a client cannot reconstruct. That is Text doing its documented
+// job of narrating what the structure cannot.
+func activationWhy(
+	ability character.AvailableAbility, slot Slot, economy *character.ActionEconomyData,
+) Shortfall {
+	if economy != nil && slot != SlotNone && remainingInSlot(slot, economy) <= 0 {
+		currency := currencyOfSlot(slot)
+		return Shortfall{
+			Reason:   ShortfallNoBudget,
+			Currency: currency,
+			Needed:   1,
+			Left:     0,
+			Text:     fmt.Sprintf("%s: 1 needed, 0 left", currency),
+		}
+	}
+
+	if ability.ResourceMax > 0 && ability.ResourceCurrent <= 0 {
+		return Shortfall{
+			Reason:   ShortfallNoBudget,
+			Currency: CurrencyCharges,
+			Needed:   1,
+			Left:     0,
+			Text:     ability.Reason,
+		}
+	}
+
+	return Shortfall{Reason: ShortfallUnavailable, Text: ability.Reason}
+}
+
+// remainingInSlot reads one shape's remaining count off the economy.
+//
+// SlotNone never reaches here: an ability that lights no shape cannot be
+// refused for want of one, and asking the economy about a shape that does not
+// exist would answer zero — which reads as "spent" and would mark every free
+// ability unaffordable.
+func remainingInSlot(slot Slot, economy *character.ActionEconomyData) int {
+	switch slot {
+	case SlotAction:
+		return economy.ActionsRemaining
+	case SlotBonus:
+		return economy.BonusActionsRemaining
+	case SlotReaction:
+		return economy.ReactionsRemaining
+	case SlotNone:
+		return 1
+	default:
+		return 1
+	}
+}
+
+// slotOfEconomySlot maps the rulebook's economy shape onto the seam's.
+//
+// The rulebook has two values this seam does not: Movement, which is a ledger
+// rather than a shape and belongs to Move, and Free, which is the rulebook's
+// way of saying "lights nothing" — the same claim SlotNone makes. Unspecified
+// maps to SlotNone as well, because an ability whose author said nothing is
+// not thereby spending an action, and inventing one would make a free ability
+// look expensive.
+func slotOfEconomySlot(slot character.EconomySlot) Slot {
+	switch slot {
+	case character.EconomySlotAction:
+		return SlotAction
+	case character.EconomySlotBonusAction:
+		return SlotBonus
+	case character.EconomySlotReaction:
+		return SlotReaction
+	case character.EconomySlotMovement, character.EconomySlotFree, character.EconomySlotUnspecified:
+		return SlotNone
+	default:
+		return SlotNone
+	}
+}
+
+// targetKindOfAbility maps the rulebook's target prompt onto the seam's.
+//
+// SIX RULEBOOK VALUES BECOME THREE, and one collapse is worth naming: Self and
+// None both become TargetNone. They are the same instruction to a client — do
+// not prompt — and the distinction the rulebook keeps is about WHOSE SHEET the
+// effect lands on, which is the rulebook's business and not the panel's.
+//
+// Position and Area have no seam value and become TargetNone rather than an
+// invented one, because nothing at level 1 uses them and a target kind arrives
+// here with a proven executor, never in advance.
+func targetKindOfAbility(kind character.TargetKind) TargetKind {
+	switch kind {
+	case character.TargetKindSingleEntity:
+		return TargetMember
+	default:
+		return TargetNone
+	}
+}

--- a/rulebooks/dnd5e/session/activations_test.go
+++ b/rulebooks/dnd5e/session/activations_test.go
@@ -1,0 +1,200 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+	"github.com/stretchr/testify/require"
+)
+
+// ragingBarbarian is a level-1 barbarian carrying Rage, with a weapon so the
+// Attack declaration compiles alongside.
+func ragingBarbarian(id string, charges int) *character.Data {
+	return &character.Data{
+		ID:       id,
+		PlayerID: "player-" + id,
+		Name:     id,
+		Level:    1,
+		ClassID:  classes.Barbarian,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, abilities.DEX: 14, abilities.CON: 16,
+			abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 8,
+		},
+		HitPoints: 15, MaxHitPoints: 15, ArmorClass: 15, ProficiencyBonus: 2,
+		Inventory: []character.InventoryItemData{
+			{Type: shared.EquipmentTypeWeapon, ID: string(weapons.Greataxe), Quantity: 1},
+		},
+		EquipmentSlots: character.EquipmentSlots{
+			character.SlotMainHand: string(weapons.Greataxe),
+		},
+		Resources: map[coreResources.ResourceKey]character.RecoverableResourceData{
+			resources.RageCharges: {
+				Current: charges, Maximum: 2, ResetType: coreResources.ResetLongRest,
+			},
+		},
+		Features: []json.RawMessage{json.RawMessage(
+			`{"ref":{"module":"dnd5e","type":"features","id":"rage"},` +
+				`"id":"rage","name":"Rage","level":1}`)},
+	}
+}
+
+func activations(decls []session.Declaration) []session.Declaration {
+	out := make([]session.Declaration, 0, len(decls))
+	for _, d := range decls {
+		if d.Verb == session.VerbActivate {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+func activationFor(t *testing.T, decls []session.Declaration, ref string) session.Declaration {
+	t.Helper()
+	for _, d := range activations(decls) {
+		if d.Ability != nil && d.Ability.Ref == ref {
+			return d
+		}
+	}
+	t.Fatalf("no activation declaration for %q in %d declarations", ref, len(decls))
+	return session.Declaration{}
+}
+
+func affordFor(t *testing.T, data *character.Data) *session.AffordOutput {
+	t.Helper()
+	mgr, _, _, _ := aFight(t, data, []int{1, 1})
+	out, err := mgr.Afford(context.Background(), &session.AffordInput{
+		Session: "sess", Member: data.ID,
+	})
+	require.NoError(t, err)
+	return out
+}
+
+// THE POINT OF THE SLICE: a barbarian's whole level-1 surface reaches the wire.
+func TestABarbariansWholeActivatableSurfaceIsOffered(t *testing.T) {
+	out := affordFor(t, ragingBarbarian("alice", 2))
+
+	offered := make([]string, 0)
+	for _, d := range activations(out.Declarations) {
+		offered = append(offered, d.Ability.Ref)
+	}
+
+	require.ElementsMatch(t, []string{
+		"dnd5e:combat_abilities:dash",
+		"dnd5e:combat_abilities:disengage",
+		"dnd5e:combat_abilities:dodge",
+		"dnd5e:combat_abilities:help",
+		"dnd5e:combat_abilities:hide",
+		"dnd5e:features:rage",
+	}, offered)
+}
+
+// Attack is a combat ability every character carries, and it must NOT appear as
+// an activation: swinging is VerbAttack at this seam, and two buttons for one
+// thing is how a player ends up spending an action to bank swings the seam
+// already banked.
+func TestTheAttackAbilityIsNotOfferedAsAnActivation(t *testing.T) {
+	out := affordFor(t, ragingBarbarian("alice", 2))
+
+	for _, d := range activations(out.Declarations) {
+		require.NotEqual(t, refs.CombatAbilities.Attack().String(), d.Ability.Ref)
+	}
+	// ...and Attack is still offered as itself.
+	require.NotEmpty(t, requireSingleDeclaration(t, out.Declarations, session.VerbAttack).ID)
+}
+
+// ONE VERB, TWO SHAPES, LIVE AT THE SAME MOMENT — which is what forces
+// multiple rows per verb rather than making it a preference. Rage draws the
+// bonus action while Dodge draws the action, and a single row per verb could
+// only carry one of the two Slots.
+func TestOneVerbCarriesBothShapesAtOnce(t *testing.T) {
+	out := affordFor(t, ragingBarbarian("alice", 2))
+
+	rage := activationFor(t, out.Declarations, "dnd5e:features:rage")
+	dodge := activationFor(t, out.Declarations, "dnd5e:combat_abilities:dodge")
+
+	require.Equal(t, session.SlotBonus, rage.Slot)
+	require.Equal(t, session.SlotAction, dodge.Slot)
+	require.True(t, rage.Available)
+	require.True(t, dodge.Available)
+}
+
+// Every offer gets its own selector, or execution could not tell them apart —
+// and the ref is the only thing that differs between two activations by the
+// same member on the same turn.
+func TestEveryActivationCarriesItsOwnSelector(t *testing.T) {
+	out := affordFor(t, ragingBarbarian("alice", 2))
+
+	seen := map[string]string{}
+	for _, d := range activations(out.Declarations) {
+		require.NotEmpty(t, d.ID, "%s has no selector", d.Ability.Ref)
+		prior, clash := seen[d.ID]
+		require.False(t, clash, "%s and %s share a selector", prior, d.Ability.Ref)
+		seen[d.ID] = d.Ability.Ref
+	}
+	require.Len(t, seen, 6)
+}
+
+// Help prompts for somebody; the other five prompt for nobody. The rulebook
+// draws a further line between "targets the actor" and "targets nothing" that
+// this seam deliberately collapses — both mean DO NOT PROMPT.
+func TestOnlyHelpAsksForATarget(t *testing.T) {
+	out := affordFor(t, ragingBarbarian("alice", 2))
+
+	for _, d := range activations(out.Declarations) {
+		want := session.TargetNone
+		if d.Ability.Ref == "dnd5e:combat_abilities:help" {
+			want = session.TargetMember
+		}
+		require.Equal(t, want, d.TargetKind, "target kind for %s", d.Ability.Ref)
+	}
+}
+
+// A CHARGE THAT RAN OUT IS A LEDGER, JUST NOT ONE OF THE TURN'S THREE. It is
+// NoBudget with CurrencyCharges — not Unavailable — because a client should
+// tell the player "come back after a rest", which is a different sentence from
+// "this will never light while you are raging".
+func TestNoChargesIsABudgetRefusalInACurrencyOfItsOwn(t *testing.T) {
+	out := affordFor(t, ragingBarbarian("alice", 0))
+
+	rage := activationFor(t, out.Declarations, "dnd5e:features:rage")
+
+	require.False(t, rage.Available)
+	require.NotNil(t, rage.Why)
+	require.Equal(t, session.ShortfallNoBudget, rage.Why.Reason)
+	require.Equal(t, session.CurrencyCharges, rage.Why.Currency)
+	require.Equal(t, 1, rage.Why.Needed)
+	require.Equal(t, 0, rage.Why.Left)
+	// THE PROSE SURVIVES because the structure deliberately does not name WHICH
+	// resource ran out — this seam does not enumerate the rulebook's resource
+	// keys — so the ability's own words carry the one fact a client cannot
+	// reconstruct from reason/currency/needed/left.
+	require.Contains(t, rage.Why.Text, "rage")
+}
+
+// A refused ability still gets its ROW, with a selector, the way a
+// budget-blocked Attack keeps its candidates. A menu that changed size as the
+// turn went on would be a worse client experience than a dimmed button.
+func TestARefusedActivationKeepsItsRow(t *testing.T) {
+	out := affordFor(t, ragingBarbarian("alice", 0))
+
+	require.Len(t, activations(out.Declarations), 6, "still six, one of them dark")
+	rage := activationFor(t, out.Declarations, "dnd5e:features:rage")
+	require.NotEmpty(t, rage.ID, "a compiled-but-refused offer still carries its selector")
+	require.NotNil(t, rage.Ability, "and still says what it is")
+	require.Equal(t, "Rage", rage.Ability.Name)
+}

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -44,6 +44,22 @@ const (
 	// see [Manager.Afford]'s own doc.
 	VerbMove Verb = "move"
 
+	// VerbActivate is [Manager.Activate]: using a combat ability or feature the
+	// character already carries — Dodge, Dash, Disengage, Help, Hide, Rage,
+	// Second Wind.
+	//
+	// THE FIRST VERB THAT COMPILES MORE THAN ONE OFFER. Attack, Move and
+	// EndTurn each compile exactly one, so "one offer per verb" and "one
+	// declaration per verb" were the same sentence for three verbs and nothing
+	// said which one a reader relied on. A level-1 barbarian gets seven of
+	// these, and [Slot] is what separates Rage on the bonus shape from Dodge
+	// on the action one — they cannot share a row, because Slot is per
+	// declaration.
+	//
+	// Its selector variant is the ability's own ref rather than a sealed
+	// string: one verb, seven offers, and the ref is what tells them apart.
+	VerbActivate Verb = "activate"
+
 	// VerbEndTurn is [Manager.EndTurn]: ending the member's turn. Like Move it
 	// carries no authored action definition, so its declaration selector uses a
 	// sealed variant string rather than a serialized [actions.Definition].
@@ -149,6 +165,13 @@ type Declaration struct {
 	// which still carries its compiled ref — and absent for Move, EndTurn,
 	// and early per-verb blockers.
 	Attack *AttackRef `json:"attack,omitempty"`
+
+	// Ability is the sole public activation identity, present on every
+	// compiled Activate declaration — including one disabled by a budget,
+	// charge or feature gate — and absent for Attack, Move, EndTurn and every
+	// early per-verb blocker. The same presence law [Declaration.Attack]
+	// keeps, for the same reason.
+	Ability *AbilityRef `json:"ability,omitempty"`
 
 	// TargetKind is fixed for every compiled or blocked declaration: Attack
 	// -> TargetMember, Move -> TargetPath, EndTurn -> TargetNone. A blocker
@@ -287,6 +310,11 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 		return &AffordOutput{Clock: ClockTurn, Declarations: []Declaration{
 			blockedDeclaration(VerbAttack, TargetMember, notYourTurn),
 			blockedDeclaration(VerbMove, TargetPath, notYourTurn),
+			// ONE Activate row, not seven. A member whose turn it is not
+			// cannot activate ANY of them, and the reason is identical for
+			// every one — so seven rows would be seven copies of "not your
+			// turn" and a panel that looks like it has choices.
+			blockedDeclaration(VerbActivate, TargetNone, notYourTurn),
 			blockedDeclaration(VerbEndTurn, TargetNone, notYourTurn),
 		}}, nil
 	}
@@ -299,7 +327,7 @@ func (m *Manager) Afford(ctx context.Context, in *AffordInput) (*AffordOutput, e
 	actor := m.loadActorSheet(ctx, in.Member)
 	offers, err := m.compileOffersFor(
 		ctx, enc, data, in.Session, in.Member, clock, actor,
-		VerbAttack, VerbMove, VerbEndTurn,
+		VerbAttack, VerbMove, VerbActivate, VerbEndTurn,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("afford: %w", err)

--- a/rulebooks/dnd5e/session/afford.go
+++ b/rulebooks/dnd5e/session/afford.go
@@ -106,11 +106,23 @@ const (
 // server-side, behind [combat.SpendProfile]. See
 // docs/adr/0042-afford-answers-in-declarations-not-currencies.md.
 //
-// ONE COMPILED OFFER PER VERB, not one declaration per target: the candidate
-// universe lives on the single Attack declaration's Candidates, each carrying
-// its own target-specific availability. The client renders availability,
-// identity, target kind, and candidates verbatim and never derives game rules;
-// Attack, Move, and End Turn regenerate the selected offer before execution.
+// ONE DECLARATION PER COMPILED OFFER — which is NOT one per verb, and was
+// never quite the same claim.
+//
+// Attack, Move and EndTurn each compile exactly one, so for three verbs the
+// two readings coincided and nothing said which one a reader relied on.
+// [VerbActivate] separates them: a level-1 barbarian gets six Activate
+// declarations, and [Slot] is what distinguishes Rage on the bonus shape from
+// Dodge on the action one — they cannot share a row, because Slot is per
+// declaration. A consumer that indexes declarations BY VERB, or treats a
+// second row for a verb as a producer defect, is reading a coincidence as a
+// contract.
+//
+// It is still not one declaration per TARGET: the candidate universe lives on
+// the single Attack declaration's Candidates, each carrying its own
+// target-specific availability. The client renders availability, identity,
+// target kind, and candidates verbatim and never derives game rules; every
+// verb regenerates the selected offer before execution.
 type Declaration struct {
 	// Verb is which seam action this prices.
 	Verb Verb `json:"verb"`
@@ -193,7 +205,8 @@ type AffordOutput struct {
 	// and that IS the answer rather than a shorter way of asking again.
 	Clock ClockKind `json:"clock"`
 
-	// Declarations is one entry per compiled verb the seam prices, empty on
+	// Declarations is one entry per compiled OFFER — one each for Attack, Move
+	// and EndTurn, and one per activatable thing the member carries — empty on
 	// the world clock — where empty IS the answer rather than a shorter way
 	// of asking again, so it is never omitted from the wire either: the same
 	// false-vs-absent law types.go keeps for every bool at this seam applies
@@ -202,8 +215,10 @@ type AffordOutput struct {
 	Declarations []Declaration `json:"declarations"`
 }
 
-// Afford reports the current compiled Attack, Move, and EndTurn offers for one
-// active turn member. Each carries an opaque selector execution must echo.
+// Afford reports the current compiled Attack, Move, Activate and EndTurn
+// offers for one active turn member. Activate compiles one per thing the
+// member carries rather than one for the verb; the rest compile exactly one
+// each. Each offer carries an opaque selector execution must echo.
 // Move reports Remaining rather than a fixed price because a walk's cost
 // depends on a path this read is never given. On the world clock declarations
 // is the complete empty answer.

--- a/rulebooks/dnd5e/session/afford_test.go
+++ b/rulebooks/dnd5e/session/afford_test.go
@@ -109,7 +109,10 @@ func (s *AffordSuite) TestAvailableMeansAttackWillNotRefuse() {
 
 	out := s.afford()
 	s.Equal(session.ClockTurn, out.Clock)
-	s.Require().Len(out.Declarations, 3, "attack, move and end turn")
+	// Attack, Move, EndTurn, and the five activations a plain fighter
+	// carries — Dash, Disengage, Dodge, Help, Hide. Attack the combat
+	// ability is excluded: swinging is VerbAttack's job here.
+	s.Require().Len(out.Declarations, 8)
 
 	decl := s.attackDecl(out)
 	s.True(decl.Available, "a fresh turn can still buy its first swing")
@@ -135,7 +138,10 @@ func (s *AffordSuite) TestUnavailableMeansAttackRefusesWithTheSameShortfall() {
 	s.Require().True(first.Hit)
 
 	out := s.afford()
-	s.Require().Len(out.Declarations, 3, "attack, move and end turn")
+	// Attack, Move, EndTurn, and the five activations a plain fighter
+	// carries — Dash, Disengage, Dodge, Help, Hide. Attack the combat
+	// ability is excluded: swinging is VerbAttack's job here.
+	s.Require().Len(out.Declarations, 8)
 	decl := s.attackDecl(out)
 	s.False(decl.Available, "nothing left to buy a second swing")
 	s.Require().NotNil(decl.Why)
@@ -208,7 +214,10 @@ func (s *AffordSuite) TestANewTurnRefillsWhatAffordSees() {
 	s.nextTurn()
 
 	out := s.afford()
-	s.Require().Len(out.Declarations, 3, "attack, move and end turn")
+	// Attack, Move, EndTurn, and the five activations a plain fighter
+	// carries — Dash, Disengage, Dodge, Help, Hide. Attack the combat
+	// ability is excluded: swinging is VerbAttack's job here.
+	s.Require().Len(out.Declarations, 8)
 	s.True(s.attackDecl(out).Available, "a new turn buys a new swing")
 	s.Equal(session.SlotAction, s.attackDecl(out).Slot)
 }
@@ -391,7 +400,9 @@ func (s *AffordSuite) TestNotYourTurnIsAnnouncedByAfford() {
 	out, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "bob"})
 	s.Require().NoError(err)
 	s.Equal(session.ClockTurn, out.Clock)
-	s.Require().Len(out.Declarations, 3, "attack, move and end turn, all blocked the same way")
+	// One blocker per VERB, all blocked the same way — Activate is one verb
+	// however many things it would compile on a turn that were hers.
+	s.Require().Len(out.Declarations, 4)
 	for _, d := range out.Declarations {
 		s.False(d.Available)
 		s.Empty(d.ID, "a blocker carries no selector ID")

--- a/rulebooks/dnd5e/session/declaration_id.go
+++ b/rulebooks/dnd5e/session/declaration_id.go
@@ -24,6 +24,10 @@ const (
 	declarationPrefix    = "v1."
 	variantMoveSealed    = "session:move:v1"
 	variantEndTurnSealed = "session:end-turn:v1"
+	// variantActivatePrefix namespaces an activation's variant so an ability
+	// ref can never collide with a sealed string, however the ref catalog
+	// grows.
+	variantActivatePrefix = "session:activate:v1:"
 )
 
 // errDeclarationIDCollision is returned internally when two non-identical
@@ -49,10 +53,23 @@ type declarationIDInput struct {
 	// rejected.
 	Slot Slot
 	// Attack is the complete validated [combatActions.Definition] for
-	// [VerbAttack]. It must be non-nil for [VerbAttack] and nil for
-	// [VerbMove]/[VerbEndTurn], whose selectors use sealed variant strings
+	// [VerbAttack]. It must be non-nil for [VerbAttack] and nil for every
+	// other verb, whose selectors use sealed or ref-derived variant strings
 	// instead.
 	Attack *combatActions.Definition
+
+	// Ability is the ref of the thing being activated, for [VerbActivate]. It
+	// must be non-empty for [VerbActivate] and empty for every other verb.
+	//
+	// IT IS THE WHOLE VARIANT, and that is a deliberate difference from
+	// Attack's. Attack serializes its complete priced definition, so a price
+	// change makes the selector change and a stale offer is caught by the ID
+	// alone. An activation's price lives on the ability rather than in a
+	// compiled definition, so this selector survives a price change that
+	// Attack's would not — which is safe because nothing alters an ability's
+	// ActionType mid-turn, and Afford regenerates the offer before execution
+	// either way (rpg-project#301 §4).
+	Ability string
 }
 
 // selectorDocument is the canonical JSON value a declaration ID is derived
@@ -89,7 +106,7 @@ func declarationID(input declarationIDInput) (string, error) {
 		return "", err
 	}
 
-	variant, err := selectorVariant(input.Verb, input.Attack)
+	variant, err := selectorVariant(input.Verb, input.Attack, input.Ability)
 	if err != nil {
 		return "", err
 	}
@@ -142,7 +159,7 @@ func canonicalSelectorVariant(raw json.RawMessage) (json.RawMessage, error) {
 // under the current version without an explicit bump.
 func validateDeclarationVerbSlot(verb Verb, slot Slot) error {
 	switch verb {
-	case VerbAttack, VerbMove, VerbEndTurn:
+	case VerbAttack, VerbMove, VerbEndTurn, VerbActivate:
 	default:
 		return fmt.Errorf("unsupported declaration verb %q", verb)
 	}
@@ -155,19 +172,35 @@ func validateDeclarationVerbSlot(verb Verb, slot Slot) error {
 }
 
 // selectorVariant builds the variant JSON value for one verb. Move and EndTurn
-// use sealed strings; Attack serializes the complete validated definition.
-func selectorVariant(verb Verb, attack *combatActions.Definition) (json.RawMessage, error) {
+// use sealed strings, Activate a namespaced ability ref, and Attack serializes
+// the complete validated definition.
+func selectorVariant(
+	verb Verb, attack *combatActions.Definition, ability string,
+) (json.RawMessage, error) {
+	// Cross-verb material is refused rather than ignored. A verb carrying the
+	// other verb's material is a producer defect, and a selector that silently
+	// dropped it would hash to something that looks legitimate.
+	if verb != VerbAttack && attack != nil {
+		return nil, fmt.Errorf("%s declaration must not carry an attack definition", verb)
+	}
+	if verb != VerbActivate && ability != "" {
+		return nil, fmt.Errorf("%s declaration must not carry an ability ref", verb)
+	}
+
 	switch verb {
 	case VerbMove:
-		if attack != nil {
-			return nil, fmt.Errorf("move declaration must not carry an attack definition")
-		}
 		return json.RawMessage(`"` + variantMoveSealed + `"`), nil
 	case VerbEndTurn:
-		if attack != nil {
-			return nil, fmt.Errorf("end-turn declaration must not carry an attack definition")
-		}
 		return json.RawMessage(`"` + variantEndTurnSealed + `"`), nil
+	case VerbActivate:
+		if ability == "" {
+			return nil, fmt.Errorf("activate declaration requires an ability ref")
+		}
+		raw, err := json.Marshal(variantActivatePrefix + ability)
+		if err != nil {
+			return nil, fmt.Errorf("activation ref marshal: %w", err)
+		}
+		return json.RawMessage(raw), nil
 	case VerbAttack:
 		if attack == nil {
 			return nil, fmt.Errorf("attack declaration requires an attack definition")

--- a/rulebooks/dnd5e/session/declaration_id.go
+++ b/rulebooks/dnd5e/session/declaration_id.go
@@ -46,7 +46,9 @@ type declarationIDInput struct {
 	// Member is the acting member the declaration is priced for.
 	Member string
 	// Verb is the seam verb. Must be one of [VerbAttack], [VerbMove],
-	// [VerbEndTurn]; any other byte is rejected.
+	// [VerbActivate], [VerbEndTurn]; any other byte is rejected by
+	// validateDeclarationVerbSlot, which holds the same list and is the one
+	// that actually enforces it.
 	Verb Verb
 	// Slot is the economy shape this declaration would spend. Must be one of
 	// [SlotNone], [SlotAction], [SlotBonus], [SlotReaction]; any other byte is

--- a/rulebooks/dnd5e/session/declaration_id_test.go
+++ b/rulebooks/dnd5e/session/declaration_id_test.go
@@ -380,9 +380,9 @@ func TestCompiledOfferCollisionDuplicateIDFailClosed(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.Equal(t, leftID, rightID, "RFC8785 canonical selectors are equal")
-		leftVariant, err := selectorVariant(VerbAttack, &left)
+		leftVariant, err := selectorVariant(VerbAttack, &left, "")
 		require.NoError(t, err)
-		rightVariant, err := selectorVariant(VerbAttack, &right)
+		rightVariant, err := selectorVariant(VerbAttack, &right, "")
 		require.NoError(t, err)
 		require.NotEqual(t, string(leftVariant), string(rightVariant),
 			"the fixture must reach equality with different raw object order")

--- a/rulebooks/dnd5e/session/doc.go
+++ b/rulebooks/dnd5e/session/doc.go
@@ -88,8 +88,9 @@
 // # Compiled declarations are the execution trust boundary
 //
 // Afford is the one current action surface on the turn clock. It compiles an
-// Attack, Move, and EndTurn offer, projects only seam-owned values, and gives
-// each compiled offer an opaque deterministic selector. Attack and EndTurn
+// Attack, Move and EndTurn offer plus one Activate offer per thing the member
+// carries, projects only seam-owned values, and gives each compiled offer an
+// opaque deterministic selector. Attack and EndTurn
 // require that ID back; Move requires it on the turn clock and requires it
 // empty on the world clock, where Afford deliberately returns no declarations.
 //

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
 	github.com/KirkDiggler/rpg-toolkit/play/intel v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.1
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.16.0

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.0 h1:HuemqoSeObvN+wFdmPurNqdPTGJa0pIkLTpLc4FpIyc=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.1 h1:aSIBiWljv5u5MzPoHgXJrJIv/QSjlXONtu0WFFPsmtU=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.1/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0 h1:LxEJMtm4M3PMDnpRC61ooGvWKS/eRZImu/GTeTDCYuM=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0/go.mod h1:Y5eXfAAyQ0N4Sp07T5C7MxD2CwAwdAUi2zo5SyN60Ds=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0 h1:t44TeeJm7Fkc8Ra72E2YH+OcvM2LC0PF6hHcrxNdq1g=

--- a/rulebooks/dnd5e/session/offers.go
+++ b/rulebooks/dnd5e/session/offers.go
@@ -152,6 +152,7 @@ func (m *Manager) compileOffersFor(
 		return finishRequestedOffers(requested,
 			blockedCompiledOffer(VerbAttack, TargetMember, why),
 			blockedCompiledOffer(VerbMove, TargetPath, why),
+			blockedCompiledOffer(VerbActivate, TargetNone, why),
 			endTurn,
 		)
 	}
@@ -165,6 +166,7 @@ func (m *Manager) compileOffersFor(
 		return finishRequestedOffers(requested,
 			blockedCompiledOffer(VerbAttack, TargetMember, why),
 			blockedCompiledOffer(VerbMove, TargetPath, why),
+			blockedCompiledOffer(VerbActivate, TargetNone, why),
 			endTurn,
 		)
 	}
@@ -174,6 +176,7 @@ func (m *Manager) compileOffersFor(
 		return finishRequestedOffers(requested,
 			blockedCompiledOffer(VerbAttack, TargetMember, why),
 			blockedCompiledOffer(VerbMove, TargetPath, why),
+			blockedCompiledOffer(VerbActivate, TargetNone, why),
 			endTurn,
 		)
 	}
@@ -186,6 +189,20 @@ func (m *Manager) compileOffersFor(
 		return nil, fmt.Errorf("%w: %v", ErrBadCost, err)
 	}
 
+	// ONE blocker row for Activate on the early paths above, and N compiled
+	// rows here. That asymmetry is the same one Attack already has between a
+	// blocker and a compiled offer, scaled by a verb that compiles more than
+	// one: a member whose sheet will not load has no abilities to enumerate,
+	// so there is nothing to emit N of.
+	var activations []compiledOffer
+	if requested[VerbActivate] {
+		var err error
+		activations, err = m.buildActivationOffers(sessionID, member, sheet)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	var move compiledOffer
 	if requested[VerbMove] {
 		var err error
@@ -195,7 +212,7 @@ func (m *Manager) compileOffersFor(
 		}
 	}
 	if !requested[VerbAttack] {
-		return finishRequestedOffers(requested, move, endTurn)
+		return finishRequestedOffers(requested, append([]compiledOffer{move, endTurn}, activations...)...)
 	}
 
 	// Price BEFORE assembly. The complete Definition is selector material, so
@@ -224,11 +241,12 @@ func (m *Manager) compileOffersFor(
 			Reason: ShortfallUnreadable,
 			Text:   fmt.Errorf("member %q: %w: %v", member, ErrBadAttack, err).Error(),
 		}
-		return finishRequestedOffers(requested,
-			blockedCompiledOffer(VerbAttack, TargetMember, why),
-			move,
-			endTurn,
-		)
+		return finishRequestedOffers(requested, append(
+			[]compiledOffer{
+				blockedCompiledOffer(VerbAttack, TargetMember, why),
+				move,
+				endTurn,
+			}, activations...)...)
 	}
 	price.cost.Profile = combatActions.CloneSpendProfile(definition.Cost)
 	slot := slotOf(definition.Cost)
@@ -314,7 +332,7 @@ func (m *Manager) compileOffersFor(
 	}
 
 	attackRef := attackRefFor(definition)
-	attackID, attackVariant, err := selectorIDFor(sessionID, member, VerbAttack, slot, &definition)
+	attackID, attackVariant, err := selectorIDFor(sessionID, member, VerbAttack, slot, &definition, "")
 	if err != nil {
 		return nil, err
 	}
@@ -345,13 +363,15 @@ func (m *Manager) compileOffersFor(
 		variant: attackVariant,
 	}
 
-	return finishRequestedOffers(requested, attack, move, endTurn)
+	return finishRequestedOffers(requested, append([]compiledOffer{attack, move, endTurn}, activations...)...)
 }
 
 // finishRequestedOffers filters candidate offers to the requested verbs and
 // runs every compiled selector through the collision guard. Zero-value
 // candidates are ignored; blockers are retained by their declaration verb.
 func finishRequestedOffers(requested map[Verb]bool, candidates ...compiledOffer) ([]compiledOffer, error) {
+	// len(requested) is a floor rather than a count now that VerbActivate
+	// contributes N rows for one requested verb.
 	offers := make([]compiledOffer, 0, len(requested))
 	for _, offer := range candidates {
 		if requested[offer.declaration.Verb] {
@@ -392,7 +412,7 @@ func (m *Manager) loadActorSheet(ctx context.Context, member string) actorSheet 
 // unreadable character do not reach it — it carries no sheet, no candidates,
 // and no currency.
 func (m *Manager) buildEndTurnOffer(session, member string) (compiledOffer, error) {
-	id, variant, err := selectorIDFor(session, member, VerbEndTurn, SlotNone, nil)
+	id, variant, err := selectorIDFor(session, member, VerbEndTurn, SlotNone, nil, "")
 	if err != nil {
 		return compiledOffer{}, err
 	}
@@ -416,7 +436,7 @@ func (m *Manager) buildEndTurnOffer(session, member string) (compiledOffer, erro
 // whether ANY step at all is still possible — one cell, five feet, the
 // smallest unit this grid has — and Remaining is the actual feet left.
 func buildMoveOffer(session, member string, sheet *character.Character) (compiledOffer, error) {
-	id, variant, err := selectorIDFor(session, member, VerbMove, SlotNone, nil)
+	id, variant, err := selectorIDFor(session, member, VerbMove, SlotNone, nil, "")
 	if err != nil {
 		return compiledOffer{}, err
 	}
@@ -570,9 +590,10 @@ func selectCompiledOffer(offers []compiledOffer, verb Verb, id string) (compiled
 // material rather than candidate state. For Move and EndTurn the variant is
 // a sealed string; for Attack it is the marshaled, validated definition.
 func selectorIDFor(
-	session, member string, verb Verb, slot Slot, attack *combatActions.Definition,
+	session, member string, verb Verb, slot Slot,
+	attack *combatActions.Definition, ability string,
 ) (id string, variant json.RawMessage, err error) {
-	variant, err = selectorVariant(verb, attack)
+	variant, err = selectorVariant(verb, attack, ability)
 	if err != nil {
 		return "", nil, err
 	}
@@ -586,6 +607,7 @@ func selectorIDFor(
 		Verb:    verb,
 		Slot:    slot,
 		Attack:  attack,
+		Ability: ability,
 	})
 	if err != nil {
 		return "", nil, err
@@ -645,10 +667,12 @@ func verbRank(v Verb) int {
 		return 0
 	case VerbMove:
 		return 1
-	case VerbEndTurn:
+	case VerbActivate:
 		return 2
-	default:
+	case VerbEndTurn:
 		return 3
+	default:
+		return 4
 	}
 }
 
@@ -657,6 +681,17 @@ func verbRank(v Verb) int {
 // regardless of the build order compileOffersFor happens to use.
 func sortDeclarations(decls []Declaration) {
 	sort.SliceStable(decls, func(i, j int) bool {
-		return verbRank(decls[i].Verb) < verbRank(decls[j].Verb)
+		if verbRank(decls[i].Verb) != verbRank(decls[j].Verb) {
+			return verbRank(decls[i].Verb) < verbRank(decls[j].Verb)
+		}
+		// WITHIN a verb, and only Activate ever has two. Verb rank alone was a
+		// total order while every verb compiled one offer; with seven Activate
+		// rows it leaves their order to whatever the caller appended, which is
+		// stable today and stable by accident. Ability ref is a fact about the
+		// character, so the panel's order is too.
+		if decls[i].Ability != nil && decls[j].Ability != nil {
+			return decls[i].Ability.Ref < decls[j].Ability.Ref
+		}
+		return false
 	})
 }

--- a/rulebooks/dnd5e/session/offers.go
+++ b/rulebooks/dnd5e/session/offers.go
@@ -23,7 +23,8 @@ import (
 // mutating verb regenerates before execution. It never crosses the host
 // boundary: only its [Declaration] projection does.
 //
-// ONE COMPILED OFFER PER VERB/ACTION/SPEND VARIANT. v1 has exactly one spend
+// ONE COMPILED OFFER PER ACTION/SPEND VARIANT — per VERB only for the verbs
+// that have exactly one variant, which is every verb except Activate. v1 has exactly one spend
 // variant per verb — the next swing's profile for Attack, SlotNone for Move
 // and EndTurn — so full Afford compilation produces one offer per verb. The day
 // a bonus-action strike lands, it arrives as a second Attack offer with a
@@ -96,7 +97,7 @@ type targetPreflight struct {
 
 // compileOffersFor builds only the requested compiled offers for one member on
 // the turn clock, applying the same per-verb blocker matrix. [Manager.Afford]
-// requests all three verbs from one actor snapshot; Move and Attack each request
+// requests all four verbs from one actor snapshot; Move and Attack each request
 // only their own offer before selecting an echoed ID. EndTurn execution keeps
 // its direct clock-only builder.
 //
@@ -684,11 +685,14 @@ func sortDeclarations(decls []Declaration) {
 		if verbRank(decls[i].Verb) != verbRank(decls[j].Verb) {
 			return verbRank(decls[i].Verb) < verbRank(decls[j].Verb)
 		}
-		// WITHIN a verb, and only Activate ever has two. Verb rank alone was a
-		// total order while every verb compiled one offer; with seven Activate
-		// rows it leaves their order to whatever the caller appended, which is
-		// stable today and stable by accident. Ability ref is a fact about the
-		// character, so the panel's order is too.
+		// WITHIN a verb, and only Activate ever has more than one — six at
+		// level 1, and however many the character carries after that, which is
+		// the point: the count is a fact about the sheet, not a constant.
+		//
+		// Verb rank alone was a total order while every verb compiled exactly
+		// one offer. With many Activate rows it leaves their order to whatever
+		// the caller appended — stable today, and stable by accident. Ability
+		// ref is a fact about the character, so the panel's order is too.
 		if decls[i].Ability != nil && decls[j].Ability != nil {
 			return decls[i].Ability.Ref < decls[j].Ability.Ref
 		}

--- a/rulebooks/dnd5e/session/offers_test.go
+++ b/rulebooks/dnd5e/session/offers_test.go
@@ -216,33 +216,42 @@ func TestAffordReturnsOneAttackOfferWithEveryLiveCandidate(t *testing.T) {
 // of a full compiled turn: Attack, Move and EndTurn each carry a selector
 // ID and the fixed target kind, Move carries Remaining, EndTurn carries no
 // candidates, and the declarations arrive in the documented verb order.
-func TestAffordProjectsThreeCompiledDeclarationsOnTheTurnClock(t *testing.T) {
+func TestAffordProjectsEveryCompiledDeclarationOnTheTurnClock(t *testing.T) {
 	mgr, _, _, _, _ := candidateFight(t)
 	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
 	require.NoError(t, err)
 
 	require.Equal(t, session.ClockTurn, out.Clock)
-	require.Len(t, out.Declarations, 3, "Attack, Move and EndTurn")
+	// Attack, Move, EndTurn, and the FIVE activations a plain fighter carries:
+	// Dash, Disengage, Dodge, Help, Hide. The sixth combat ability every
+	// character has is Attack, and it is deliberately not among them —
+	// swinging is VerbAttack's job, and offering the Attack action separately
+	// would put two buttons on the panel for one thing.
+	require.Len(t, out.Declarations, 8)
 
-	// Documented verb order: Attack, Move, EndTurn.
+	// Documented verb order: Attack, Move, Activate, EndTurn — and EndTurn is
+	// no longer at a fixed index, which is why every lookup below is BY VERB.
+	// Positional indexing was only ever valid while each verb compiled exactly
+	// one offer, and it read as a statement about order when it was really a
+	// statement about count.
 	require.Equal(t, session.VerbAttack, out.Declarations[0].Verb)
 	require.Equal(t, session.VerbMove, out.Declarations[1].Verb)
-	require.Equal(t, session.VerbEndTurn, out.Declarations[2].Verb)
+	require.Equal(t, session.VerbEndTurn, out.Declarations[len(out.Declarations)-1].Verb)
 
-	attack := out.Declarations[0]
+	attack := requireSingleDeclaration(t, out.Declarations, session.VerbAttack)
 	require.NotEmpty(t, attack.ID, "compiled Attack has a selector ID")
 	require.NotNil(t, attack.Attack)
 	require.Equal(t, session.TargetMember, attack.TargetKind)
 	require.NotEmpty(t, attack.Candidates)
 
-	move := out.Declarations[1]
+	move := requireSingleDeclaration(t, out.Declarations, session.VerbMove)
 	require.NotEmpty(t, move.ID, "compiled Move has a selector ID")
 	require.Nil(t, move.Attack)
 	require.Equal(t, session.TargetPath, move.TargetKind)
 	require.NotNil(t, move.Remaining, "Move carries remaining feet")
 	require.Empty(t, move.Candidates, "Move carries no candidates")
 
-	endTurn := out.Declarations[2]
+	endTurn := requireSingleDeclaration(t, out.Declarations, session.VerbEndTurn)
 	require.NotEmpty(t, endTurn.ID, "compiled EndTurn has a selector ID")
 	require.Nil(t, endTurn.Attack)
 	require.Equal(t, session.TargetNone, endTurn.TargetKind)
@@ -253,7 +262,7 @@ func TestAffordProjectsThreeCompiledDeclarationsOnTheTurnClock(t *testing.T) {
 // TestNotYourTurnBlocksAllThreeVerbs pins the cheap, sheet-free blocker:
 // every verb is blocked with the same NotYourTurn reason, an empty selector
 // ID, no AttackRef, an empty candidate slice, and the fixed target kind.
-func TestNotYourTurnBlocksAllThreeVerbs(t *testing.T) {
+func TestNotYourTurnBlocksEveryVerb(t *testing.T) {
 	sessions, encounters := newFakeSessions(), newFakeEncounters()
 	characters := newFakeCharacters(armedFighter("alice"), armedFighter("bob"))
 	mgr, err := session.NewManager(&session.Config{
@@ -289,7 +298,10 @@ func TestNotYourTurnBlocksAllThreeVerbs(t *testing.T) {
 	out, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "bob"})
 	require.NoError(t, err)
 	require.Equal(t, session.ClockTurn, out.Clock)
-	require.Len(t, out.Declarations, 3)
+	// One blocker per verb. Activate is ONE verb however many things it could
+	// compile when the sheet is readable: a member who cannot act cannot
+	// activate any of them, and the reason is identical for every one.
+	require.Len(t, out.Declarations, 4)
 
 	for _, d := range out.Declarations {
 		require.False(t, d.Available)
@@ -313,7 +325,7 @@ func TestNotYourTurnBlocksAllThreeVerbs(t *testing.T) {
 // fight first (alice active on the turn clock) and only then dropping her
 // stored sheet to zero hit points, so the encounter's clock still names her
 // active while the session's sheet-based standing seam reads her downed.
-func TestDownedBlocksAttackAndMoveButNotEndTurn(t *testing.T) {
+func TestDownedBlocksEveryVerbButEndTurn(t *testing.T) {
 	alice := armedFighter("alice")
 	mgr, _, _, characters := aFight(t, alice, []int{1, 1})
 
@@ -325,7 +337,10 @@ func TestDownedBlocksAttackAndMoveButNotEndTurn(t *testing.T) {
 	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
 	require.NoError(t, err)
 	require.Equal(t, session.ClockTurn, out.Clock)
-	require.Len(t, out.Declarations, 3)
+	// One blocker per verb. Activate is ONE verb however many things it could
+	// compile when the sheet is readable: a member who cannot act cannot
+	// activate any of them, and the reason is identical for every one.
+	require.Len(t, out.Declarations, 4)
 
 	attack := requireSingleDeclaration(t, out.Declarations, session.VerbAttack)
 	require.False(t, attack.Available)
@@ -398,7 +413,12 @@ func TestBadAttackCompilationBlocksAttackOnly(t *testing.T) {
 	out, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "alice"})
 	require.NoError(t, err)
 	require.Equal(t, session.ClockTurn, out.Clock)
-	require.Len(t, out.Declarations, 3)
+	// Attack, Move, EndTurn, and the FIVE activations a plain fighter carries:
+	// Dash, Disengage, Dodge, Help, Hide. The sixth combat ability every
+	// character has is Attack, and it is deliberately not among them —
+	// swinging is VerbAttack's job, and offering the Attack action separately
+	// would put two buttons on the panel for one thing.
+	require.Len(t, out.Declarations, 8)
 
 	attack := requireSingleDeclaration(t, out.Declarations, session.VerbAttack)
 	require.False(t, attack.Available)
@@ -425,7 +445,7 @@ func TestBadAttackCompilationBlocksAttackOnly(t *testing.T) {
 // repository does not hold blocks Attack and Move — there is no sheet to
 // compile a swing or read movement from — while EndTurn, governed by the
 // clock alone, stays compiled with a selector ID.
-func TestUnreadableCharacterBlocksAttackAndMoveButNotEndTurn(t *testing.T) {
+func TestUnreadableCharacterBlocksEveryVerbButEndTurn(t *testing.T) {
 	// alice is armed and in the repository; bob is a player member the
 	// repository does not hold, so loading bob's sheet fails with
 	// ErrNoCharacter once bob is the active member.
@@ -471,7 +491,10 @@ func TestUnreadableCharacterBlocksAttackAndMoveButNotEndTurn(t *testing.T) {
 	out, err := mgr.Afford(ctx, &session.AffordInput{Session: "sess", Member: "bob"})
 	require.NoError(t, err)
 	require.Equal(t, session.ClockTurn, out.Clock)
-	require.Len(t, out.Declarations, 3)
+	// One blocker per verb. Activate is ONE verb however many things it could
+	// compile when the sheet is readable: a member who cannot act cannot
+	// activate any of them, and the reason is identical for every one.
+	require.Len(t, out.Declarations, 4)
 
 	attack := requireSingleDeclaration(t, out.Declarations, session.VerbAttack)
 	require.False(t, attack.Available)

--- a/rulebooks/dnd5e/session/offers_test.go
+++ b/rulebooks/dnd5e/session/offers_test.go
@@ -351,6 +351,17 @@ func TestDownedBlocksEveryVerbButEndTurn(t *testing.T) {
 	require.NotNil(t, attack.Why)
 	require.Equal(t, session.ShortfallDowned, attack.Why.Reason)
 
+	// The Activate blocker carries the SAME reason, one row, no ability named:
+	// a downed member has not compiled any of the things they carry, so there
+	// is nothing to emit six of.
+	activate := requireSingleDeclaration(t, out.Declarations, session.VerbActivate)
+	require.False(t, activate.Available)
+	require.Empty(t, activate.ID)
+	require.Nil(t, activate.Ability)
+	require.Equal(t, session.TargetNone, activate.TargetKind)
+	require.NotNil(t, activate.Why)
+	require.Equal(t, session.ShortfallDowned, activate.Why.Reason)
+
 	move := requireSingleDeclaration(t, out.Declarations, session.VerbMove)
 	require.False(t, move.Available)
 	require.Empty(t, move.ID)

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -1040,6 +1040,23 @@ const (
 // dropped on the floor since the first swing (rpg-toolkit#866). Carried on a
 // compiled Declaration, AttackOutput, and the Struck/Missed event bodies, so
 // selection and outcome name the same authored attack for every witness.
+type AbilityRef struct {
+	// Ref is the ability's full core.Ref.String() —
+	// "dnd5e:combat_abilities:dodge", "dnd5e:features:rage". An OPEN set, so a
+	// string, for [AttackRef.Ref]'s reason: the catalog grows without this
+	// type changing.
+	//
+	// It is also the SELECTOR MATERIAL for an Activate declaration. One verb
+	// compiles seven offers and this is what makes their IDs differ, the way a
+	// serialized definition makes two Attack offers differ.
+	Ref string `json:"ref"`
+
+	// Name is the ability's own display name — "Dodge", "Rage", "Second
+	// Wind". Authored by the ability, never derived from the ref by a reader.
+	Name string `json:"name"`
+}
+
+// AttackRef is the sole public identity of a compiled Attack.
 type AttackRef struct {
 	// Ref is the full catalog ref the attack compiled from —
 	// "dnd5e:weapons:longsword", "dnd5e:weapons:unarmed-strike". An OPEN set,
@@ -1101,6 +1118,17 @@ const (
 	// answer remains ShortfallNoTargetInReach when no candidate is in reach
 	// at all (rpg-toolkit#1010, rpg-project#249 §6).
 	ShortfallTargetOutOfReach ShortfallReason = "target_out_of_reach"
+
+	// ShortfallUnavailable is the ability's own precondition refusing: already
+	// raging, already at full hit points. NOT a budget — nothing ran out,
+	// Currency is empty, and waiting will not help the way it does for
+	// [ShortfallNoBudget].
+	//
+	// This is the seam's word for what features.Feature.CanActivate refuses,
+	// which is a different question from what the economy refuses. A projection
+	// that collapsed the two would tell a raging barbarian to come back next
+	// turn.
+	ShortfallUnavailable ShortfallReason = "unavailable"
 )
 
 // Currency names which of a turn's budgets a NO_BUDGET shortfall ran out
@@ -1123,6 +1151,15 @@ const (
 	// CurrencyMovement is feet, not a count — Needed and Left on a MOVEMENT
 	// shortfall are in feet, at the server's five per cell.
 	CurrencyMovement Currency = "movement"
+
+	// CurrencyCharges is charges of a named feature resource — rage uses,
+	// Second Wind uses, ki points. A count, like the three slots.
+	//
+	// WHICH resource is named only in Text. This seam does not enumerate the
+	// rulebook's resource keys, for the reason [Verb] does not enumerate the
+	// rulebook's actions: the catalog grows without this contract changing,
+	// and a client that branched on a specific pool would be deriving rules.
+	CurrencyCharges Currency = "charges"
 )
 
 // Shortfall is the structured reason a declaration cannot be paid for.

--- a/rulebooks/dnd5e/session/types.go
+++ b/rulebooks/dnd5e/session/types.go
@@ -1036,10 +1036,13 @@ const (
 	DamageThunder     DamageType = "thunder"
 )
 
-// AttackRef identifies WHAT was swung — weapon identity, which this seam
-// dropped on the floor since the first swing (rpg-toolkit#866). Carried on a
-// compiled Declaration, AttackOutput, and the Struck/Missed event bodies, so
-// selection and outcome name the same authored attack for every witness.
+// AbilityRef identifies WHAT is being activated — the combat ability or
+// feature behind a [VerbActivate] declaration.
+//
+// It exists for the reason [AttackRef] does: a declaration a client renders
+// verbatim needs an identity, and "Rage" is not derivable from the verb the
+// way "Move" is from [VerbMove]. Attack has one identity per weapon; Activate
+// has one per thing the character carries.
 type AbilityRef struct {
 	// Ref is the ability's full core.Ref.String() —
 	// "dnd5e:combat_abilities:dodge", "dnd5e:features:rage". An OPEN set, so a
@@ -1047,7 +1050,7 @@ type AbilityRef struct {
 	// type changing.
 	//
 	// It is also the SELECTOR MATERIAL for an Activate declaration. One verb
-	// compiles seven offers and this is what makes their IDs differ, the way a
+	// compiles many offers and this is what makes their IDs differ, the way a
 	// serialized definition makes two Attack offers differ.
 	Ref string `json:"ref"`
 
@@ -1056,7 +1059,10 @@ type AbilityRef struct {
 	Name string `json:"name"`
 }
 
-// AttackRef is the sole public identity of a compiled Attack.
+// AttackRef identifies WHAT was swung — weapon identity, which this seam
+// dropped on the floor since the first swing (rpg-toolkit#866). Carried on a
+// compiled Declaration, AttackOutput, and the Struck/Missed event bodies, so
+// selection and outcome name the same authored attack for every witness.
 type AttackRef struct {
 	// Ref is the full catalog ref the attack compiled from —
 	// "dnd5e:weapons:longsword", "dnd5e:weapons:unarmed-strike". An OPEN set,
@@ -1091,7 +1097,7 @@ const (
 	ShortfallNoBudget ShortfallReason = "no_budget"
 
 	// ShortfallNotYourTurn is it not being this member's turn — what
-	// Attack, Move and EndTurn refuse as ErrNotYourTurn.
+	// Attack, Move, Activate and EndTurn all refuse as ErrNotYourTurn.
 	ShortfallNotYourTurn ShortfallReason = "not_your_turn"
 
 	// ShortfallNoTargetInReach is nothing to swing at within reach. Echoing
@@ -1197,7 +1203,9 @@ type Shortfall struct {
 
 // TargetKind tells a client which selector shape a Declaration accepts. A
 // closed set owned at the seam, mirroring the merged proto's TargetKind: the
-// three currently executable verbs fix their kind, and a new kind arrives the
+// currently executable verbs fix their kind — Activate by which ABILITY it is
+// rather than by the verb, since Help prompts for an ally and the rest prompt
+// for nobody — and a new kind arrives the
 // day a proven executor for it lands — never in advance.
 //
 // FIXED FOR EVERY COMPILED OR BLOCKED DECLARATION: Attack -> TargetMember,


### PR DESCRIPTION
`Manager.Afford` now offers what a member can **activate**. rpg-project#300, design #301.

Read-only: this compiles offers and nothing executes them yet — `Manager.Activate` is the next PR, and it waits on rpg-toolkit#1269 being tagged.

## A projection, not a second pricing engine

`character.AvailableAbilities` already answers, per ability: ref, display name, which economy shape it draws, what target it prompts for, whether it can be used right now, and how many charges are left. **That is a declaration in everything but name** — assembled in the rulebook for a menu that no longer exists, and never once crossing this seam.

So this compiles nothing and prices nothing. Afford's *"read the price off the SAME profile the door would charge"* rule is kept **by construction** rather than by care: the shape comes from the ability's own `ActionType`, and that is what the door charges.

## The Attack combat ability is excluded, deliberately

Every character carries one. Swinging is already `VerbAttack` here, priced off a compiled definition. Emitting the Attack **action** as an eighth activation would put two buttons on the panel for one thing and invite a player to spend an action banking swings the seam already banked. Pinned by a test.

## The one real conversion: prose → structure

`AvailableAbility` carries a single `Reason` **string** covering three different refusals. Matching on that string would be the exact inversion of this seam's law — the SDK renders `Text` *from* the structure — and it would break the first time a feature reworded its own error.

So the discrimination is made from state the seam can see for itself:

1. Ask the **economy** whether this shape is spent → `NO_BUDGET`, every figure known, text rendered.
2. Otherwise the economy allowed it and the **ability** refused. If it carries a resource that ran out, that is a ledger too — just not one of the turn's three → `NO_BUDGET` + `CURRENCY_CHARGES`.
3. Otherwise a precondition → `UNAVAILABLE`. Nothing ran out; waiting will not help.

Cases 2 and 3 keep the **ability's own words**, because the structure deliberately does not name which resource ran out — this seam does not enumerate the rulebook's resource keys — so `"no rage uses remaining"` carries the one fact a client cannot reconstruct. That is `Text` doing its documented job.

## The case that forces many rows per verb

`TestOneVerbCarriesBothShapesAtOnce`: a barbarian's **Rage draws the bonus action while Dodge draws the action, live at the same moment.** `Slot` is per declaration, so one row per verb could carry only one of the two. Multiple rows is forced, not preferred.

The blocker paths stay at **one** Activate row: a member who is downed, unreadable, or not on the clock has compiled none of the things they carry, and six copies of "not your turn" is a panel that looks like it has choices.

## Nine assertions and three test names said "three declarations"

Every one updated rather than relaxed — the compiled paths name eight and say which five are new, the blocker paths name four and say why Activate is one row there. Three tests were **renamed**, because a name like `TestNotYourTurnBlocksAllThreeVerbs` is an assertion that no compiler checks.

**Positional indexing into `Declarations` is gone.** It was only valid while each verb compiled one offer, and it read as a claim about order when it was a claim about count.

## Evidence

Session suite green on `dnd5e v0.105.1`. Three mutants, each killed:

| mutant | killed by |
|---|---|
| the wrong ability excluded (Dash instead of Attack) | 3 |
| charges collapsed into `UNAVAILABLE` | 1 — the currency test |
| Help stops asking for a target | 1 |

— platform agent, on behalf of KirkDiggler
