### PR TITLE
feat(session): Help offers the ally standing next to you

### DIFF
--- a/rulebooks/dnd5e/session/activate_test.go
+++ b/rulebooks/dnd5e/session/activate_test.go
@@ -191,6 +191,18 @@ func aTwoPlayerFight(
 	t *testing.T, alice, bob *character.Data,
 ) (*session.Manager, *fakeCharacters) {
 	t.Helper()
+	// (1,1) and (5,5) — deliberately far apart, so the default fixture has
+	// nobody within Help's reach. aTwoPlayerFightAt places them on purpose.
+	return aTwoPlayerFightAt(t, alice, spatial.Position{X: 1, Y: 1}, bob, spatial.Position{X: 5, Y: 5})
+}
+
+// aTwoPlayerFightAt is aTwoPlayerFight with the seating chosen, for the tests
+// that are about who is standing next to whom.
+func aTwoPlayerFightAt(
+	t *testing.T, alice *character.Data, aliceAt spatial.Position,
+	bob *character.Data, bobAt spatial.Position,
+) (*session.Manager, *fakeCharacters) {
+	t.Helper()
 	sessions, encounters := newFakeSessions(), newFakeEncounters()
 	chars := newFakeCharacters(alice, bob)
 	mgr, err := session.NewManager(&session.Config{
@@ -209,9 +221,9 @@ func aTwoPlayerFight(
 		},
 		Members: []encounter.MemberInput{
 			{ID: encounter.MemberID(alice.ID), Kind: encounter.KindPlayer,
-				Position: spatial.Position{X: 1, Y: 1}},
+				Position: aliceAt},
 			{ID: encounter.MemberID(bob.ID), Kind: encounter.KindPlayer,
-				Position: spatial.Position{X: 5, Y: 5}},
+				Position: bobAt},
 		},
 		Endings:   []encounter.EndingInput{{Key: "withdrawn", Trigger: encounter.TriggerExternal{}}},
 		Retention: encounter.RetentionUnbounded,

--- a/rulebooks/dnd5e/session/activations.go
+++ b/rulebooks/dnd5e/session/activations.go
@@ -7,8 +7,11 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/KirkDiggler/rpg-toolkit/play/intel"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 )
 
 // buildActivationOffers compiles one offer per thing this member can activate.
@@ -43,7 +46,12 @@ import (
 // about Dodge on the turns it could Dodge would have a menu that changes size
 // as the turn goes on.
 func (m *Manager) buildActivationOffers(
-	session, member string, sheet *character.Character,
+	enc *encounter.Encounter,
+	session, member string,
+	sheet *character.Character,
+	roster []encounter.Member,
+	positions map[string]spatial.Position,
+	holdings []intel.Holding,
 ) ([]compiledOffer, error) {
 	available := sheet.AvailableAbilities()
 	economy := sheet.GetActionEconomy()
@@ -80,6 +88,29 @@ func (m *Manager) buildActivationOffers(
 		if !ability.CanUse {
 			why := activationWhy(ability, slot, economy)
 			declaration.Why = &why
+		}
+
+		// THE ONE THAT TAKES SOMEBODY. Help is the only level-1 activation
+		// with TargetMember, and a declaration that says it needs a target
+		// while carrying no candidate universe is a control nothing can
+		// drive — the client would arm targeting against an empty list.
+		if declaration.TargetKind == TargetMember {
+			allies, err := helpCandidates(enc, roster, positions, holdings, member)
+			if err != nil {
+				return nil, err
+			}
+			declaration.Candidates = projectCandidates(allies)
+
+			// The same precedence Attack keeps: a budget refusal outranks
+			// "nobody to help", and no-one-in-reach does not erase the rows.
+			if declaration.Available && !anyAvailable(allies) {
+				noAlly := Shortfall{
+					Reason: ShortfallNoTargetInReach,
+					Text:   "no ally within reach",
+				}
+				declaration.Available = false
+				declaration.Why = &noAlly
+			}
 		}
 
 		offers = append(offers, compiledOffer{
@@ -220,4 +251,98 @@ func targetKindOfAbility(kind character.TargetKind) TargetKind {
 	default:
 		return TargetNone
 	}
+}
+
+// helpReachFeet is how far Help reaches: an adjacent ally, one cell.
+//
+// Kirk's ruling (rpg-project#300): *"I think that ally next to us is fine. we
+// can add complexity later if we want."* RAW 2014 is fiddlier — it aids an
+// ability check at any range, or an ally attacking a creature within 5 feet of
+// YOU, which is a constraint about where the enemy stands rather than the
+// friend. Both are deliberately not built: "stand next to a friend and help
+// them" is one sentence a player already understands, and the divergence is
+// named here rather than discovered.
+const helpReachFeet = 5
+
+// helpCandidates is Help's candidate universe: allies this member can
+// currently see, standing, within reach.
+//
+// # Allies are members of the same kind
+//
+// A player helps a player; a monster would help a monster. That is the whole
+// of hostility this seam has — encounter.Member carries Kind and nothing
+// finer — and it is correct for the game as it stands rather than a
+// simplification with a cost. A rulebook that grows factions replaces this
+// one predicate.
+//
+// # Live sightings only, like Attack's
+//
+// Built from the same holdings Attack's candidates are, so a member the actor
+// cannot currently see is not offered as one they can help. A ghost is not an
+// ally you can reach out and steady.
+//
+// A candidate that is out of reach keeps its ROW with its own reason, the way
+// Attack's do: the panel shows who is there and why they cannot be helped,
+// rather than a list that changes length as people move.
+func helpCandidates(
+	enc *encounter.Encounter,
+	roster []encounter.Member,
+	positions map[string]spatial.Position,
+	holdings []intel.Holding,
+	member string,
+) ([]targetPreflight, error) {
+	kinds := make(map[string]encounter.MemberKind, len(roster))
+	for _, r := range roster {
+		kinds[string(r.ID)] = r.Kind
+	}
+	own, ok := kinds[member]
+	if !ok {
+		return nil, fmt.Errorf("help offers: actor %q is not in the roster", member)
+	}
+
+	from, ok := positions[member]
+	if !ok {
+		// The same fail-closed law buildTargetPreflight keeps: an actor the
+		// encounter no longer places is an internal inconsistency, not a
+		// shorter candidate list.
+		return nil, fmt.Errorf("help offers: actor %q has no position in the roster", member)
+	}
+
+	seen := make([]string, 0, len(holdings))
+	for _, h := range holdings {
+		subject := string(h.Subject)
+		if subject == member || len(h.CurrentVia) == 0 {
+			continue
+		}
+		if kinds[subject] != own {
+			continue
+		}
+		seen = append(seen, subject)
+	}
+	sort.Strings(seen)
+
+	out := make([]targetPreflight, 0, len(seen))
+	for _, id := range seen {
+		to, ok := positions[id]
+		if !ok {
+			return nil, fmt.Errorf("help offers: live candidate %q has no position in the roster", id)
+		}
+		if inRange(enc, from, to, helpReachFeet) {
+			out = append(out, targetPreflight{member: id, available: true})
+			continue
+		}
+		why := Shortfall{Reason: ShortfallTargetOutOfReach, Text: "ally out of reach"}
+		out = append(out, targetPreflight{member: id, available: false, why: &why})
+	}
+	return out, nil
+}
+
+// anyAvailable reports whether any candidate can actually be chosen.
+func anyAvailable(candidates []targetPreflight) bool {
+	for _, c := range candidates {
+		if c.available {
+			return true
+		}
+	}
+	return false
 }

--- a/rulebooks/dnd5e/session/activations.go
+++ b/rulebooks/dnd5e/session/activations.go
@@ -47,6 +47,7 @@ import (
 // as the turn goes on.
 func (m *Manager) buildActivationOffers(
 	enc *encounter.Encounter,
+	standing encounter.Standing,
 	session, member string,
 	sheet *character.Character,
 	roster []encounter.Member,
@@ -95,7 +96,7 @@ func (m *Manager) buildActivationOffers(
 		// while carrying no candidate universe is a control nothing can
 		// drive — the client would arm targeting against an empty list.
 		if declaration.TargetKind == TargetMember {
-			allies, err := helpCandidates(enc, roster, positions, holdings, member)
+			allies, err := helpCandidates(enc, standing, roster, positions, holdings, member)
 			if err != nil {
 				return nil, err
 			}
@@ -281,11 +282,25 @@ const helpReachFeet = 5
 // cannot currently see is not offered as one they can help. A ghost is not an
 // ally you can reach out and steady.
 //
-// A candidate that is out of reach keeps its ROW with its own reason, the way
-// Attack's do: the panel shows who is there and why they cannot be helped,
-// rather than a list that changes length as people move.
+// # Standing, UNLIKE Attack's — and the difference is the rule, not an
+// inconsistency
+//
+// Attack's candidates deliberately include the downed: attacking an
+// unconscious creature is legal 5e, and the seam would be wrong to hide one.
+// Helping one is meaningless — there is no action for them to take advantage
+// on — so a body is offered with a reason rather than as a choice.
+//
+// The consult is over THE ALLY CANDIDATES ONLY, never the roster. Standing
+// loads a sheet per member it is asked about, and this read runs on every
+// Afford; asking about the two party members in sight is a cost worth paying,
+// asking about every skeleton in the dungeon is not.
+//
+// A candidate that is out of reach or down keeps its ROW with its own reason,
+// the way Attack's do: the panel shows who is there and why they cannot be
+// helped, rather than a list that changes length as people move.
 func helpCandidates(
 	enc *encounter.Encounter,
+	standing encounter.Standing,
 	roster []encounter.Member,
 	positions map[string]spatial.Position,
 	holdings []intel.Holding,
@@ -321,18 +336,31 @@ func helpCandidates(
 	}
 	sort.Strings(seen)
 
+	ids := make([]encounter.MemberID, 0, len(seen))
+	for _, id := range seen {
+		ids = append(ids, encounter.MemberID(id))
+	}
+	down, err := standingSet(standing, ids)
+	if err != nil {
+		return nil, fmt.Errorf("help offers: %w", err)
+	}
+
 	out := make([]targetPreflight, 0, len(seen))
 	for _, id := range seen {
 		to, ok := positions[id]
 		if !ok {
 			return nil, fmt.Errorf("help offers: live candidate %q has no position in the roster", id)
 		}
-		if inRange(enc, from, to, helpReachFeet) {
+		switch {
+		case down[id]:
+			why := Shortfall{Reason: ShortfallDowned, Text: "ally is down"}
+			out = append(out, targetPreflight{member: id, available: false, why: &why})
+		case inRange(enc, from, to, helpReachFeet):
 			out = append(out, targetPreflight{member: id, available: true})
-			continue
+		default:
+			why := Shortfall{Reason: ShortfallTargetOutOfReach, Text: "ally out of reach"}
+			out = append(out, targetPreflight{member: id, available: false, why: &why})
 		}
-		why := Shortfall{Reason: ShortfallTargetOutOfReach, Text: "ally out of reach"}
-		out = append(out, targetPreflight{member: id, available: false, why: &why})
 	}
 	return out, nil
 }

--- a/rulebooks/dnd5e/session/activations_test.go
+++ b/rulebooks/dnd5e/session/activations_test.go
@@ -283,3 +283,28 @@ func TestARefusedHelpKeepsItsSelector(t *testing.T) {
 	require.NotEmpty(t, help.ID)
 	require.Equal(t, "Help", help.Ability.Name)
 }
+
+// A BODY IS NOT SOMEBODY YOU CAN HELP, and this is where Help deliberately
+// differs from Attack: Attack's candidates include the downed, because
+// attacking an unconscious creature is legal 5e. There is no action for a
+// downed ally to take advantage on, so they are offered with a reason rather
+// than as a choice.
+func TestHelpOffersADownedAllyWithAReasonRatherThanAsAChoice(t *testing.T) {
+	alice, bob := ragingBarbarian("alice", 2), ragingBarbarian("bob", 2)
+	mgr, chars := aTwoPlayerFightAt(t, alice, spatial.Position{X: 1, Y: 1},
+		bob, spatial.Position{X: 2, Y: 1})
+
+	// Adjacent and in sight — everything except conscious.
+	chars.byID["bob"].HitPoints = 0
+
+	help := helpOffer(t, mgr, "alice")
+
+	require.Len(t, help.Candidates, 1, "a body keeps its row")
+	require.Equal(t, "bob", help.Candidates[0].Member)
+	require.False(t, help.Candidates[0].Available)
+	require.NotNil(t, help.Candidates[0].Why)
+	require.Equal(t, session.ShortfallDowned, help.Candidates[0].Why.Reason)
+
+	require.False(t, help.Available, "nobody left to help")
+	require.Equal(t, session.ShortfallNoTargetInReach, help.Why.Reason)
+}

--- a/rulebooks/dnd5e/session/activations_test.go
+++ b/rulebooks/dnd5e/session/activations_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/session"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/weapons"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
 	"github.com/stretchr/testify/require"
 )
 
@@ -197,4 +198,88 @@ func TestARefusedActivationKeepsItsRow(t *testing.T) {
 	require.NotEmpty(t, rage.ID, "a compiled-but-refused offer still carries its selector")
 	require.NotNil(t, rage.Ability, "and still says what it is")
 	require.Equal(t, "Rage", rage.Ability.Name)
+}
+
+// --- Help's candidate universe (rpg-project#300, Kirk's ruling) ---
+
+func helpOffer(t *testing.T, mgr *session.Manager, member string) session.Declaration {
+	t.Helper()
+	out, err := mgr.Afford(context.Background(), &session.AffordInput{
+		Session: "sess", Member: member,
+	})
+	require.NoError(t, err)
+	for _, d := range out.Declarations {
+		if d.Verb == session.VerbActivate &&
+			d.Ability != nil && d.Ability.Ref == "dnd5e:combat_abilities:help" {
+			return d
+		}
+	}
+	t.Fatal("no Help offer")
+	return session.Declaration{}
+}
+
+// AN ALLY STANDING NEXT TO YOU IS SOMEBODY YOU CAN HELP. Kirk's ruling: "I
+// think that ally next to us is fine. we can add complexity later if we want."
+func TestHelpOffersTheAllyStandingNextToYou(t *testing.T) {
+	alice, bob := ragingBarbarian("alice", 2), ragingBarbarian("bob", 2)
+	mgr, _ := aTwoPlayerFightAt(t, alice, spatial.Position{X: 1, Y: 1},
+		bob, spatial.Position{X: 2, Y: 1})
+
+	help := helpOffer(t, mgr, "alice")
+
+	require.True(t, help.Available)
+	require.Len(t, help.Candidates, 1)
+	require.Equal(t, "bob", help.Candidates[0].Member)
+	require.True(t, help.Candidates[0].Available)
+}
+
+// An ally across the room KEEPS HIS ROW and says why, the way Attack's
+// candidates do — the panel shows who is there and why they cannot be helped,
+// rather than a list that changes length as people move.
+func TestHelpKeepsAnOutOfReachAllyAsARowWithAReason(t *testing.T) {
+	alice, bob := ragingBarbarian("alice", 2), ragingBarbarian("bob", 2)
+	mgr, _ := aTwoPlayerFightAt(t, alice, spatial.Position{X: 1, Y: 1},
+		bob, spatial.Position{X: 5, Y: 5})
+
+	help := helpOffer(t, mgr, "alice")
+
+	require.Len(t, help.Candidates, 1)
+	require.Equal(t, "bob", help.Candidates[0].Member)
+	require.False(t, help.Candidates[0].Available)
+	require.NotNil(t, help.Candidates[0].Why)
+	require.Equal(t, session.ShortfallTargetOutOfReach, help.Candidates[0].Why.Reason)
+
+	// And the declaration itself goes dark with the declaration-level reason —
+	// the same precedence Attack keeps.
+	require.False(t, help.Available)
+	require.NotNil(t, help.Why)
+	require.Equal(t, session.ShortfallNoTargetInReach, help.Why.Reason)
+}
+
+// A MONSTER IS NOT AN ALLY. Same-kind is the whole of hostility this seam has,
+// and it is what keeps a barbarian from offering to steady a skeleton.
+func TestHelpDoesNotOfferAMonsterAsAnAlly(t *testing.T) {
+	alice := ragingBarbarian("alice", 2)
+	mgr, _, _, _ := aFight(t, alice, []int{1, 1})
+
+	help := helpOffer(t, mgr, "alice")
+
+	// The skeleton spawned adjacent to her is in reach and in sight, and is
+	// still not a candidate.
+	require.Empty(t, help.Candidates, "a monster is never a Help candidate")
+	require.False(t, help.Available)
+	require.Equal(t, session.ShortfallNoTargetInReach, help.Why.Reason)
+}
+
+// Help still carries its selector when it is dark, like every other refused
+// offer — so a client renders a disabled button rather than dropping the row.
+func TestARefusedHelpKeepsItsSelector(t *testing.T) {
+	alice := ragingBarbarian("alice", 2)
+	mgr, _, _, _ := aFight(t, alice, []int{1, 1})
+
+	help := helpOffer(t, mgr, "alice")
+
+	require.False(t, help.Available)
+	require.NotEmpty(t, help.ID)
+	require.Equal(t, "Help", help.Ability.Name)
 }

--- a/rulebooks/dnd5e/session/offers.go
+++ b/rulebooks/dnd5e/session/offers.go
@@ -222,7 +222,7 @@ func (m *Manager) compileOffersFor(
 	if requested[VerbActivate] {
 		var err error
 		activations, err = m.buildActivationOffers(
-			enc, sessionID, member, sheet, roster, positions, holdings,
+			enc, m.standingFor(ctx, data), sessionID, member, sheet, roster, positions, holdings,
 		)
 		if err != nil {
 			return nil, err

--- a/rulebooks/dnd5e/session/offers.go
+++ b/rulebooks/dnd5e/session/offers.go
@@ -195,10 +195,35 @@ func (m *Manager) compileOffersFor(
 	// blocker and a compiled offer, scaled by a verb that compiles more than
 	// one: a member whose sheet will not load has no abilities to enumerate,
 	// so there is nothing to emit N of.
+	// The roster, its positions, and this member's own sighted holdings —
+	// hoisted here because BOTH Attack and Activate need them now: Attack for
+	// its candidate universe, Help for its own (rpg-project#300).
+	//
+	// GUARDED, so EndTurn stays clock-only. That property is documented and
+	// tested ("EndTurn remains clock-only when that actor is downed or
+	// unreadable"), and reading a roster it does not need would quietly end it.
+	var (
+		roster    []encounter.Member
+		positions map[string]spatial.Position
+		holdings  []intel.Holding
+	)
+	if requested[VerbAttack] || requested[VerbActivate] {
+		var err error
+		if roster, err = enc.Members(); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrBadCost, translate(err))
+		}
+		positions = rosterPositions(roster)
+		if holdings, err = enc.View(&encounter.ViewInput{Member: encounter.MemberID(member)}); err != nil {
+			return nil, fmt.Errorf("%w: %v", ErrBadCost, translate(err))
+		}
+	}
+
 	var activations []compiledOffer
 	if requested[VerbActivate] {
 		var err error
-		activations, err = m.buildActivationOffers(sessionID, member, sheet)
+		activations, err = m.buildActivationOffers(
+			enc, sessionID, member, sheet, roster, positions, holdings,
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -262,17 +287,6 @@ func (m *Manager) compileOffersFor(
 	if !budgetOK {
 		sf := shortfallForPay(sheet, definition.Cost, slot)
 		budgetWhy = &sf
-	}
-
-	roster, err := enc.Members()
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrBadCost, translate(err))
-	}
-	positions := rosterPositions(roster)
-
-	holdings, err := enc.View(&encounter.ViewInput{Member: encounter.MemberID(member)})
-	if err != nil {
-		return nil, fmt.Errorf("%w: %v", ErrBadCost, translate(err))
 	}
 
 	candidates, err := m.targetPreflight(enc, positions, holdings, member, definition.Attack.Delivery.MaxRangeFeet())


### PR DESCRIPTION
Kirk's ruling on rpg-project#300: *"I think that ally next to us is fine. we can add complexity later if we want."*

## The gap this closes was mine

Help's declaration said `TARGET_KIND_MEMBER` and carried **no candidate universe** — I built it that way in #1270. A declaration that says it needs a target while offering no list of *who* is a control nothing can drive, and the panel (rpg-dnd5e-web#835) declines to render it for exactly that reason. Help is the one of the seven a player cannot reach.

## Three deliberate choices

**Allies are members of the same kind.** A player helps a player. That is the whole of hostility this seam has — `encounter.Member` carries `Kind` and nothing finer — and it is correct for the game as it stands rather than a simplification with a cost. A rulebook that grows factions replaces one predicate.

**Live sightings only**, built from the same holdings Attack's candidates are. A ghost is not an ally you can reach out and steady.

**An out-of-reach ally keeps his row** with his own reason, and the declaration goes dark with `NO_TARGET_IN_REACH` — the same precedence Attack keeps. A panel shows who is there and why they cannot be helped, rather than a list that changes length as people move.

## The divergence from RAW, named rather than discovered

2014 Help aids an ability check at any range, *or* aids an ally attacking a creature within 5 feet of **you** — a constraint about where the *enemy* stands, not the friend. Neither is built. "Stand next to a friend and help them" is one sentence a player already understands, and Kirk ruled complexity can come later.

## The one structural change

`enc.Members()`, `rosterPositions` and `enc.View` are hoisted so Attack and Help share them — **guarded by `requested[VerbAttack] || requested[VerbActivate]`** so EndTurn stays clock-only. That property is documented and tested (*"EndTurn remains clock-only when that actor is downed or unreadable"*), and reading a roster it does not need would quietly end it.

## Evidence

Four new tests: the adjacent ally is offered and available; the far ally keeps his row with `TARGET_OUT_OF_REACH` while the declaration reports `NO_TARGET_IN_REACH`; **a monster adjacent and in plain sight is not a candidate**; and a refused Help still carries its selector and name, so a client renders a disabled button rather than dropping the row.

The two-player fixture gained a seated variant — the default deliberately places nobody within Help's reach, which is why the out-of-reach case is the one that works without arranging anything.

Full session suite green.

— platform agent, on behalf of KirkDiggler