### PR TITLE
fix(dnd5e): Disengage publishes its condition so it reaches the sheet

### DIFF
--- a/rulebooks/dnd5e/character/activation_persists_test.go
+++ b/rulebooks/dnd5e/character/activation_persists_test.go
@@ -1,0 +1,104 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/stretchr/testify/suite"
+)
+
+// ActivationPersistsTestSuite is the test rpg-toolkit#1272 needed and did not
+// have: it asks what an activation leaves ON THE SHEET, not what it does to a
+// bus.
+//
+// Disengage shipped applying its condition directly to the interaction's bus.
+// Every test it had passed — the condition really did suppress opportunity
+// attacks, right up until the bus was torn down at the end of the call. Nothing
+// asked whether the character was still disengaging afterwards, so nothing
+// noticed that the answer was no.
+type ActivationPersistsTestSuite struct {
+	suite.Suite
+	ctx context.Context
+	bus events.EventBus
+}
+
+func TestActivationPersistsSuite(t *testing.T) {
+	suite.Run(t, new(ActivationPersistsTestSuite))
+}
+
+func (s *ActivationPersistsTestSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+}
+
+func (s *ActivationPersistsTestSuite) sheet() *Data {
+	return &Data{
+		ID: "persist-fighter", PlayerID: "p1", Name: "Persist",
+		Level: 3, ProficiencyBonus: 2,
+		RaceID: races.Human, ClassID: classes.Fighter,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, abilities.DEX: 14, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 8,
+		},
+		HitPoints: 24, MaxHitPoints: 28, ArmorClass: 16,
+	}
+}
+
+// activated loads a character ONTO THE BUS (which is what attaches its keeper),
+// puts it on a turn, activates one ability, and hands back the sheet as it
+// would be written.
+func (s *ActivationPersistsTestSuite) activated(ability *core.Ref) *Data {
+	char, err := LoadFromData(s.ctx, s.sheet(), s.bus)
+	s.Require().NoError(err)
+
+	_, err = char.StartTurn(s.ctx, &StartTurnInput{TurnNumber: 1, Speed: 30})
+	s.Require().NoError(err)
+
+	// ONE ability per sheet. Both of these cost the action, so activating a
+	// second on the same turn would come back "no actions remaining" and the
+	// test would be reading an empty condition list for the wrong reason.
+	out, err := char.ActivateAbility(s.ctx, &ActivateAbilityInput{AbilityRef: ability})
+	s.Require().NoError(err)
+	s.Require().True(out.Success, "activation must succeed: %s", out.Error)
+
+	return char.ToData()
+}
+
+func conditionRefs(data *Data) []string {
+	out := make([]string, 0, len(data.Conditions))
+	for _, raw := range data.Conditions {
+		var envelope struct {
+			Ref string `json:"ref"`
+		}
+		if err := json.Unmarshal(raw, &envelope); err != nil {
+			continue
+		}
+		out = append(out, envelope.Ref)
+	}
+	return out
+}
+
+// THE REGRESSION. Before rpg-toolkit#1272 this came back empty: Disengage
+// applied its own condition to the bus, the keeper never heard a
+// ConditionAppliedEvent, and the sheet was written without it.
+func (s *ActivationPersistsTestSuite) TestDisengagingReachesTheSheet() {
+	s.Contains(conditionRefs(s.activated(refs.CombatAbilities.Disengage())), "dnd5e:conditions:disengaging")
+}
+
+// The control, and the reason the bug was findable at all: Dodge has always
+// published, so it has always persisted. Two abilities three files apart
+// behaving differently is what the sweep below now prevents.
+func (s *ActivationPersistsTestSuite) TestDodgingReachesTheSheet() {
+	s.Contains(conditionRefs(s.activated(refs.CombatAbilities.Dodge())), "dnd5e:conditions:dodging")
+}

--- a/rulebooks/dnd5e/combatabilities/disengage.go
+++ b/rulebooks/dnd5e/combatabilities/disengage.go
@@ -100,12 +100,27 @@ func (d *Disengage) Activate(ctx context.Context, owner core.Entity, input Comba
 		return err
 	}
 
