### PR TITLE
feat(session): Manager.Activate — a player uses what they carry

### DIFF
--- a/rulebooks/dnd5e/session/activate.go
+++ b/rulebooks/dnd5e/session/activate.go
@@ -1,0 +1,263 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
+)
+
+// ActivateInput uses a combat ability or feature the member already carries.
+type ActivateInput struct {
+	// Session is the session to act inside.
+	Session string
+
+	// Member is who is activating. Required.
+	//
+	// THE HOST MUST BIND THIS TO THE AUTHENTICATED CALLER, exactly as
+	// [Manager.Afford] and [Manager.Where] require and for the same reason:
+	// this package cannot tell who is asking, and a client-supplied ID wired
+	// through unchecked turns a caller-scoped verb into one that acts for
+	// anybody.
+	Member string
+
+	// DeclarationID is the opaque selector echoed from [Manager.Afford], and
+	// it is also WHICH ABILITY this activates: one verb compiles one offer per
+	// thing the member carries, so the selector names the row rather than the
+	// verb. Required.
+	//
+	// There is deliberately no ability ref on this input. A caller that named
+	// the ability itself would be deciding something Afford already decided,
+	// and the two could disagree.
+	DeclarationID string
+
+	// Target is who it lands on, for the one level-1 ability that takes
+	// somebody: Help. Empty for the rest, and a populated ID on an ability
+	// that takes none is refused rather than ignored.
+	Target string
+
+	// ObserverPassivePerceptions is the passive Perception of everyone who
+	// could notice, which Hide's Stealth check is rolled against. Empty for
+	// every other ability — and empty is a legitimate answer for Hide too
+	// (nobody is watching), so it cannot be validated by presence.
+	ObserverPassivePerceptions []int
+}
+
+// ActivateOutput is what an activation produced.
+//
+// AN ACKNOWLEDGEMENT, by Kirk's ruling on rpg-project#300: it says nothing
+// about what the member can do next. Returning a refreshed ability list would
+// put a SECOND declaration surface beside [Manager.Afford] — two reads
+// answering "what can I do", free to disagree, with the caller left to learn
+// which one wins. The caller re-reads Afford.
+//
+// What it does carry is S6's law, which every mutating verb here keeps: an
+// activation writes a sheet and publishes a condition, so both halves can be
+// half-done, and a caller told only "fine" could not tell a durable rage from
+// one that never reached disk.
+type ActivateOutput struct {
+	// Ability is the ref that ran, echoed back — so a caller that dispatched
+	// by selector learns what the selector meant without parsing it.
+	Ability string
+
+	// GrantedCapacity is the ability's own description of what it banked
+	// ("30ft movement" for Dash), or empty. Display text authored by the
+	// ability and never parsed: Dash's effect on the ledger is in the ledger.
+	GrantedCapacity string
+
+	Saved    SaveReport
+	Delivery DeliveryReport
+}
+
+// Activate uses a combat ability or feature the member already carries —
+// Dodge, Dash, Disengage, Help, Hide, Rage, Second Wind.
+//
+// # A refusal is an error, never a field
+//
+// The rulebook underneath answers every refusal as a SUCCESSFUL call carrying
+// a false: "not in combat", "unknown ability", "no rage uses remaining". This
+// verb does not propagate that shape. An ability that said no comes back
+// [ErrCannotActivate] with its own words attached; a malformed activation
+// comes back [ErrBadActivation]. The split is [ErrCannotAfford] versus
+// [ErrBadCost]'s, for the same reason — one wants a different verb, the other
+// wants a developer.
+//
+// # Nothing is charged here
+//
+// [resolution.Input.Cost] stays nil, deliberately. The ability spends its own
+// slot, so a Cost passed alongside would charge the same ledger twice and the
+// second charge would look exactly like the first. This is the one executing
+// verb at this seam that does not pay at the door, and it is not free — see
+// [resolution.NewActivation].
+//
+// # Everyone is in the cast
+//
+// R3: pass everyone in. Rage lands on its owner alone, but Help aids an ally
+// and Hide is judged against whoever is watching — and more to the point, the
+// condition an activation publishes is applied by the OWNER'S keeper, which is
+// only attached for participants. A cast trimmed to "whoever this obviously
+// affects" would be a rule decided here, in the one place that cannot see it.
+//
+// Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoDeclarationID,
+// ErrNoSession, ErrNoEncounter, ErrNoMember, ErrNotACharacter, ErrNotYourTurn,
+// ErrDowned, ErrStaleDeclaration, ErrCannotActivate, or ErrBadActivation.
+func (m *Manager) Activate(ctx context.Context, in *ActivateInput) (*ActivateOutput, error) {
+	if in == nil {
+		return nil, fmt.Errorf("activate: %w", ErrNilInput)
+	}
+	if in.Member == "" {
+		return nil, fmt.Errorf("activate: %w", ErrNoMemberID)
+	}
+
+	scope, err := m.openForWrite(ctx, in.Session)
+	if err != nil {
+		return nil, fmt.Errorf("activate: %w", err)
+	}
+
+	roster, err := scope.enc.Members()
+	if err != nil {
+		return nil, fmt.Errorf("activate: %w", translate(err))
+	}
+	kind, inRoster := encounter.MemberKind(""), false
+	for _, member := range roster {
+		if string(member.ID) == in.Member {
+			kind, inRoster = member.Kind, true
+			break
+		}
+	}
+	if !inRoster {
+		return nil, fmt.Errorf("activate: member %q: %w", in.Member, ErrNoMember)
+	}
+	if kind != encounter.MemberKind(KindPlayer) {
+		// A monster is in the roster and still cannot declare: its abilities
+		// are driven by behaviour rather than chosen, and its economy belongs
+		// to whoever runs its turn.
+		return nil, fmt.Errorf("activate: member %q: %w", in.Member, ErrNotACharacter)
+	}
+
+	// NOT YOUR TURN, checked before anything touches character storage — the
+	// precedence Attack and Move both keep.
+	clock, err := scope.enc.ClockOf(&encounter.ClockOfInput{Member: encounter.MemberID(in.Member)})
+	if err != nil {
+		return nil, fmt.Errorf("activate: %w", translate(err))
+	}
+	if ClockKind(clock.Kind) == ClockTurn && string(clock.Active) != in.Member {
+		return nil, fmt.Errorf("activate: member %q: %w", in.Member, ErrNotYourTurn)
+	}
+	if ClockKind(clock.Kind) != ClockTurn {
+		// There are no world-clock activations. Afford returns no declarations
+		// there at all, so every selector is stale by construction — and an
+		// empty one is still the caller's omission rather than a stale offer.
+		if in.DeclarationID == "" {
+			return nil, fmt.Errorf("activate: %w", ErrNoDeclarationID)
+		}
+		return nil, fmt.Errorf("activate: %w", ErrStaleDeclaration)
+	}
+
+	// Loaded strictly ONCE. Standing and every piece of the regenerated offer
+	// come from this same snapshot, so a repository cannot answer standing to
+	// one gate and downed to compilation.
+	actor := m.loadActorSheet(ctx, in.Member)
+	if actor.downed {
+		return nil, fmt.Errorf("activate: member %q: %w", in.Member, ErrDowned)
+	}
+	if in.DeclarationID == "" {
+		return nil, fmt.Errorf("activate: %w", ErrNoDeclarationID)
+	}
+
+	// Regenerate and select. compileOffersFor owns identity and availability;
+	// selectCompiledOffer refuses a selector that names nothing, names two
+	// things, or names an offer that is no longer available — all as
+	// ErrStaleDeclaration, because from a client's side they are the same
+	// event: you saw an offer and the world moved.
+	offers, err := m.compileOffersFor(
+		ctx, scope.enc, scope.data, scope.session, in.Member, clock, actor, VerbActivate,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("activate: %w", err)
+	}
+	selected, err := selectCompiledOffer(offers, VerbActivate, in.DeclarationID)
+	if err != nil {
+		return nil, fmt.Errorf("activate: %w", err)
+	}
+	if selected.declaration.Ability == nil || selected.sheet == nil {
+		// A compiled Activate offer always carries both. Failing closed here
+		// keeps a provider defect from reaching resolution as a nil ref.
+		return nil, fmt.Errorf("activate: %w", ErrStaleDeclaration)
+	}
+
+	// Back through core.ParseString, because the declaration carries the ref
+	// as the STRING a client echoes. It round-trips by construction — the
+	// declaration was built from a *core.Ref moments ago — so a failure here
+	// is a provider defect rather than bad input, and it says so.
+	ability, err := core.ParseString(selected.declaration.Ability.Ref)
+	if err != nil {
+		return nil, fmt.Errorf("activate: %w: unreadable ability ref %q: %v",
+			ErrBadActivation, selected.declaration.Ability.Ref, err)
+	}
+
+	machine, err := resolution.NewActivation(&resolution.ActivationInput{
+		MemberID:                   in.Member,
+		Ability:                    ability,
+		TargetID:                   in.Target,
+		ObserverPassivePerceptions: in.ObserverPassivePerceptions,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("activate: %w", translateResolution(err))
+	}
+
+	// The readied sheet goes into the cast rather than being fetched again:
+	// compileOffersFor readied this turn's economy on it, and a second read
+	// would hand resolution a ledger that had not been filled.
+	readied := selected.sheet.ToData()
+	cast, failures := m.compileResolutionCast(ctx, scope.data, roster, readied)
+	if len(failures) > 0 {
+		return nil, fmt.Errorf("activate: participant %q: %w: %v",
+			failures[0].member, ErrBadCharacter, failures[0].err)
+	}
+
+	world := scope.enc.ToData()
+	out, err := resolution.Resolve(ctx, &resolution.Input{
+		World:        world,
+		Participants: cast,
+		Initiative:   m.initiative,
+		Standing:     scope.standing,
+		Sight:        &sightSeam{members: append([]encounter.MemberData(nil), world.Members...)},
+		TurnDriver:   m.turnDriver,
+		Machine:      machine,
+		// Cost is nil ON PURPOSE — see this verb's own doc.
+		Roller: &diceSeam{roller: m.dice},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("activate: %w", translateResolution(err))
+	}
+
+	activated, ok := out.Outcome.(resolution.ActivationOutcome)
+	if !ok {
+		return nil, fmt.Errorf("activate: %w: activation produced %T", ErrInvalidWorld, out.Outcome)
+	}
+
+	if err := m.adopt(scope, out.World); err != nil {
+		return nil, fmt.Errorf("activate: %w", err)
+	}
+	if err := m.saveDirty(ctx, scope, out); err != nil {
+		return nil, fmt.Errorf("activate: %w", err)
+	}
+
+	report, delivery, err := m.commit(ctx, scope)
+	if err != nil {
+		return nil, fmt.Errorf("activate: %w", err)
+	}
+
+	return &ActivateOutput{
+		Ability:         activated.Ability,
+		GrantedCapacity: activated.GrantedCapacity,
+		Saved:           report,
+		Delivery:        delivery,
+	}, nil
+}

--- a/rulebooks/dnd5e/session/activate.go
+++ b/rulebooks/dnd5e/session/activate.go
@@ -105,7 +105,17 @@ type ActivateOutput struct {
 //
 // Returns ErrNilInput, ErrNoSessionID, ErrNoMemberID, ErrNoDeclarationID,
 // ErrNoSession, ErrNoEncounter, ErrNoMember, ErrNotACharacter, ErrNotYourTurn,
-// ErrDowned, ErrStaleDeclaration, ErrCannotActivate, or ErrBadActivation.
+// ErrDowned, ErrStaleDeclaration, ErrNoSheet, ErrNoCharacter, ErrBadCharacter,
+// ErrBadRepository, ErrBadCost, ErrCannotActivate, ErrBadActivation,
+// ErrInvalidWorld, ErrClosed, or ErrSaveFailed with a populated report.
+//
+// The two the list gains over an obvious reading, since both come from paths
+// this verb walks rather than from the ones it names: ErrBadCharacter covers a
+// cast member whose sheet will not load — everyone is a participant here (see
+// above), so ANY unreadable member refuses the whole activation rather than
+// just the actor's own — and ErrInvalidWorld covers a machine that returned an
+// outcome this verb has no case for, which is a provider defect this fails
+// closed on rather than reporting as a successful activation that did nothing.
 func (m *Manager) Activate(ctx context.Context, in *ActivateInput) (*ActivateOutput, error) {
 	if in == nil {
 		return nil, fmt.Errorf("activate: %w", ErrNilInput)

--- a/rulebooks/dnd5e/session/activate.go
+++ b/rulebooks/dnd5e/session/activate.go
@@ -87,6 +87,20 @@ type ActivateOutput struct {
 // [ErrBadCost]'s, for the same reason — one wants a different verb, the other
 // wants a developer.
 //
+// [ErrCannotActivate] is NOT reachable through this verb today, and saying so
+// is better than implying a path. [Manager.Afford] consults the same gates the
+// sheet does, so an unavailable ability is refused as a stale selector before
+// the sheet is ever asked, and the one combat ability with a precondition
+// beyond the economy is Help — whose missing target the activation machine
+// catches first, as [ErrBadActivation].
+//
+// The arm exists anyway, and not as a placeholder. The sheet's contract
+// genuinely answers refusals as a successful call carrying a false, so a verb
+// that ASSUMED the two gates always agree would report a refusal as a
+// successful activation that did nothing. This is that assumption declined.
+// Pinned in translate_internal_test.go, where the reachability is written down
+// beside it.
+//
 // # Nothing is charged here
 //
 // [resolution.Input.Cost] stays nil, deliberately. The ability spends its own

--- a/rulebooks/dnd5e/session/activate_test.go
+++ b/rulebooks/dnd5e/session/activate_test.go
@@ -9,8 +9,11 @@ import (
 	"testing"
 
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 	"github.com/stretchr/testify/require"
 )
 
@@ -179,4 +182,108 @@ func TestActivateRefusesANilInput(t *testing.T) {
 
 	_, err := mgr.Activate(context.Background(), nil)
 	require.ErrorIs(t, err, session.ErrNilInput)
+}
+
+// aTwoPlayerFight puts two characters in one hall and starts a fight, so a
+// test can ask what somebody does on a turn that is not theirs.
+func aTwoPlayerFight(
+	t *testing.T, alice, bob *character.Data,
+) (*session.Manager, *fakeCharacters) {
+	t.Helper()
+	sessions, encounters := newFakeSessions(), newFakeEncounters()
+	chars := newFakeCharacters(alice, bob)
+	mgr, err := session.NewManager(&session.Config{
+		Dice: testDice{}, TurnDriver: session.Pass{}, Sessions: sessions,
+		Encounters: encounters, Characters: chars, Events: session.DiscardEvents{},
+	})
+	require.NoError(t, err)
+
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Striker: encounter.RefusingStriker{}, Announcer: encQuietAnnouncer{},
+		Sight: encEveryoneSees{}, Initiative: encOrderAsGiven{},
+		TurnDriver: encPassDriver{}, Standing: encEveryoneStanding{},
+		Field: encounter.FieldInput{
+			Canvas:  pointyCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("hall", 0, 0, 8, 8)},
+		},
+		Members: []encounter.MemberInput{
+			{ID: encounter.MemberID(alice.ID), Kind: encounter.KindPlayer,
+				Position: spatial.Position{X: 1, Y: 1}},
+			{ID: encounter.MemberID(bob.ID), Kind: encounter.KindPlayer,
+				Position: spatial.Position{X: 5, Y: 5}},
+		},
+		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
+		Retention: encounter.RetentionUnbounded,
+	})
+	require.NoError(t, err)
+	data := enc.ToData()
+
+	ctx := context.Background()
+	_, err = mgr.StartSession(ctx, &session.StartSessionInput{
+		Session: "sess", Encounter: "world", World: &data,
+	})
+	require.NoError(t, err)
+
+	_, err = mgr.Spawn(ctx, &session.SpawnInput{
+		Session: "sess", ID: "skel-1", Ref: refs.Monsters.Skeleton().String(),
+		Position: spatial.Position{X: 2, Y: 1},
+	})
+	require.NoError(t, err)
+
+	return mgr, chars
+}
+
+// --- The two gates mutation testing found untested ---
+
+// A DOWNED MEMBER CANNOT ACTIVATE. Found by removing the gate and watching
+// every test still pass: the whole suite acted through a standing barbarian,
+// so nothing distinguished a build that checked from one that did not.
+func TestADownedMemberCannotActivate(t *testing.T) {
+	alice := ragingBarbarian("alice", 2)
+	mgr, _, _, chars := aFight(t, alice, []int{1, 1})
+
+	id := activationSelector(t, mgr, "alice", "dnd5e:features:rage")
+
+	// Dropped AFTER the fight formed and after the offer was taken, so the
+	// clock still names her active while the standing seam reads her downed —
+	// which is also the real shape of this race.
+	chars.byID["alice"].HitPoints = 0
+
+	_, err := mgr.Activate(context.Background(), &session.ActivateInput{
+		Session: "sess", Member: "alice", DeclarationID: id,
+	})
+
+	require.ErrorIs(t, err, session.ErrDowned)
+	require.NotContains(t, storedConditionRefs(t, chars, "alice"), "dnd5e:conditions:raging")
+}
+
+// A MEMBER CANNOT ACTIVATE ON SOMEBODY ELSE'S TURN, and this is the one that
+// mattered: nothing in a declaration selector encodes the round, so bob's own
+// offer from his own turn REGENERATES IDENTICALLY on alice's. Without the
+// clock gate the selector would validate and the rage would land out of turn.
+//
+// Also surfaced by mutation rather than by review — the gate was written from
+// the pattern Attack and Move keep, and copied faithfully enough that nobody
+// thought to test it.
+func TestActivatingOnSomebodyElsesTurnIsRefused(t *testing.T) {
+	alice, bob := ragingBarbarian("alice", 2), ragingBarbarian("bob", 2)
+	mgr, chars := aTwoPlayerFight(t, alice, bob)
+
+	ctx := context.Background()
+	turn, err := mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	require.Equal(t, session.ClockTurn, turn.Clock)
+
+	// Whoever is NOT active takes an offer while it is not theirs to take.
+	idle := "bob"
+	if turn.Active != "alice" {
+		idle = "alice"
+	}
+
+	_, err = mgr.Activate(ctx, &session.ActivateInput{
+		Session: "sess", Member: idle, DeclarationID: "v1.any-selector-at-all",
+	})
+
+	require.ErrorIs(t, err, session.ErrNotYourTurn)
+	require.NotContains(t, storedConditionRefs(t, chars, idle), "dnd5e:conditions:raging")
 }

--- a/rulebooks/dnd5e/session/activate_test.go
+++ b/rulebooks/dnd5e/session/activate_test.go
@@ -1,0 +1,182 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package session_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
+	"github.com/stretchr/testify/require"
+)
+
+// activationSelector asks Afford for the current offer for one ability and
+// hands back its selector — which is exactly what a client does.
+func activationSelector(t *testing.T, mgr *session.Manager, member, ref string) string {
+	t.Helper()
+	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: member})
+	require.NoError(t, err)
+	for _, d := range out.Declarations {
+		if d.Verb == session.VerbActivate && d.Ability != nil && d.Ability.Ref == ref {
+			return d.ID
+		}
+	}
+	t.Fatalf("no activation offer for %q", ref)
+	return ""
+}
+
+func storedSheet(t *testing.T, chars *fakeCharacters, id string) *character.Data {
+	t.Helper()
+	sheet, err := chars.GetCharacter(context.Background(), id)
+	require.NoError(t, err)
+	return sheet
+}
+
+func storedConditionRefs(t *testing.T, chars *fakeCharacters, id string) []string {
+	t.Helper()
+	out := make([]string, 0)
+	for _, raw := range storedSheet(t, chars, id).Conditions {
+		var envelope struct {
+			Ref string `json:"ref"`
+		}
+		require.NoError(t, json.Unmarshal(raw, &envelope))
+		out = append(out, envelope.Ref)
+	}
+	return out
+}
+
+// THE TEST THE WHOLE SLICE IS FOR, and the one #294 and #295 could not have
+// written: a player activates something, and it is there afterwards.
+//
+// The assertion is on what the REPOSITORY holds, not on the returned value or
+// an in-memory sheet. Rage does not attach its own condition — it publishes one
+// and the owner's keeper applies it — so a version of this that read back the
+// object it just acted on would pass with the bus missing entirely.
+func TestRagingSurvivesTheRoundTripToStorage(t *testing.T) {
+	alice := ragingBarbarian("alice", 2)
+	mgr, _, _, chars := aFight(t, alice, []int{1, 1})
+
+	id := activationSelector(t, mgr, "alice", "dnd5e:features:rage")
+	out, err := mgr.Activate(context.Background(), &session.ActivateInput{
+		Session: "sess", Member: "alice", DeclarationID: id,
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "dnd5e:features:rage", out.Ability)
+	require.Contains(t, out.Saved.Written, "character:alice")
+	require.Contains(t, storedConditionRefs(t, chars, "alice"), "dnd5e:conditions:raging")
+}
+
+// The charge and the bonus action come off the STORED sheet too, from the same
+// call. A rage that applied its condition without spending anything would be
+// free and permanent.
+func TestActivatingSpendsFromTheStoredSheet(t *testing.T) {
+	alice := ragingBarbarian("alice", 2)
+	mgr, _, _, chars := aFight(t, alice, []int{1, 1})
+
+	id := activationSelector(t, mgr, "alice", "dnd5e:features:rage")
+	_, err := mgr.Activate(context.Background(), &session.ActivateInput{
+		Session: "sess", Member: "alice", DeclarationID: id,
+	})
+	require.NoError(t, err)
+
+	sheet := storedSheet(t, chars, "alice")
+	require.Equal(t, 1, sheet.Resources[resources.RageCharges].Current)
+	require.NotNil(t, sheet.ActionEconomy)
+	require.Equal(t, 0, sheet.ActionEconomy.BonusActionsRemaining, "rage costs the bonus action")
+	require.Equal(t, 1, sheet.ActionEconomy.ActionsRemaining, "and nothing else")
+}
+
+// Dodge is the other arm of the lookup — a combat ability rather than a
+// feature, with no resource behind it.
+func TestDodgingSurvivesTheRoundTripToStorage(t *testing.T) {
+	alice := ragingBarbarian("alice", 2)
+	mgr, _, _, chars := aFight(t, alice, []int{1, 1})
+
+	id := activationSelector(t, mgr, "alice", "dnd5e:combat_abilities:dodge")
+	_, err := mgr.Activate(context.Background(), &session.ActivateInput{
+		Session: "sess", Member: "alice", DeclarationID: id,
+	})
+	require.NoError(t, err)
+
+	require.Contains(t, storedConditionRefs(t, chars, "alice"), "dnd5e:conditions:dodging")
+	require.Equal(t, 0, storedSheet(t, chars, "alice").ActionEconomy.ActionsRemaining)
+}
+
+// A SELECTOR SPENT ONCE IS STALE. The second call regenerates the offer,
+// finds the bonus action gone, and refuses — which is the whole reason
+// execution regenerates rather than trusting what it was handed.
+func TestASpentSelectorIsStale(t *testing.T) {
+	alice := ragingBarbarian("alice", 2)
+	mgr, _, _, _ := aFight(t, alice, []int{1, 1})
+
+	id := activationSelector(t, mgr, "alice", "dnd5e:features:rage")
+	_, err := mgr.Activate(context.Background(), &session.ActivateInput{
+		Session: "sess", Member: "alice", DeclarationID: id,
+	})
+	require.NoError(t, err)
+
+	_, err = mgr.Activate(context.Background(), &session.ActivateInput{
+		Session: "sess", Member: "alice", DeclarationID: id,
+	})
+	require.ErrorIs(t, err, session.ErrStaleDeclaration)
+}
+
+func TestAnUnknownSelectorIsStale(t *testing.T) {
+	alice := ragingBarbarian("alice", 2)
+	mgr, _, _, _ := aFight(t, alice, []int{1, 1})
+
+	_, err := mgr.Activate(context.Background(), &session.ActivateInput{
+		Session: "sess", Member: "alice", DeclarationID: "v1.not-a-real-selector",
+	})
+	require.ErrorIs(t, err, session.ErrStaleDeclaration)
+}
+
+func TestActivatingWithoutASelectorIsRefused(t *testing.T) {
+	alice := ragingBarbarian("alice", 2)
+	mgr, _, _, _ := aFight(t, alice, []int{1, 1})
+
+	_, err := mgr.Activate(context.Background(), &session.ActivateInput{
+		Session: "sess", Member: "alice",
+	})
+	require.ErrorIs(t, err, session.ErrNoDeclarationID)
+}
+
+// An ability with no charges left is not AVAILABLE, so its selector never
+// survives regeneration. The refusal a player sees for that is the one Afford
+// already gave them — this is the door agreeing with the panel.
+func TestAnUnavailableAbilityCannotBeActivated(t *testing.T) {
+	alice := ragingBarbarian("alice", 0)
+	mgr, _, _, chars := aFight(t, alice, []int{1, 1})
+
+	out, err := mgr.Afford(context.Background(), &session.AffordInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	var id string
+	for _, d := range out.Declarations {
+		if d.Verb == session.VerbActivate && d.Ability != nil && d.Ability.Ref == "dnd5e:features:rage" {
+			require.False(t, d.Available)
+			id = d.ID
+		}
+	}
+	require.NotEmpty(t, id, "a refused offer still carries its selector")
+
+	_, err = mgr.Activate(context.Background(), &session.ActivateInput{
+		Session: "sess", Member: "alice", DeclarationID: id,
+	})
+	require.ErrorIs(t, err, session.ErrStaleDeclaration)
+	// AND NOTHING MOVED. A refusal that had already spent the bonus action
+	// would be the worst of both.
+	require.NotContains(t, storedConditionRefs(t, chars, "alice"), "dnd5e:conditions:raging")
+}
+
+func TestActivateRefusesANilInput(t *testing.T) {
+	alice := ragingBarbarian("alice", 2)
+	mgr, _, _, _ := aFight(t, alice, []int{1, 1})
+
+	_, err := mgr.Activate(context.Background(), nil)
+	require.ErrorIs(t, err, session.ErrNilInput)
+}

--- a/rulebooks/dnd5e/session/activate_test.go
+++ b/rulebooks/dnd5e/session/activate_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resources"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
 	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
@@ -301,4 +302,34 @@ func TestAMonsterCannotActivate(t *testing.T) {
 	})
 
 	require.ErrorIs(t, err, session.ErrNotACharacter)
+}
+
+// THE OTHER HALF OF THE SPLIT. ErrCannotActivate is an ability saying no;
+// this is a call nobody could run, and the two must not be reachable from one
+// another — a developer chasing ErrBadActivation must never be handed a
+// barbarian who is simply out of rages, and a player must never be told their
+// rage is malformed.
+//
+// Rage takes no target. Naming one is refused rather than ignored, because a
+// target quietly dropped is a client that believes it aimed somewhere and a
+// server that knows better.
+func TestAMalformedActivationIsNotAnAbilityRefusing(t *testing.T) {
+	alice, bob := ragingBarbarian("alice", 2), ragingBarbarian("bob", 2)
+	mgr, _ := aTwoPlayerFight(t, alice, bob)
+
+	ctx := context.Background()
+	turn, err := mgr.Turn(ctx, &session.TurnInput{Session: "sess", Member: "alice"})
+	require.NoError(t, err)
+	active := string(turn.Active)
+
+	id := activationSelector(t, mgr, active, "dnd5e:features:rage")
+	_, err = mgr.Activate(ctx, &session.ActivateInput{
+		Session: "sess", Member: active, DeclarationID: id, Target: "bob",
+	})
+
+	require.ErrorIs(t, err, session.ErrBadActivation)
+	require.NotErrorIs(t, err, session.ErrCannotActivate)
+	// And the inner module's sentinel does not ride along — the translation
+	// uses %v, so a host never sees resolution's vocabulary.
+	require.NotErrorIs(t, err, resolution.ErrBadActivation)
 }

