### PR TITLE
fix(dnd5e): EffectiveAC refuses rather than guesses

### DIFF
--- a/rulebooks/dnd5e/character/character.go
+++ b/rulebooks/dnd5e/character/character.go
@@ -1370,8 +1370,33 @@ func calculateShieldAC(shieldItem *armor.Armor) combat.ACComponent {
 	}
 }
 
-// EffectiveAC calculates the character's armor class with detailed breakdown
-func (c *Character) EffectiveAC(ctx context.Context) *combat.ACBreakdown {
+// EffectiveAC calculates the character's armor class with detailed breakdown.
+//
+// # It refuses rather than guesses
+//
+// The fold rides the bus parked on the sheet, so a sheet that was never
+// attached has no subscribers and every AC contributor is silently absent —
+// Unarmored Defense, the fighting styles, Shield. The number that comes back
+// from that is not a smaller answer, it is a WRONG one, and it is wrong in the
+// most plausible direction there is: exactly base armour, which reads like a
+// character who simply has no features.
+//
+// That is how a monk fought at 10+DEX with Unarmored Defense attached and
+// nobody noticed, and it is the same shape as rpg-api#842. So an unattached
+// sheet is an error here, not a fallback. Chain failures are returned for the
+// same reason: this used to swallow both the publish and the execute error and
+// return whatever the breakdown happened to hold, which meant a broken
+// contributor degraded the total instead of failing the read.
+//
+// Callers holding a sheet from the bus-free [Load] must [Attach] it before
+// asking. A stat block that has no chain to fold wants [Character.AC].
+func (c *Character) EffectiveAC(ctx context.Context) (*combat.ACBreakdown, error) {
+	if c.bus == nil {
+		return nil, rpgerr.New(rpgerr.CodePrerequisiteNotMet,
+			"effective AC needs an attached sheet: this character is on no bus, "+
+				"so every condition and feature that contributes AC is absent")
+	}
+
 	breakdown := &combat.ACBreakdown{
 		Total:      0,
 		Components: []combat.ACComponent{},
@@ -1435,13 +1460,14 @@ func (c *Character) EffectiveAC(ctx context.Context) *combat.ACBreakdown {
 	acTopic := combat.ACChain.On(c.bus)
 
 	modifiedChain, err := acTopic.PublishWithChain(ctx, acEvent, acChain)
-	if err == nil {
-		// Execute chain to get final AC with all modifiers
-		finalEvent, err := modifiedChain.Execute(ctx, acEvent)
-		if err == nil {
-			breakdown = finalEvent.Breakdown
-		}
+	if err != nil {
+		return nil, rpgerr.Wrapf(err, "publish AC chain for character %s", c.id)
 	}
 
-	return breakdown
+	finalEvent, err := modifiedChain.Execute(ctx, acEvent)
+	if err != nil {
+		return nil, rpgerr.Wrapf(err, "fold AC chain for character %s", c.id)
+	}
+
+	return finalEvent.Breakdown, nil
 }

--- a/rulebooks/dnd5e/character/effective_ac_attached_test.go
+++ b/rulebooks/dnd5e/character/effective_ac_attached_test.go
@@ -1,0 +1,130 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// EffectiveACAttachmentSuite pins EffectiveAC's two refusals.
+//
+// They are different failures and it is worth not conflating them, because the
+// first is the one everybody assumes and the second is the one that actually
+// cost us a wrong AC in production:
+//
+//  1. NO BUS AT ALL. Folding a chain on a nil bus PANICS — verified by
+//     mutation: disabling the guard turns these tests into a nil-bus panic, not
+//     a quiet 13. So this guard converts a crash in a read path into a typed
+//     error. It is not preventing a silent wrong answer; there was never a
+//     silent answer to prevent here.
+//
+//  2. A CONTRIBUTOR THAT FAILS MID-FOLD. This is the silent one. EffectiveAC
+//     used to discard both the publish and the execute error and return
+//     whatever the breakdown held, so one broken contributor degraded the total
+//     to base armour with nothing in the call stack saying so — how a monk
+//     fought at 10+DEX with Unarmored Defense attached. Those errors are now
+//     returned.
+//
+// Both halves of (1) matter. The refusal is only meaningful if the same sheet,
+// once attached, actually produces the higher number; otherwise these would
+// pass against an EffectiveAC that had simply been broken.
+type EffectiveACAttachmentSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func (s *EffectiveACAttachmentSuite) SetupTest() { s.ctx = context.Background() }
+
+// monkData is a level-1 monk with Unarmored Defense persisted the way the
+// class grant writes it: DEX 16 (+3) and WIS 14 (+2), wearing nothing.
+//
+// Correct AC is 15. Base armour is 13. The two differ by the WIS modifier,
+// which is precisely the contribution an unattached sheet loses, so a wrong
+// answer here cannot coincide with the right one.
+func (s *EffectiveACAttachmentSuite) monkData() *Data {
+	ud := conditions.NewUnarmoredDefenseCondition(conditions.UnarmoredDefenseInput{
+		CharacterID: "char-monk",
+		Type:        conditions.UnarmoredDefenseMonk,
+		Source:      "dnd5e:classes:monk",
+	})
+	raw, err := ud.ToJSON()
+	s.Require().NoError(err)
+
+	return &Data{
+		ID:               "char-monk",
+		PlayerID:         "player-1",
+		Name:             "Attachment Monk",
+		Level:            1,
+		ProficiencyBonus: 2,
+		RaceID:           races.Human,
+		ClassID:          classes.Monk,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 12,
+			abilities.DEX: 16, // +3
+			abilities.CON: 14,
+			abilities.INT: 10,
+			abilities.WIS: 14, // +2
+			abilities.CHA: 8,
+		},
+		HitPoints:      9,
+		MaxHitPoints:   9,
+		ArmorClass:     15,
+		EquipmentSlots: EquipmentSlots{},
+		Conditions:     []json.RawMessage{raw},
+	}
+}
+
+// A bus-free Load is the shape rpg-api and the session SDK both reach for when
+// they only want to read static facts off a sheet. Asking THAT sheet for an
+// effective AC used to panic on the nil bus; it is now refused by name.
+func (s *EffectiveACAttachmentSuite) TestUnattachedSheetRefusesEffectiveAC() {
+	loaded, err := Load(s.ctx, s.monkData())
+	s.Require().NoError(err)
+
+	breakdown, acErr := loaded.EffectiveAC(s.ctx)
+
+	s.Require().Error(acErr, "an unattached sheet must refuse by name rather than panic on its nil bus")
+	s.Assert().Nil(breakdown, "a refused read returns no breakdown to be mistaken for an answer")
+}
+
+// The other half: attached, the very same bytes fold Unarmored Defense and
+// report 15. Without this, a permanently-erroring EffectiveAC would pass above.
+func (s *EffectiveACAttachmentSuite) TestAttachedSheetFoldsUnarmoredDefense() {
+	loaded, err := Load(s.ctx, s.monkData())
+	s.Require().NoError(err)
+	s.Require().NoError(Attach(s.ctx, loaded, events.NewEventBus()))
+
+	breakdown, acErr := loaded.EffectiveAC(s.ctx)
+
+	s.Require().NoError(acErr)
+	s.Require().NotNil(breakdown)
+	s.Assert().Equal(15, breakdown.Total, "10 base + 3 DEX + 2 WIS (Unarmored Defense)")
+}
+
+// EquipmentView carries a folded AC, so it inherits the refusal rather than
+// reporting base armour in a display the player reads as authoritative.
+func (s *EffectiveACAttachmentSuite) TestUnattachedSheetRefusesEquipmentView() {
+	loaded, err := Load(s.ctx, s.monkData())
+	s.Require().NoError(err)
+
+	view, viewErr := loaded.EquipmentView(s.ctx)
+
+	s.Require().Error(viewErr)
+	s.Assert().Nil(view)
+}
+
+func TestEffectiveACAttachmentSuite(t *testing.T) {
+	suite.Run(t, new(EffectiveACAttachmentSuite))
+}

--- a/rulebooks/dnd5e/character/effective_ac_test.go
+++ b/rulebooks/dnd5e/character/effective_ac_test.go
@@ -46,7 +46,8 @@ func (s *EffectiveACTestSuite) TestUnarmoredCharacter() {
 	}
 
 	// Calculate AC
-	breakdown := char.EffectiveAC(s.ctx)
+	breakdown, acErr := char.EffectiveAC(s.ctx)
+	s.Require().NoError(acErr)
 
 	// Verify total AC = 10 + 2 = 12
 	s.Assert().Equal(12, breakdown.Total, "Unarmored AC should be 10 + DEX modifier")
@@ -89,7 +90,8 @@ func (s *EffectiveACTestSuite) TestHeavyArmor() {
 	char.equipmentSlots.Set(SlotArmor, armor.ChainMail)
 
 	// Calculate AC
-	breakdown := char.EffectiveAC(s.ctx)
+	breakdown, acErr := char.EffectiveAC(s.ctx)
+	s.Require().NoError(acErr)
 
 	// Verify total AC = 16 (no DEX bonus for heavy armor)
 	s.Assert().Equal(16, breakdown.Total, "Heavy armor AC should not include DEX")
@@ -161,7 +163,8 @@ func (s *EffectiveACTestSuite) TestMediumArmorDexCap() {
 			char.equipmentSlots.Set(SlotArmor, armor.ScaleMail)
 
 			// Calculate AC
-			breakdown := char.EffectiveAC(s.ctx)
+			breakdown, acErr := char.EffectiveAC(s.ctx)
+			s.Require().NoError(acErr)
 
 			// Verify total AC
 			s.Assert().Equal(tc.expectedTotal, breakdown.Total,
@@ -207,7 +210,8 @@ func (s *EffectiveACTestSuite) TestLightArmor() {
 	char.equipmentSlots.Set(SlotArmor, armor.Leather)
 
 	// Calculate AC
-	breakdown := char.EffectiveAC(s.ctx)
+	breakdown, acErr := char.EffectiveAC(s.ctx)
+	s.Require().NoError(acErr)
 
 	// Verify total AC = 11 + 4 = 15
 	s.Assert().Equal(15, breakdown.Total, "Light armor AC should include full DEX bonus")
@@ -256,7 +260,8 @@ func (s *EffectiveACTestSuite) TestShieldBonus() {
 	char.equipmentSlots.Set(SlotOffHand, armor.Shield)
 
 	// Calculate AC
-	breakdown := char.EffectiveAC(s.ctx)
+	breakdown, acErr := char.EffectiveAC(s.ctx)
+	s.Require().NoError(acErr)
 
 	// Verify total AC = 11 (armor) + 2 (DEX) + 2 (shield) = 15
 	s.Assert().Equal(15, breakdown.Total, "Shield should add +2 to AC")
@@ -310,7 +315,8 @@ func (s *EffectiveACTestSuite) TestBreakdownTransparency() {
 	char.equipmentSlots.Set(SlotOffHand, armor.Shield)
 
 	// Calculate AC
-	breakdown := char.EffectiveAC(s.ctx)
+	breakdown, acErr := char.EffectiveAC(s.ctx)
+	s.Require().NoError(acErr)
 
 	// Verify total
 	s.Assert().Equal(18, breakdown.Total, "AC should be 16 (armor) + 2 (shield)")
@@ -356,7 +362,8 @@ func (s *EffectiveACTestSuite) TestNoEquipment() {
 	}
 
 	// Calculate AC
-	breakdown := char.EffectiveAC(s.ctx)
+	breakdown, acErr := char.EffectiveAC(s.ctx)
+	s.Require().NoError(acErr)
 
 	// Verify total AC = 10 (base only, no DEX bonus since modifier is 0)
 	s.Assert().Equal(10, breakdown.Total, "Unarmored with no DEX bonus should be 10")
@@ -396,7 +403,8 @@ func (s *EffectiveACTestSuite) TestNegativeDexModifier() {
 	char.equipmentSlots.Set(SlotArmor, armor.Leather)
 
 	// Calculate AC
-	breakdown := char.EffectiveAC(s.ctx)
+	breakdown, acErr := char.EffectiveAC(s.ctx)
+	s.Require().NoError(acErr)
 
 	// Verify total AC = 11 + (-1) = 10
 	s.Assert().Equal(10, breakdown.Total, "Negative DEX should reduce AC")
@@ -438,7 +446,8 @@ func (s *EffectiveACTestSuite) TestNoModifiers() {
 	char.equipmentSlots.Set(SlotArmor, armor.Leather)
 
 	// Calculate AC - should work with event bus but no modifiers
-	breakdown := char.EffectiveAC(s.ctx)
+	breakdown, acErr := char.EffectiveAC(s.ctx)
+	s.Require().NoError(acErr)
 
 	// Verify total AC = 11 + 2 = 13
 	s.Assert().Equal(13, breakdown.Total, "AC calculation should work with no modifiers")

--- a/rulebooks/dnd5e/character/equipment_display.go
+++ b/rulebooks/dnd5e/character/equipment_display.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/armor"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
@@ -83,7 +84,12 @@ type EquipmentView struct {
 // item (equipped or carried), the slot taxonomy, AC total + note, and the
 // resolved main-hand damage display. Consumable by rpg-api with zero
 // rules knowledge.
-func (c *Character) EquipmentView(ctx context.Context) *EquipmentView {
+//
+// Fallible because the AC it carries is folded, not echoed: an unattached sheet
+// cannot produce an effective AC and this refuses rather than displaying base
+// armour as though it were the whole answer. [Character.StatusView] is fallible
+// for the same reason and this now matches it.
+func (c *Character) EquipmentView(ctx context.Context) (*EquipmentView, error) {
 	items := make([]EquippedItemView, 0, len(c.inventory))
 	for _, invItem := range c.inventory {
 		id := invItem.Equipment.EquipmentID()
@@ -97,7 +103,10 @@ func (c *Character) EquipmentView(ctx context.Context) *EquipmentView {
 		})
 	}
 
-	breakdown := c.EffectiveAC(ctx)
+	breakdown, err := c.EffectiveAC(ctx)
+	if err != nil {
+		return nil, rpgerr.Wrap(err, "equipment view needs this character's effective AC")
+	}
 	mainHand := c.GetEquippedSlot(SlotMainHand)
 	return &EquipmentView{
 		Items:          items,
@@ -105,7 +114,7 @@ func (c *Character) EquipmentView(ctx context.Context) *EquipmentView {
 		ACTotal:        breakdown.Total,
 		ACNote:         ACNote(breakdown),
 		MainHandDamage: MainHandDamage(mainHand.AsWeapon(), c.GetEquippedSlot(SlotOffHand)),
-	}
+	}, nil
 }
 
 // slotKeys converts CompatibleSlots' typed InventorySlots into the plain

--- a/rulebooks/dnd5e/character/equipment_display_test.go
+++ b/rulebooks/dnd5e/character/equipment_display_test.go
@@ -186,7 +186,9 @@ func (s *EquipmentDisplayTestSuite) TestEquipmentView() {
 		},
 	}
 
-	view := char.EquipmentView(s.ctx)
+	view, viewErr := char.EquipmentView(s.ctx)
+
+	s.Require().NoError(viewErr)
 	s.Require().NotNil(view)
 	s.Assert().Equal(18, view.ACTotal)
 	s.Assert().Equal("16 chain mail + 2 shield", view.ACNote)
@@ -240,11 +242,15 @@ func (s *EquipmentDisplayTestSuite) TestEquipmentView_SlotsIsDefensiveCopy() {
 		equipmentSlots: make(EquipmentSlots),
 	}
 
-	first := char.EquipmentView(s.ctx)
+	first, viewErr := char.EquipmentView(s.ctx)
+
+	s.Require().NoError(viewErr)
 	first.Slots[0].Accepts[0] = "MUTATED"
 	first.Slots = append(first.Slots, SlotDefView{Key: "mutated_slot"})
 
-	second := char.EquipmentView(s.ctx)
+	second, viewErr := char.EquipmentView(s.ctx)
+
+	s.Require().NoError(viewErr)
 	s.Require().Len(second.Slots, 3)
 	s.Assert().Equal("weapon", second.Slots[0].Accepts[0])
 	s.Assert().Equal([]SlotDefView{
@@ -267,7 +273,9 @@ func (s *EquipmentDisplayTestSuite) TestEquipmentView_CarriedItemHasNoSlot() {
 		equipmentSlots: make(EquipmentSlots),
 	}
 
-	view := char.EquipmentView(s.ctx)
+	view, viewErr := char.EquipmentView(s.ctx)
+
+	s.Require().NoError(viewErr)
 	s.Require().Len(view.Items, 1)
 	s.Assert().Equal(InventorySlot(""), view.Items[0].Slot)
 	s.Assert().Equal("1d6 slashing damage · light, thrown 20/60", view.Items[0].StatLine)
@@ -289,7 +297,9 @@ func (s *EquipmentDisplayTestSuite) TestEquipmentView_SlotlessGear() {
 		equipmentSlots: make(EquipmentSlots),
 	}
 
-	view := char.EquipmentView(s.ctx)
+	view, viewErr := char.EquipmentView(s.ctx)
+
+	s.Require().NoError(viewErr)
 	s.Require().Len(view.Items, 1)
 	s.Assert().Equal("gear", view.Items[0].Kind)
 	s.Assert().Nil(view.Items[0].SlotKeys)
@@ -312,7 +322,9 @@ func (s *EquipmentDisplayTestSuite) TestEquipmentView_VersatileFreeOffHand() {
 		},
 	}
 
-	view := char.EquipmentView(s.ctx)
+	view, viewErr := char.EquipmentView(s.ctx)
+
+	s.Require().NoError(viewErr)
 	s.Assert().Equal("1d10 slashing damage", view.MainHandDamage)
 }
 
@@ -342,7 +354,9 @@ func (s *EquipmentDisplayTestSuite) TestEquipmentView_DualWield() {
 		},
 	}
 
-	view := char.EquipmentView(s.ctx)
+	view, viewErr := char.EquipmentView(s.ctx)
+
+	s.Require().NoError(viewErr)
 	s.Assert().Equal("1d4 piercing damage · off-hand 1d4 piercing damage", view.MainHandDamage)
 }
 

--- a/rulebooks/dnd5e/combat/combatant.go
+++ b/rulebooks/dnd5e/combat/combatant.go
@@ -93,8 +93,8 @@ type Combatant interface {
 type EffectiveACCalculator interface {
 	// EffectiveAC calculates AC through the modifier chain, allowing conditions/spells to adjust it.
 	// Returns an ACBreakdown with the final AC and all contributing components, or an
-	// error when the sheet cannot answer — see [github.com/KirkDiggler/rpg-toolkit/
-	// rulebooks/dnd5e/character.Character.EffectiveAC].
+	// error when the sheet cannot answer — see
+	// [github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character.Character.EffectiveAC].
 	EffectiveAC(ctx context.Context) (*ACBreakdown, error)
 }
 

--- a/rulebooks/dnd5e/combat/combatant.go
+++ b/rulebooks/dnd5e/combat/combatant.go
@@ -92,17 +92,32 @@ type Combatant interface {
 // Combatants that don't implement this will use their base AC() value.
 type EffectiveACCalculator interface {
 	// EffectiveAC calculates AC through the modifier chain, allowing conditions/spells to adjust it.
-	// Returns an ACBreakdown with the final AC and all contributing components.
-	EffectiveAC(ctx context.Context) *ACBreakdown
+	// Returns an ACBreakdown with the final AC and all contributing components, or an
+	// error when the sheet cannot answer — see [github.com/KirkDiggler/rpg-toolkit/
+	// rulebooks/dnd5e/character.Character.EffectiveAC].
+	EffectiveAC(ctx context.Context) (*ACBreakdown, error)
 }
 
 // GetEffectiveAC returns the effective AC for a combatant.
-// If the combatant implements EffectiveACCalculator (like Character), uses the chain-based calculation.
-// Otherwise, returns the base AC() value.
-func GetEffectiveAC(ctx context.Context, c Combatant) int {
-	if calc, ok := c.(EffectiveACCalculator); ok {
-		breakdown := calc.EffectiveAC(ctx)
-		return breakdown.Total
+//
+// A combatant that folds a chain is asked to fold it, and a failure to fold is
+// returned rather than papered over. The old shape fell back to c.AC() on any
+// trouble, which turned "this sheet could not answer" into "this sheet has no
+// features" — a wrong number that looks exactly like a right one. See
+// [EffectiveACCalculator].
+//
+// A combatant that does NOT implement the interface is a different case
+// entirely and keeps its AC(): a monster's stat block AC is a real authored
+// value, not a cached derivation, so reading it is correct rather than a
+// fallback.
+func GetEffectiveAC(ctx context.Context, c Combatant) (int, error) {
+	calc, ok := c.(EffectiveACCalculator)
+	if !ok {
+		return c.AC(), nil
 	}
-	return c.AC()
+	breakdown, err := calc.EffectiveAC(ctx)
+	if err != nil {
+		return 0, err
+	}
+	return breakdown.Total, nil
 }

--- a/rulebooks/dnd5e/integration/monk_encounter_test.go
+++ b/rulebooks/dnd5e/integration/monk_encounter_test.go
@@ -569,7 +569,8 @@ func (s *MonkEncounterSuite) TestUnarmoredDefense_ACChainIncludesWIS() {
 
 		// Verify EffectiveAC includes WIS modifier via the AC chain.
 		// Expected: 10 (base) + 3 (DEX) + 2 (WIS from UnarmoredDefense) = 15
-		breakdown := monk.EffectiveAC(ctx)
+		breakdown, acErr := monk.EffectiveAC(ctx)
+		s.Require().NoError(acErr)
 
 		s.T().Logf("  Monk EffectiveAC breakdown:")
 		s.T().Logf("    Total: %d", breakdown.Total)
@@ -674,7 +675,8 @@ func (s *MonkEncounterSuite) TestUnarmoredDefense_ACChainNeedsNoGameContext() {
 
 		// A completely bare context. No room, no cast, no registry.
 		bareCtx := context.Background()
-		breakdown := monk.EffectiveAC(bareCtx)
+		breakdown, acErr := monk.EffectiveAC(bareCtx)
+		s.Require().NoError(acErr)
 
 		s.T().Logf("  Monk EffectiveAC (bare context):")
 		s.T().Logf("    Total: %d", breakdown.Total)


### PR DESCRIPTION
## What

`EffectiveAC` had two ways to be wrong and neither of them said so. This makes both refuse.

**1. No bus at all → was a panic.** A sheet from the bus-free `Load` has no bus, and folding the AC chain on a nil bus panics — a crash in a plain read path. Now a typed `CodePrerequisiteNotMet` that names the missing attachment.

**2. A contributor that fails mid-fold → was silent.** This is the one that actually cost a wrong number. Both the publish and the execute errors were discarded, so a failing contributor left the breakdown holding base armour with nothing in the call stack saying so. That is how a monk fought at 10+DEX with Unarmored Defense attached (same shape as rpg-api#842). Both errors are now returned.

`GetEffectiveAC` loses its `c.AC()` fallback **for combatants that fold a chain** — that fallback turned "this sheet could not answer" into "this sheet has no features", a wrong number shaped exactly like a right one. A combatant that does *not* implement the interface keeps `AC()`: a monster's stat block AC is an authored value, not a cached derivation, so reading it is correct rather than a fallback.

`EquipmentView` becomes fallible for the same reason, matching the already-fallible `StatusView`, so a display cannot report base armour as the whole answer.

## Why now

Audit of level-1 features found three of six characters in production carrying a base-only AC (monks and barbarians missing their WIS/CON contribution). The formula was never wrong — `armor_class` is a cached scalar with two writers and no recompute-on-read. Kirk ruled AC should be **derived on every read**, with fail-closed as the prerequisite: without it, swapping the read sites would spread base-AC answers everywhere the bus-free `Load` is used instead of confining them to stale rows.

This PR is the prerequisite only. Derive-on-read lands as the modules bump.

## Evidence

- Full `rulebooks/dnd5e` suite green; `golangci-lint` 0 issues; pre-commit hooks passed.
- New `EffectiveACAttachmentSuite` pins both refusals **and** pins that an *attached* sheet still folds Unarmored Defense to 15 — without that half a permanently-broken `EffectiveAC` would pass.
- **Mutation-checked**: disabling the nil-bus guard turns the refusal test into a panic, not a quiet 13. That corrected an overclaim in the test's own doc comment, which had asserted the unattached case was the silent one. It isn't — the swallowed fold error is.

## Downstream

Sub-modules pin `dnd5e` by version and are unaffected until they bump. Bottom-up order:

1. **this PR** — `rulebooks/dnd5e`
2. `resolution` — `strike.go` propagates the new `GetEffectiveAC` error
3. `session` — `entities.go` `projectCharacter` switches to derive-on-read
4. `rpg-api` — equip sites and the v1alpha1 sheet read the derived value

No proto change anywhere in the chain.

— platform agent, on behalf of KirkDiggler