-	// Apply the DisengagingCondition. The condition subscribes to
-	// MovementChain (adds OAPreventionSources when the owner moves) and
-	// TurnEndTopic (self-removes when the owner's turn ends).
+	// PUBLISHED, NEVER APPLIED DIRECTLY (rpg-toolkit#1272). The condition
+	// subscribes to MovementChain (adds OAPreventionSources when the owner
+	// moves) and TurnEndTopic (self-removes when the owner's turn ends) — but
+	// only the OWNER'S SheetKeeper, listening on ConditionAppliedTopic, records
+	// it ON THE CHARACTER so it reaches ToData and the repository.
+	//
+	// This used to call condition.Apply(ctx, input.Bus) itself. That put the
+	// condition on the interaction's bus and nowhere else, and per ADR-0038
+	// nothing survives a resolution — so Disengage spent the action, reported
+	// success, and protected nobody from anything, because the next move is a
+	// different interaction with a different bus. Dodge, three files away, has
+	// always published; the two now agree.
 	condition := conditions.NewDisengagingCondition(owner.GetID())
-	if err := condition.Apply(ctx, input.Bus); err != nil {
-		return fmt.Errorf("failed to apply disengaging condition: %w", err)
+	topic := dnd5eEvents.ConditionAppliedTopic.On(input.Bus)
+	if err := topic.Publish(ctx, dnd5eEvents.ConditionAppliedEvent{
+		Target:    owner,
+		Type:      dnd5eEvents.ConditionDisengaging,
+		Source:    dnd5eEvents.ConditionSourceCombatAbility,
+		Condition: condition,
+	}); err != nil {
+		return fmt.Errorf("failed to publish disengaging condition: %w", err)
 	}
 
 	// Telemetry event for the game server. The condition is already

--- a/rulebooks/dnd5e/combatabilities/disengage_test.go
+++ b/rulebooks/dnd5e/combatabilities/disengage_test.go
@@ -41,6 +41,23 @@ func (s *DisengageAbilityTestSuite) SetupTest() {
 	s.disengage = combatabilities.NewDisengage("test-disengage")
 }
 
+// listenAsTheOwnerWould stands in for the owner's SheetKeeper: the thing that
+// subscribes to ConditionAppliedTopic and applies whatever arrives.
+//
+// It is here because rpg-toolkit#1272 moved Disengage from applying its own
+// condition to PUBLISHING one, and that is the whole point of the fix — only a
+// listener records a condition on the character, so only a published condition
+// survives the interaction. A suite with no listener could not tell the two
+// apart, which is precisely why the bug shipped: this test passed while
+// Disengage protected nobody in production.
+func (s *DisengageAbilityTestSuite) listenAsTheOwnerWould() {
+	_, err := dnd5eEvents.ConditionAppliedTopic.On(s.bus).Subscribe(s.ctx,
+		func(ctx context.Context, event dnd5eEvents.ConditionAppliedEvent) error {
+			return event.Condition.Apply(ctx, s.bus)
+		})
+	s.Require().NoError(err)
+}
+
 func (s *DisengageAbilityTestSuite) TestNewDisengage_Properties() {
 	// Assert
 	s.Assert().Equal("test-disengage", s.disengage.GetID())
@@ -144,6 +161,7 @@ func (s *DisengageAbilityTestSuite) TestActivate_PublishesDisengageActivatedEven
 // the condition to the bus so the suppression mechanism activates.
 func (s *DisengageAbilityTestSuite) TestActivate_AppliesDisengagingCondition_OASuppressed() {
 	// Arrange
+	s.listenAsTheOwnerWould()
 	err := s.disengage.Activate(s.ctx, s.owner, combatabilities.CombatAbilityInput{
 		ActionEconomy: s.actionEconomy,
 		Bus:           s.bus,

--- a/rulebooks/dnd5e/combatabilities/publishes_conditions_test.go
+++ b/rulebooks/dnd5e/combatabilities/publishes_conditions_test.go
@@ -1,0 +1,133 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package combatabilities_test
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNothingAppliesAConditionToTheBusItself is the structural guard
+// rpg-toolkit#1272 exists to install.
+//
+// # The bug it prevents
+//
+// A condition reaches a CHARACTER only through ConditionAppliedTopic: the
+// owner's SheetKeeper subscribes to it, applies what arrives, and records it so
+// ToData writes it down. An ability that calls condition.Apply(ctx, input.Bus)
+// itself skips all of that. The condition works — on the interaction's bus,
+// for the length of one call — and then ADR-0038 tears the bus down and it is
+// gone. Nothing errors. Nothing logs. The sheet is written without it.
+//
+// Disengage shipped that way and did nothing for a player: you spent your
+// action and still provoked, because the next move is a different interaction
+// with a different bus. Step of the Wind's disengage branch had the identical
+// line. Two out of two occurrences in the module were bugs, which is the ratio
+// that makes this worth pinning structurally rather than by example.
+//
+// # Why AST rather than a test per ability
+//
+// A behavioural test proves one ability publishes. This proves NO ability
+// applies — including the one somebody adds next year by copying the file that
+// still looked reasonable. The tests that missed the original bug were not
+// missing, they were asking the wrong question: they drove the condition on a
+// bare bus, where a direct Apply and a publish-with-listener are
+// indistinguishable.
+func TestNothingAppliesAConditionToTheBusItself(t *testing.T) {
+	// Both packages that author activations, scanned together: the defect
+	// appeared once in each, and a guard installed in only one of them would
+	// have caught only half of it.
+	dirs := []string{".", "../features"}
+
+	var offenders []string
+	for _, dir := range dirs {
+		paths, err := filepath.Glob(filepath.Join(dir, "*.go"))
+		require.NoError(t, err)
+
+		for _, path := range paths {
+			if strings.HasSuffix(path, "_test.go") {
+				continue
+			}
+			file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+			require.NoError(t, err, "parse %s", path)
+
+			for _, decl := range file.Decls {
+				fn, ok := decl.(*ast.FuncDecl)
+				if !ok || fn.Body == nil {
+					continue
+				}
+				offenders = append(offenders, appliedConditionsIn(path, fn)...)
+			}
+		}
+	}
+
+	require.Empty(t, offenders,
+		"an ability must PUBLISH its condition on ConditionAppliedTopic, never apply it "+
+			"to the bus itself — a directly applied condition never reaches the owner's "+
+			"sheet and dies with the interaction (rpg-toolkit#1272)")
+}
+
+// appliedConditionsIn finds, within one function, every value built by a
+// conditions.NewX constructor that then has Apply called on it.
+//
+// Narrow ON PURPOSE. A feature's own Apply method — SecondWind.Apply,
+// ActionSurge.Apply — delegates to a recoverable resource so it recovers on a
+// rest, which is attachment rather than a condition being applied and is
+// entirely correct. An earlier draft of this guard flagged both, and a guard
+// that cries wolf gets deleted by the third person who trips over it.
+func appliedConditionsIn(path string, fn *ast.FuncDecl) []string {
+	built := map[string]bool{}
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok {
+			return true
+		}
+		for i, rhs := range assign.Rhs {
+			call, ok := rhs.(*ast.CallExpr)
+			if !ok || i >= len(assign.Lhs) {
+				continue
+			}
+			selector, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				continue
+			}
+			pkg, ok := selector.X.(*ast.Ident)
+			if !ok || pkg.Name != "conditions" || !strings.HasPrefix(selector.Sel.Name, "New") {
+				continue
+			}
+			if name, ok := assign.Lhs[i].(*ast.Ident); ok {
+				built[name.Name] = true
+			}
+		}
+		return true
+	})
+	if len(built) == 0 {
+		return nil
+	}
+
+	var found []string
+	ast.Inspect(fn.Body, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		selector, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || selector.Sel.Name != "Apply" {
+			return true
+		}
+		receiver, ok := selector.X.(*ast.Ident)
+		if !ok || !built[receiver.Name] {
+			return true
+		}
+		found = append(found, path+": "+fn.Name.Name+" applies "+receiver.Name)
+		return true
+	})
+	return found
+}

--- a/rulebooks/dnd5e/combatabilities/publishes_conditions_test.go
+++ b/rulebooks/dnd5e/combatabilities/publishes_conditions_test.go
@@ -83,6 +83,12 @@ func TestNothingAppliesAConditionToTheBusItself(t *testing.T) {
 // entirely correct. An earlier draft of this guard flagged both, and a guard
 // that cries wolf gets deleted by the third person who trips over it.
 func appliedConditionsIn(path string, fn *ast.FuncDecl) []string {
+	// Two shapes reach the same bug, and an earlier draft of this guard only
+	// caught the first — Copilot's finding on #1273. A guard with a loophole is
+	// worse than none, because it is read as coverage.
+	//
+	//   cond := conditions.NewX(...); cond.Apply(ctx, bus)   // via a local
+	//   conditions.NewX(...).Apply(ctx, bus)                 // chained
 	built := map[string]bool{}
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
 		assign, ok := n.(*ast.AssignStmt)
@@ -90,16 +96,7 @@ func appliedConditionsIn(path string, fn *ast.FuncDecl) []string {
 			return true
 		}
 		for i, rhs := range assign.Rhs {
-			call, ok := rhs.(*ast.CallExpr)
-			if !ok || i >= len(assign.Lhs) {
-				continue
-			}
-			selector, ok := call.Fun.(*ast.SelectorExpr)
-			if !ok {
-				continue
-			}
-			pkg, ok := selector.X.(*ast.Ident)
-			if !ok || pkg.Name != "conditions" || !strings.HasPrefix(selector.Sel.Name, "New") {
+			if i >= len(assign.Lhs) || !isConditionConstructor(rhs) {
 				continue
 			}
 			if name, ok := assign.Lhs[i].(*ast.Ident); ok {
@@ -108,9 +105,6 @@ func appliedConditionsIn(path string, fn *ast.FuncDecl) []string {
 		}
 		return true
 	})
-	if len(built) == 0 {
-		return nil
-	}
 
 	var found []string
 	ast.Inspect(fn.Body, func(n ast.Node) bool {
@@ -122,12 +116,35 @@ func appliedConditionsIn(path string, fn *ast.FuncDecl) []string {
 		if !ok || selector.Sel.Name != "Apply" {
 			return true
 		}
-		receiver, ok := selector.X.(*ast.Ident)
-		if !ok || !built[receiver.Name] {
-			return true
+
+		switch receiver := selector.X.(type) {
+		case *ast.Ident:
+			if built[receiver.Name] {
+				found = append(found, path+": "+fn.Name.Name+" applies "+receiver.Name)
+			}
+		case *ast.CallExpr:
+			// The chained form. No local ever exists, so nothing above sees it.
+			if isConditionConstructor(receiver) {
+				found = append(found, path+": "+fn.Name.Name+" applies a condition inline")
+			}
 		}
-		found = append(found, path+": "+fn.Name.Name+" applies "+receiver.Name)
 		return true
 	})
 	return found
+}
+
+// isConditionConstructor reports whether an expression is a conditions.NewX
+// call — the one thing that makes an Apply below it a bug rather than a
+// feature attaching its own recoverable resource.
+func isConditionConstructor(expr ast.Expr) bool {
+	call, ok := expr.(*ast.CallExpr)
+	if !ok {
+		return false
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	return ok && pkg.Name == "conditions" && strings.HasPrefix(selector.Sel.Name, "New")
 }

--- a/rulebooks/dnd5e/events/events.go
+++ b/rulebooks/dnd5e/events/events.go
@@ -74,6 +74,13 @@ const (
 	// Attackers have disadvantage against the character and the character has
 	// advantage on DEX saves, until the start of the character's next turn.
 	ConditionDodging ConditionType = "dodging"
+
+	// ConditionDisengaging is applied when a character takes the Disengage
+	// action, or a monk spends Step of the Wind on it. It arrives late
+	// (rpg-toolkit#1272) because Disengage applied its condition directly to
+	// the bus instead of publishing one, so there was never an event to
+	// name — which is exactly why the condition never reached a sheet.
+	ConditionDisengaging ConditionType = "disengaging"
 	// ConditionHidden is applied when a character successfully hides
 	// (a Stealth check beating observers' passive Perception). Grants
 	// advantage on the hidden character's attacks and disadvantage on

--- a/rulebooks/dnd5e/features/step_of_the_wind.go
+++ b/rulebooks/dnd5e/features/step_of_the_wind.go
@@ -111,9 +111,21 @@ func (s *StepOfTheWind) Activate(ctx context.Context, owner core.Entity, input F
 		// branch stays event-only; Dash itself doesn't suppress OAs in
 		// 5e, and the Dash action is not part of Wave 2.11e's scope.
 		if action == "disengage" {
+			// Published rather than applied, for Disengage's reason
+			// (rpg-toolkit#1272): a direct Apply reaches the interaction's bus
+			// and never the owner's sheet, so the condition dies with the call.
+			// Not reachable by a player yet — Step of the Wind is monk level 2
+			// — and fixed here anyway, because leaving one copy of a defect
+			// behind is how it comes back.
 			condition := conditions.NewDisengagingCondition(owner.GetID())
-			if err := condition.Apply(ctx, input.Bus); err != nil {
-				return rpgerr.Wrapf(err, "failed to apply disengaging condition")
+			topic := dnd5eEvents.ConditionAppliedTopic.On(input.Bus)
+			if err := topic.Publish(ctx, dnd5eEvents.ConditionAppliedEvent{
+				Target:    owner,
+				Type:      dnd5eEvents.ConditionDisengaging,
+				Source:    dnd5eEvents.ConditionSourceFeature,
+				Condition: condition,
+			}); err != nil {
+				return rpgerr.Wrapf(err, "failed to publish disengaging condition")
 			}
 		}
 

--- a/rulebooks/dnd5e/features/step_of_the_wind_test.go
+++ b/rulebooks/dnd5e/features/step_of_the_wind_test.go
@@ -217,7 +217,20 @@ func (s *StepOfTheWindTestSuite) TestActivate_FailsWhenNoKi() {
 // owner on input.Bus so the next MovementChain for the owner emits an
 // OAPreventionSources entry. Without this, monks using Step of the Wind
 // would take OAs when moving past enemies — breaking the playable goal.
+// listenAsTheOwnerWould stands in for the owner's SheetKeeper — see the twin
+// helper in combatabilities/disengage_test.go and rpg-toolkit#1272. Step of the
+// Wind's disengage branch publishes now rather than applying directly, so the
+// condition reaches the owner's sheet instead of dying with the bus.
+func (s *StepOfTheWindTestSuite) listenAsTheOwnerWould() {
+	_, err := dnd5eEvents.ConditionAppliedTopic.On(s.bus).Subscribe(s.ctx,
+		func(ctx context.Context, event dnd5eEvents.ConditionAppliedEvent) error {
+			return event.Condition.Apply(ctx, s.bus)
+		})
+	s.Require().NoError(err)
+}
+
 func (s *StepOfTheWindTestSuite) TestActivate_DisengageBranch_AppliesDisengagingCondition() {
+	s.listenAsTheOwnerWould()
 	err := s.feature.Activate(s.ctx, s.accessor, features.FeatureInput{
 		Bus:    s.bus,
 		Action: "disengage",


### PR DESCRIPTION
Closes #1272. **Disengage did nothing.**

Found by an rpg-api acceptance test written for rpg-project#300 — a player activates Disengage through the real service, the call succeeds, and the stored sheet has no conditions at all.

## The defect

```go
condition := conditions.NewDisengagingCondition(owner.GetID())
condition.Apply(ctx, input.Bus)      // ← reaches the bus, and nothing else
```

A condition reaches a **character** only through `ConditionAppliedTopic`: the owner's `SheetKeeper` subscribes to it, applies what arrives, and records it so `ToData` writes it down. A direct `Apply` skips all of that. It works — on that bus, for the length of one call — and then ADR-0038 tears the bus down and it is gone.

So a player spent their action, the server said yes, and they **still provoked opportunity attacks on their next move**, because that move is a different interaction with a different bus. Dodge, three files away, has always published. The two agree now.

`step_of_the_wind.go`'s disengage branch had the identical line. Monk level 2, not reachable yet, fixed anyway — leaving one copy of a defect behind is how it comes back.

## Why it shipped: the old tests were asking the wrong question

Both existing tests failed the moment the fix landed, and that is the diagnosis rather than a complication. They drove the condition on a **bare bus with nothing subscribed**, where a direct `Apply` and a publish-with-listener are indistinguishable:

```
--- FAIL: TestActivate_AppliesDisengagingCondition_OASuppressed
    DisengagingCondition must add OAPreventionSources after Disengage.Activate
```

They now stand a `listenAsTheOwnerWould()` helper in for the keeper, which is what makes the publish observable — and what makes the two cases different at all.

## Two new tests, deliberately different in kind

**`ActivationPersistsTestSuite`** asks what an activation leaves **on the sheet** rather than what it does to a bus. That is the question nothing was asking, and it is the whole reason the bug was invisible.

**`TestNothingAppliesAConditionToTheBusItself`** walks the AST of both packages that author activations and fails on any condition applied rather than published. **Two out of two occurrences in this module were bugs** — that ratio is what makes it worth pinning structurally instead of by example, and it catches the copy somebody makes next year from a file that still looks reasonable.

The guard is narrow on purpose: it only flags values built by a `conditions.New*` constructor. An earlier draft flagged `SecondWind.Apply` and `ActionSurge.Apply` — which delegate to a recoverable resource so it recovers on a rest, entirely correct — and a guard that cries wolf gets deleted by the third person who trips over it.

## Evidence

Restoring the original line fails **both** new tests, independently:

| restored bug | caught by |
|---|---|
| `condition.Apply(ctx, input.Bus)` | `TestDisengagingReachesTheSheet` (behavioural) |
| same | `TestNothingAppliesAConditionToTheBusItself` (structural) |

`ConditionDisengaging` joins the `ConditionType` vocabulary. It arrives late because there was never an event to name — which is the same fact as the bug.

Full `rulebooks/dnd5e` suite green.

— platform agent, on behalf of KirkDiggler