--- a/rulebooks/dnd5e/session/activate_test.go
+++ b/rulebooks/dnd5e/session/activate_test.go
@@ -287,3 +287,18 @@ func TestActivatingOnSomebodyElsesTurnIsRefused(t *testing.T) {
 	require.ErrorIs(t, err, session.ErrNotYourTurn)
 	require.NotContains(t, storedConditionRefs(t, chars, idle), "dnd5e:conditions:raging")
 }
+
+// A monster is IN the roster and still cannot declare: its abilities are
+// driven by behaviour rather than chosen, and its economy belongs to whoever
+// runs its turn rather than to its sheet. The refusal names that rather than
+// saying the member is missing, because the member is right there.
+func TestAMonsterCannotActivate(t *testing.T) {
+	alice := ragingBarbarian("alice", 2)
+	mgr, _, _, _ := aFight(t, alice, []int{1, 1})
+
+	_, err := mgr.Activate(context.Background(), &session.ActivateInput{
+		Session: "sess", Member: "skeleton", DeclarationID: "v1.any-selector-at-all",
+	})
+
+	require.ErrorIs(t, err, session.ErrNotACharacter)
+}

--- a/rulebooks/dnd5e/session/attack.go
+++ b/rulebooks/dnd5e/session/attack.go
@@ -422,6 +422,14 @@ func translateResolution(err error) error {
 		// Reporting it as "out of actions" would send whoever debugs it to a
 		// player's sheet to look for a bug that is in the code.
 		return fmt.Errorf("%w: %v", ErrBadCost, err)
+	case errors.Is(err, resolution.ErrActivationRefused):
+		// The activation half of the same split, and the same argument: an
+		// ability that said no is a fact about the game, and its own words
+		// ("no rage uses remaining") ride along so the refusal is something a
+		// client can say out loud.
+		return fmt.Errorf("%w: %v", ErrCannotActivate, err)
+	case errors.Is(err, resolution.ErrBadActivation):
+		return fmt.Errorf("%w: %v", ErrBadActivation, err)
 	case errors.Is(err, resolution.ErrOutOfRange):
 		return fmt.Errorf("%w: %v", ErrOutOfReach, err)
 	case errors.Is(err, resolution.ErrBadParticipant):

--- a/rulebooks/dnd5e/session/errors.go
+++ b/rulebooks/dnd5e/session/errors.go
@@ -336,6 +336,23 @@ var (
 	// sentinel changing meaning.
 	ErrDowned = errors.New("member is downed")
 
+	// ErrCannotActivate is returned when an ability could have run and said
+	// no: the charges are gone, the barbarian is already raging, the fighter is
+	// at full hit points.
+	//
+	// THE PLAYER-FACING ONE, and it is separate from ErrBadActivation for the
+	// reason ErrCannotAfford is separate from ErrBadCost: an actor who cannot
+	// do this right now wants a different verb, and wiring that is wrong wants
+	// a developer. A single sentinel would send the first one looking at the
+	// wrong sheet. The ability's own words ride along as text, so the message
+	// still names what ran out.
+	ErrCannotActivate = errors.New("ability cannot be activated")
+
+	// ErrBadActivation is returned when an activation nobody could run reaches
+	// this seam — no ability named, a target on an ability that takes none, a
+	// member the interaction never received. Content or wiring being wrong.
+	ErrBadActivation = errors.New("activation is invalid")
+
 	// ErrBadAttack is returned when an attack cannot be compiled from the
 	// attacker's own sheet or shared persisted definition — an empty hand,
 	// malformed declared action, or a weapon the strike has no semantics for.

--- a/rulebooks/dnd5e/session/go.mod
+++ b/rulebooks/dnd5e/session/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.1
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.16.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.17.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/session/go.sum
+++ b/rulebooks/dnd5e/session/go.sum
@@ -22,8 +22,8 @@ github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0 h1:LxEJMtm4M3
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/behavior v0.1.0/go.mod h1:Y5eXfAAyQ0N4Sp07T5C7MxD2CwAwdAUi2zo5SyN60Ds=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0 h1:t44TeeJm7Fkc8Ra72E2YH+OcvM2LC0PF6hHcrxNdq1g=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.16.0 h1:34LGnMfKw+GMBxWbUc97mxOZHreE4V/N5xLAd5TOpxQ=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.16.0/go.mod h1:4yhOFZrX9cZ+1hDIi/SZt/Hyrqw2L6X3soA41Nyk5DM=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.17.0 h1:N3faLTXSbQpIPa2MarhwmP2lPPnQAeywn4acURTwHlY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/resolution v0.17.0/go.mod h1:4yhOFZrX9cZ+1hDIi/SZt/Hyrqw2L6X3soA41Nyk5DM=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0/go.mod h1:3SZFDKtQWXwplGyRfUDSsdrGH25Etkm62BdZig0Q3rY=
 github.com/cyberphone/json-canonicalization v0.0.0-20241213102144-19d51d7fe467 h1:uX1JmpONuD549D73r6cgnxyUu18Zb7yHAy5AYU0Pm4Q=

--- a/rulebooks/dnd5e/session/sentinels_test.go
+++ b/rulebooks/dnd5e/session/sentinels_test.go
@@ -128,6 +128,16 @@ var resolutionSentinels = map[string]error{
 	"resolution.ErrCannotPay": resolution.ErrCannotPay,
 	"resolution.ErrBadCost":   resolution.ErrBadCost,
 	"resolution.ErrNoPayer":   resolution.ErrNoPayer,
+	// The activation pair, added with the verb that made them reachable
+	// (rpg-project#300), and split the same way for the same reason:
+	// ErrActivationRefused is what a PLAYER produces (no charges, already
+	// raging) and ErrBadActivation is wiring being wrong. Both are listed
+	// because an unlisted sentinel reaching a host is a leak whether or not
+	// anybody wrote an arm — Manager.Activate translates both to this
+	// package's own vocabulary with %v, so neither is in the chain a host
+	// sees.
+	"resolution.ErrActivationRefused": resolution.ErrActivationRefused,
+	"resolution.ErrBadActivation":     resolution.ErrBadActivation,
 }
 
 // refSentinels is core's identifier vocabulary — what a malformed ref is
@@ -206,6 +216,8 @@ var sessionSentinels = map[string]error{
 	"ErrNoSheet":          session.ErrNoSheet,
 	"ErrDowned":           session.ErrDowned,
 	"ErrBadAttack":        session.ErrBadAttack,
+	"ErrCannotActivate":   session.ErrCannotActivate,
+	"ErrBadActivation":    session.ErrBadActivation,
 	"ErrOutOfReach":       session.ErrOutOfReach,
 	"ErrCannotAfford":     session.ErrCannotAfford,
 	"ErrBadCost":          session.ErrBadCost,

--- a/rulebooks/dnd5e/session/translate_internal_test.go
+++ b/rulebooks/dnd5e/session/translate_internal_test.go
@@ -116,6 +116,29 @@ func TestTranslateResolutionLetsNoResolutionSentinelThrough(t *testing.T) {
 		// split one layer further out (rpg-toolkit#1097).
 		{"a price nobody could be charged", resolution.ErrBadCost, ErrBadCost},
 		{"a payer this cast cannot charge", resolution.ErrNoPayer, ErrBadCost},
+		// The activation pair, split for the economy pair's reason and worth
+		// the same note about what each can actually be reached by.
+		//
+		// ErrBadActivation IS reachable from a caller: Manager.Activate passes
+		// Target through, and naming one for an ability that takes none is
+		// refused at the machine's preflight. Driven end to end by
+		// TestAMalformedActivationIsNotAnAbilityRefusing.
+		{"an activation nobody could run", resolution.ErrBadActivation, ErrBadActivation},
+		// ErrActivationRefused is NOT reachable through Manager.Activate today,
+		// and saying so is better than implying a path. Afford consults the same
+		// gates ActivateAbility does, so an unavailable ability is refused as a
+		// stale selector before the sheet is ever asked; the one combat ability
+		// with a precondition beyond the economy is Help, whose missing target
+		// the machine catches first as ErrBadActivation.
+		//
+		// The arm exists anyway, and not as a placeholder. The sheet's contract
+		// genuinely answers refusals as (output{Success:false}, nil), so a verb
+		// that assumed the two gates always agree would report a refusal as a
+		// SUCCESSFUL activation that did nothing. This is that assumption
+		// declined, and it is tested here rather than through a scenario
+		// because inventing one would mean building a disagreement that does
+		// not exist.
+		{"an ability that said no", resolution.ErrActivationRefused, ErrCannotActivate},
 		// Defects here rather than in the call, and unreachable for that
 		// reason.
 		{"no input at all", resolution.ErrNilInput, ErrNilInput},


### PR DESCRIPTION
The executing half of **rpg-project#300**. #1270 offers the seven; this is the verb that runs one. Last toolkit piece — rpg-api is next.

## A refusal is an error, never a field

The rulebook underneath answers every refusal as a **successful call carrying a false**: "not in combat", "unknown ability", "no rage uses remaining". This verb does not propagate that shape.

| refusal | comes back as |
|---|---|
| the ability said no | `ErrCannotActivate`, with the ability's own words attached |
| the activation was malformed | `ErrBadActivation` |

That split is `ErrCannotAfford` / `ErrBadCost`'s, for exactly its reason: one wants a different verb, the other wants a developer. A single sentinel would send the first one looking at the wrong sheet.

## Nothing is charged at the door

`resolution.Input.Cost` stays **nil**, and it is a constraint rather than an omission. The ability spends its own slot, so a `Cost` alongside would charge the same ledger twice and the second charge would look exactly like the first. This is the one executing verb at this seam that does not pay at the door, and it is not free — said in the verb's doc so the next person does not helpfully add one.

## The selector *is* the ability

`ActivateInput` takes no ability ref. One verb compiles one offer per thing the member carries, so the selector names the row rather than the verb — and a caller naming the ability itself would be deciding something Afford already decided, with two answers free to disagree.

## The test that matters reads storage

`TestRagingSurvivesTheRoundTripToStorage` asserts on what the **repository holds** — not the returned value, and not the sheet the call just acted on.

That is not fussiness. Rage does not attach its own condition: it publishes one and the owner's `SheetKeeper` applies it. A version of this test that read back the object it had just acted on **would pass with the bus missing entirely**, because `Rage.Activate` mutates resource state either way.

It is also the assertion #294 and #295 could not write, because nothing could create the condition in the first place.

## Mutation testing earned its keep here

Three mutants, and **two survived the first pass**:

| mutant | first pass | after |
|---|---|---|
| dirty sheets never saved | killed by 4 | — |
| **downed gate removed** | **survived** | killed by `TestADownedMemberCannotActivate` |
| **not-your-turn gate removed** | **survived** | killed by `TestActivatingOnSomebodyElsesTurnIsRefused` |
| monster gate inverted | (added after) | killed by `TestAMonsterCannotActivate` |

The turn one is the bad one. **Nothing in a declaration selector encodes the round**, so bob's own offer, taken on bob's own turn, regenerates identically on alice's. Without that gate the selector validates and the rage lands out of turn.

Neither gate was wrong. Both were written from the pattern Attack and Move keep, and copied faithfully enough that nobody thought to test them — which is the point: a gate that is correct and unpinned is one refactor away from being neither.

## Known gap, named rather than shipped quietly

**An activation records no story beat.** Other players will not see "Standre flies into a rage" in the log; they will see the condition on his sheet. There is no `EventActivated` kind, and adding one is a proto change with its own ruling, so it is not smuggled in here. Filed as a follow-up on #300 rather than left for someone to notice.

## Evidence

Session suite green, including under `-race`. `sentinels_test`'s AST allow-list caught both new sentinels on the way through, which is that file doing exactly its job — and both `resolution` sentinels are registered as inner ones that must not leak (the translation uses `%v`, so neither is in the chain a host sees).

— platform agent, on behalf of KirkDiggler
