### PR TITLE
fix(resolution): a target that cannot derive its AC stops the strike

### DIFF
--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.104.0
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.3
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.104.0 h1:2jblZY0C1On+PtUgb02sQrPc2Jk8B6FIYjtLmGYKiZQ=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.104.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.3 h1:FVZ7i4rE4Ke/Rj7/bWtsYfb7lagAcrbnISfc+4Jrlaw=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.3/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0 h1:t44TeeJm7Fkc8Ra72E2YH+OcvM2LC0PF6hHcrxNdq1g=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/resolution/strike.go
+++ b/rulebooks/dnd5e/resolution/strike.go
@@ -215,7 +215,16 @@ func (m *strikeMachine) effectiveACStep(target combat.Combatant, longRange bool)
 			// was built with. Setting only the outcome would report the effective AC
 			// and roll against the flat one — a strike that tells the truth and does
 			// something else. Pinned by TestTheFoldedACDecidesTheHitNotJustTheReport.
-			effectiveAC := combat.GetEffectiveAC(ctx, target)
+			// A target that cannot report its AC stops the strike rather than
+			// being swung at with a guess. combat.GetEffectiveAC used to fall
+			// back to the flat sheet number whenever the fold could not run,
+			// which meant an unattached or broken defender was attacked at base
+			// armour and the log said nothing — the strike would report a
+			// TargetAC it had not actually derived (rpg-toolkit#1276).
+			effectiveAC, err := combat.GetEffectiveAC(ctx, target)
+			if err != nil {
+				return nil, fmt.Errorf("effective AC for target %s: %w", m.in.TargetID, err)
+			}
 
 			m.outcome = StrikeOutcome{
 				AttackerID: m.in.AttackerID,

--- a/rulebooks/dnd5e/resolution/strike_effective_ac_refusal_test.go
+++ b/rulebooks/dnd5e/resolution/strike_effective_ac_refusal_test.go
@@ -1,0 +1,82 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// acRefusingTarget is a defender whose sheet cannot derive an AC — the shape a
+// character loaded off the bus-free Load has.
+//
+// Its AC() deliberately returns a perfectly plausible 13. That number is the
+// whole point: it is what the old fallback would have handed the strike, and it
+// is indistinguishable from a real answer, so a test that only checked "an
+// error happened" would not notice the strike swinging at it anyway.
+type acRefusingTarget struct{ id string }
+
+func (t *acRefusingTarget) GetID() string        { return t.id }
+func (t *acRefusingTarget) GetHitPoints() int    { return 10 }
+func (t *acRefusingTarget) GetMaxHitPoints() int { return 10 }
+func (t *acRefusingTarget) AC() int              { return 13 }
+func (t *acRefusingTarget) ApplyDamage(
+	_ context.Context, _ *combat.ApplyDamageInput,
+) *combat.ApplyDamageResult {
+	return nil
+}
+func (t *acRefusingTarget) IsDirty() bool                       { return false }
+func (t *acRefusingTarget) MarkClean()                          {}
+func (t *acRefusingTarget) AbilityScores() shared.AbilityScores { return shared.AbilityScores{} }
+func (t *acRefusingTarget) ProficiencyBonus() int               { return 2 }
+func (t *acRefusingTarget) PassivePerception() int              { return 10 }
+
+var errNoBus = errors.New("sheet is on no bus")
+
+func (t *acRefusingTarget) EffectiveAC(_ context.Context) (*combat.ACBreakdown, error) {
+	return nil, errNoBus
+}
+
+// A defender that cannot report its AC stops the strike.
+//
+// Before rpg-toolkit#1276, combat.GetEffectiveAC fell back to the flat sheet
+// number whenever the fold could not run, so this target would have been
+// attacked at AC 13 and the outcome would have reported 13 as though it had
+// been derived. The strike now refuses instead.
+//
+// The positive half of this contract is already measured end to end by
+// EffectiveACTestSuite (TestUnarmoredDefenseReachesTheStrike and
+// TestUnarmoredDefenseDecidesTheHit): a defender that CAN fold has the folded
+// number reach the roll. So this test does not need to re-prove that, and a
+// blanket "EffectiveAC always errors" regression could not hide behind it.
+func TestStrikeRefusesATargetThatCannotDeriveAC(t *testing.T) {
+	// attack is populated so the gather can run to completion if it ever stops
+	// refusing. Without it the machine panics further down on a nil profile,
+	// and this test would "pass" on a crash instead of on its own assertions —
+	// verified by mutation: restoring the old target.AC() fallback must fail
+	// HERE, on the outcome, not incidentally somewhere after it.
+	m := &strikeMachine{
+		in:     &StrikeInput{AttackerID: "attacker-1", TargetID: "defender-1"},
+		attack: &combatActions.AttackProfile{AttackBonus: 5},
+	}
+	target := &acRefusingTarget{id: "defender-1"}
+
+	step, err := m.effectiveACStep(target, false).run(context.Background(), events.NewEventBus())
+
+	require.Error(t, err, "a target that cannot derive its AC must stop the strike")
+	require.ErrorIs(t, err, errNoBus, "the defender's own reason must survive to the caller")
+	require.Nil(t, step, "a refused gather yields no step to continue the machine with")
+	require.Contains(t, err.Error(), "defender-1", "the error names which combatant could not answer")
+	require.NotEqual(t, 13, m.outcome.TargetAC,
+		"the strike must not fall back to the flat AC() the old code would have used")
+	require.Zero(t, m.outcome.TargetAC, "a refused read leaves the outcome untouched")
+}


### PR DESCRIPTION
Step 2 of the derive-on-read chain. Follows #1276.

## What

Bumps `rulebooks/dnd5e` to **v0.105.3** (the auto-tag from #1276), where `combat.GetEffectiveAC` returns `(int, error)` instead of silently falling back to the flat sheet number. `strike.go` propagates that error.

This is exactly the break Copilot predicted on #1276 and that PR's description committed to fixing here — it could not compile until #1276 merged and tagged, because `resolution` is a separate module with no `replace` directive.

## Why it matters

The fallback being removed is not cosmetic. A defender whose sheet could not derive an AC was attacked at **base armour**, and the outcome reported that number as `TargetAC` as though it had been derived — the strike told the truth and did something else. This seam already has a pinned test against the mirror-image failure (`TestTheFoldedACDecidesTheHitNotJustTheReport`); this closes the other direction.

## Evidence

`build`, `vet`, `test`, `golangci-lint` (0 issues) all green; pre-commit hooks passed.

The new `TestStrikeRefusesATargetThatCannotDeriveAC` is deliberately built so it cannot pass for the wrong reason:

- Its target's `AC()` returns **13** — precisely the plausible number the old fallback would have supplied — so the assertion is that the strike *did not use it*, not merely that some error occurred.
- Its machine carries an attack profile. Without one, the mutant crashes on a nil profile further down and the test would "pass" on a panic instead of its own assertion.

**Mutation-verified twice.** Restoring the old `effectiveAC = target.AC()` fallback fails the test with `An error is expected but got nil` — on the assertion, not on a crash. The first version of this test only killed the mutant via panic; that was fixed rather than left.

The positive half stays where it already lives: `EffectiveACTestSuite` measures a folding defender end to end (`TestUnarmoredDefenseReachesTheStrike`, `TestUnarmoredDefenseDecidesTheHit`, `TestAMonsterTargetStillReportsItsStatBlockAC`), so a blanket always-errors regression cannot hide behind the new test. All still green.

## Chain

1. ✅ `rulebooks/dnd5e` — #1276, merged, tagged `v0.105.3`
2. ✅ **this PR** — `resolution`
3. `session` — `entities.go` `projectCharacter` reads `ch.AC()` (the cache) and switches to derive; needs a `ctx` threaded
4. `rpg-api` — the two equip sites and the v1alpha1 sheet, which reads `data.ArmorClass`

No proto change anywhere in the chain.

No Copilot round requested: this is a pin bump plus the mechanical adaptation #1276 already specified, and that PR spent the round on the design.

— platform agent, on behalf of KirkDiggler
