### PR TITLE
feat(dnd5e): the opportunity attack meters itself, and characters pay for it

### DIFF
--- a/rulebooks/dnd5e/conditions/opportunity_attack.go
+++ b/rulebooks/dnd5e/conditions/opportunity_attack.go
@@ -9,6 +9,8 @@ import (
 	"errors"
 	"fmt"
 
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+
 	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/core/chain"
 	"github.com/KirkDiggler/rpg-toolkit/events"
@@ -36,6 +38,12 @@ const defaultMeleeReach = 1.0
 type OpportunityAttackConditionData struct {
 	Ref         *core.Ref `json:"ref"`
 	CharacterID string    `json:"character_id"`
+
+	// UsedThisTurn is persisted rather than kept in memory for the reason
+	// SneakAttackData gives for its own copy of this field: every call
+	// reconstructs the condition from JSON, so a runtime-only flag is a flag
+	// that resets on each RPC and meters nothing at all.
+	UsedThisTurn bool `json:"used_this_turn"`
 }
 
 // OpportunityAttackCondition publishes a ReactionTriggerEvent when an enemy
@@ -58,9 +66,36 @@ type OpportunityAttackConditionData struct {
 // Reach defaults to 5ft (1 grid unit). Reach weapons + action-economy reaction
 // availability are future extensions; the predicate is conservative today.
 type OpportunityAttackCondition struct {
-	CharacterID     string
+	CharacterID string
+
+	// UsedThisTurn is the meter EVERY reactor has, character and monster
+	// alike. It is cleared at the start of this reactor's OWN turn, which is
+	// when 5e refreshes a spent reaction — see onTurnStart.
+	UsedThisTurn bool
+
 	bus             events.EventBus
 	subscriptionIDs []string
+
+	// dirty persists a change to UsedThisTurn. Without it the flag updates in
+	// silence and resolution.Resolve discards the update, because it hands
+	// back only participants that report IsDirty (see selfPersisting).
+	dirty selfPersisting
+
+	// purse is the reactor's own action economy, and IS ALLOWED TO BE NIL.
+	//
+	// A *character.Character has one; a monster does not — monsters carry no
+	// action economy in this rulebook at all, so there is no reaction slot for
+	// a gate to read. Kirk ruled 2026-08-28: "characters have to pay for it.
+	// the condition can still track it was used but players have a cost." So
+	// the asymmetry is the rule rather than a hole in it: UsedThisTurn meters
+	// everyone, and the reaction slot is an additional cost only a sheet can
+	// be charged. A purse-less reactor is metered by the flag alone, never
+	// unmetered and never refused for lacking an economy it was never given.
+	//
+	// Paying also keeps OA and Protection fighting style mutually exclusive,
+	// which they are in the rules: both spend the one reaction, and the second
+	// one to ask finds it gone.
+	purse combat.Ledger
 }
 
 // Ensure OpportunityAttackCondition implements dnd5eEvents.ConditionBehavior
@@ -69,6 +104,33 @@ var _ dnd5eEvents.ConditionBehavior = (*OpportunityAttackCondition)(nil)
 // Ref returns the canonical ref this condition names itself by — the same ref
 // its ToJSON embeds and its loader routes on.
 func (o *OpportunityAttackCondition) Ref() *core.Ref { return refs.Conditions.OpportunityAttack() }
+
+// Ensure OpportunityAttackCondition implements dnd5eEvents.OwnerAware
+var _ dnd5eEvents.OwnerAware = (*OpportunityAttackCondition)(nil)
+
+// SetOwner hands this condition its own reactor's live sheet.
+//
+// The two halves are asserted INDEPENDENTLY because they are independently
+// available: every reactor that persists condition state satisfies
+// selfPersisting, while only one with an action economy satisfies
+// combat.Ledger. An owner satisfying neither is not an error — the condition
+// simply meters itself in memory and charges nothing, the same "nothing to do"
+// default every other unmet check here already takes.
+func (o *OpportunityAttackCondition) SetOwner(owner any) {
+	if d, ok := owner.(selfPersisting); ok {
+		o.dirty = d
+	}
+	if p, ok := owner.(combat.Ledger); ok {
+		o.purse = p
+	}
+}
+
+// markDirty records that this condition's persisted meter changed.
+func (o *OpportunityAttackCondition) markDirty() {
+	if o.dirty != nil {
+		o.dirty.MarkDirty()
+	}
+}
 
 // NewOpportunityAttackCondition creates a new OA condition for the given character.
 // The condition is universal for melee combatants and applied programmatically
@@ -99,6 +161,35 @@ func (o *OpportunityAttackCondition) Apply(ctx context.Context, bus events.Event
 		return rpgerr.Wrap(err, "failed to subscribe to movement chain")
 	}
 	o.subscriptionIDs = append(o.subscriptionIDs, subID)
+
+	turnStarts := dnd5eEvents.TurnStartTopic.On(bus)
+	resetID, err := turnStarts.Subscribe(ctx, o.onTurnStart)
+	if err != nil {
+		o.bus = nil
+		return rpgerr.Wrap(err, "failed to subscribe to turn start")
+	}
+	o.subscriptionIDs = append(o.subscriptionIDs, resetID)
+	return nil
+}
+
+// onTurnStart refreshes the spent reaction at the start of the reactor's own
+// turn.
+//
+// TURN START, NOT TURN END, and the difference is the whole point of the
+// field. A reaction is spent on somebody ELSE's turn — that is what makes it a
+// reaction — so a meter cleared at the end of its holder's turn would be full
+// again for the entire window it is supposed to govern. 2014 PHB: "you regain
+// a spent reaction at the start of each of your turns."
+//
+// Only when the flag actually changes, for SneakAttackCondition's stated
+// reason: marking unconditionally would flag every combatant dirty at the
+// start of every turn they did not react on, and a boundary already runs for
+// every participant.
+func (o *OpportunityAttackCondition) onTurnStart(_ context.Context, event dnd5eEvents.TurnStartEvent) error {
+	if event.SubjectID == o.CharacterID && o.UsedThisTurn {
+		o.UsedThisTurn = false
+		o.markDirty()
+	}
 	return nil
 }
 
@@ -125,8 +216,9 @@ func (o *OpportunityAttackCondition) Remove(ctx context.Context, bus events.Even
 // ToJSON converts the condition to its JSON representation.
 func (o *OpportunityAttackCondition) ToJSON() (json.RawMessage, error) {
 	data := OpportunityAttackConditionData{
-		Ref:         refs.Conditions.OpportunityAttack(),
-		CharacterID: o.CharacterID,
+		Ref:          refs.Conditions.OpportunityAttack(),
+		CharacterID:  o.CharacterID,
+		UsedThisTurn: o.UsedThisTurn,
 	}
 	return json.Marshal(data)
 }
@@ -138,6 +230,7 @@ func (o *OpportunityAttackCondition) loadJSON(data json.RawMessage) error {
 		return rpgerr.Wrap(err, "failed to unmarshal opportunity attack data")
 	}
 	o.CharacterID = oaData.CharacterID
+	o.UsedThisTurn = oaData.UsedThisTurn
 	return nil
 }
 
@@ -159,6 +252,18 @@ func (o *OpportunityAttackCondition) onMovementChain(
 
 	// Disengaging (or any other source) prevented OAs for this step.
 	if event.IsOAPrevented() {
+		return c, nil
+	}
+
+	// Already reacted. Cleared at the start of this reactor's own turn.
+	if o.UsedThisTurn {
+		return c, nil
+	}
+
+	// A reactor with a sheet PAYS; one without a purse is metered by
+	// UsedThisTurn alone. See the purse field for why that asymmetry is the
+	// rule rather than a gap.
+	if o.purse != nil && o.purse.SlotsLeft(coreCombat.ActionReaction) <= 0 {
 		return c, nil
 	}
 
@@ -196,6 +301,16 @@ func (o *OpportunityAttackCondition) onMovementChain(
 	}); pubErr != nil {
 		return c, rpgerr.Wrap(pubErr, "failed to publish OA reaction trigger event")
 	}
+
+	// Spend AFTER the publish, never before: a trigger that failed to reach
+	// the orchestrator is a reaction that did not happen, and charging for it
+	// would leave the reactor unable to react to the next mover for a swing
+	// nobody made.
+	o.UsedThisTurn = true
+	if o.purse != nil {
+		o.purse.SpendSlots(coreCombat.ActionReaction, 1)
+	}
+	o.markDirty()
 
 	return c, nil
 }

--- a/rulebooks/dnd5e/conditions/opportunity_attack.go
+++ b/rulebooks/dnd5e/conditions/opportunity_attack.go
@@ -162,10 +162,16 @@ func (o *OpportunityAttackCondition) Apply(ctx context.Context, bus events.Event
 	}
 	o.subscriptionIDs = append(o.subscriptionIDs, subID)
 
+	// Roll the movement subscription back rather than dropping the bus on the
+	// floor, which is what DisengagingCondition does at the same seam and for
+	// the same reason. Nil-ing o.bus with a live subscription still recorded
+	// leaves the WORST of both: IsApplied reports false, Remove early-returns
+	// on the nil bus and unsubscribes nothing, and the orphaned handler keeps
+	// receiving movement on a bus this condition no longer admits to holding.
 	turnStarts := dnd5eEvents.TurnStartTopic.On(bus)
 	resetID, err := turnStarts.Subscribe(ctx, o.onTurnStart)
 	if err != nil {
-		o.bus = nil
+		_ = o.Remove(ctx, bus)
 		return rpgerr.Wrap(err, "failed to subscribe to turn start")
 	}
 	o.subscriptionIDs = append(o.subscriptionIDs, resetID)

--- a/rulebooks/dnd5e/conditions/opportunity_attack_meter_test.go
+++ b/rulebooks/dnd5e/conditions/opportunity_attack_meter_test.go
@@ -6,6 +6,7 @@ package conditions_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"sync"
 	"testing"
 
@@ -67,6 +68,35 @@ func (f *fakeReactor) BankCapacity(_ combat.CapacityType, _ int)    {}
 type purseless struct{ dirtied int }
 
 func (p *purseless) MarkDirty() { p.dirtied++ }
+
+// failAfterBus is a real bus that refuses the Nth subscribe, and remembers
+// every Unsubscribe it was asked for.
+//
+// A wrapper rather than a hand-rolled fake so the SUCCESSFUL subscribes are
+// the genuine article: the point of the test is what happens to a real, live
+// subscription when a later one fails, and a fake that never actually
+// registered anything could not tell a rollback from a no-op.
+type failAfterBus struct {
+	events.EventBus
+	allow        int
+	seen         int
+	unsubscribed []string
+}
+
+func (b *failAfterBus) Subscribe(ctx context.Context, topic events.Topic, handler any) (string, error) {
+	b.seen++
+	if b.seen > b.allow {
+		return "", errRefusedSubscribe
+	}
+	return b.EventBus.Subscribe(ctx, topic, handler)
+}
+
+func (b *failAfterBus) Unsubscribe(ctx context.Context, id string) error {
+	b.unsubscribed = append(b.unsubscribed, id)
+	return b.EventBus.Unsubscribe(ctx, id)
+}
+
+var errRefusedSubscribe = errors.New("bus refused the subscription")
 
 // oaMeterEntity implements core.Entity for room placement.
 type oaMeterEntity struct {
@@ -334,4 +364,30 @@ func (s *OpportunityAttackMeterSuite) TestTheMeterSurvivesTheJSONRoundTrip() {
 	restored, ok := reloaded.(*conditions.OpportunityAttackCondition)
 	s.Require().True(ok, "the loader must route this ref back to an OA condition")
 	s.True(restored.UsedThisTurn, "the meter must survive the load, not just the save")
+}
+
+// A half-applied condition is worse than an unapplied one. Nil-ing the bus with
+// a live subscription still recorded leaves IsApplied reporting false, Remove
+// early-returning and unsubscribing nothing, and the orphaned movement handler
+// still receiving events on a bus the condition no longer admits to holding.
+func (s *OpportunityAttackMeterSuite) TestAFailedSecondSubscribeRollsTheFirstOneBack() {
+	s.place("fighter-1", "character", 5, 5)
+	s.place("wolf-1", "monster", 5, 6)
+
+	// Allow the MovementChain subscribe, refuse the TurnStart one after it.
+	bus := &failAfterBus{EventBus: s.bus, allow: 1}
+
+	oa := conditions.NewOpportunityAttackCondition("fighter-1")
+	err := oa.Apply(s.ctx, bus)
+	s.Require().Error(err, "a condition that could not finish applying must say so")
+
+	s.False(oa.IsApplied(), "a half-applied condition does not report itself applied")
+	s.Require().Len(bus.unsubscribed, 1, "the movement subscription must be rolled back, not orphaned")
+
+	// The real proof: the orphaned handler is gone from the underlying bus, so
+	// a qualifying walk publishes nothing.
+	collected := s.triggers()
+	s.walkAway(s.readyCtx("fighter-1"), "wolf-1",
+		spatial.Position{X: 5, Y: 6}, spatial.Position{X: 5, Y: 8})
+	s.Empty(*collected, "a rolled-back condition must not still be listening")
 }

--- a/rulebooks/dnd5e/conditions/opportunity_attack_meter_test.go
+++ b/rulebooks/dnd5e/conditions/opportunity_attack_meter_test.go
@@ -1,0 +1,337 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package conditions_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	coreCombat "github.com/KirkDiggler/rpg-toolkit/core/combat"
+	coreResources "github.com/KirkDiggler/rpg-toolkit/core/resources"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// fakeReactor stands in for the reactor's own live sheet.
+//
+// It can be built WITHOUT a purse (withPurse false), which is the monster
+// case and not a degenerate one: monsters carry no action economy in this
+// rulebook at all, so "there is no reaction slot to read" is the production
+// shape rather than a gap in the fake. SetOwner asserts the two halves
+// independently, so an owner that only marks dirty is a real configuration.
+type fakeReactor struct {
+	withPurse bool
+	reactions int
+	dirtied   int
+	spent     []coreCombat.ActionType
+}
+
+func (f *fakeReactor) MarkDirty() { f.dirtied++ }
+
+func (f *fakeReactor) InCombat() bool { return true }
+
+func (f *fakeReactor) SlotsLeft(slot coreCombat.ActionType) int {
+	if slot == coreCombat.ActionReaction {
+		return f.reactions
+	}
+	return 0
+}
+
+func (f *fakeReactor) SpendSlots(slot coreCombat.ActionType, n int) {
+	if slot == coreCombat.ActionReaction {
+		f.reactions -= n
+	}
+	f.spent = append(f.spent, slot)
+}
+
+func (f *fakeReactor) CapacityLeft(_ combat.CapacityType) int       { return 0 }
+func (f *fakeReactor) PoolLeft(_ coreResources.ResourceKey) int     { return 0 }
+func (f *fakeReactor) SpendCapacity(_ combat.CapacityType, _ int)   {}
+func (f *fakeReactor) SpendPool(_ coreResources.ResourceKey, _ int) {}
+func (f *fakeReactor) BankCapacity(_ combat.CapacityType, _ int)    {}
+
+// purseless is the monster shape: it marks dirty and nothing else, so a type
+// assertion to combat.Ledger fails and the condition finds no purse.
+type purseless struct{ dirtied int }
+
+func (p *purseless) MarkDirty() { p.dirtied++ }
+
+// oaMeterEntity implements core.Entity for room placement.
+type oaMeterEntity struct {
+	id   string
+	kind core.EntityType
+}
+
+func (e *oaMeterEntity) GetID() string            { return e.id }
+func (e *oaMeterEntity) GetType() core.EntityType { return e.kind }
+
+// OpportunityAttackMeterSuite pins the once-per-turn meter Kirk ruled on
+// 2026-08-28: "characters have to pay for it. the condition can still track it
+// was used but players have a cost."
+//
+// The two meters have two distinct jobs and both are tested here. UsedThisTurn
+// is the one EVERY reactor carries and is what makes the rule enforceable for
+// monsters. The reaction slot is an additional charge only a sheet can bear,
+// and is what keeps OA and Protection fighting style mutually exclusive.
+type OpportunityAttackMeterSuite struct {
+	suite.Suite
+	ctx  context.Context
+	bus  events.EventBus
+	room spatial.Room
+}
+
+func TestOpportunityAttackMeterSuite(t *testing.T) {
+	suite.Run(t, new(OpportunityAttackMeterSuite))
+}
+
+func (s *OpportunityAttackMeterSuite) SetupTest() {
+	s.ctx = context.Background()
+	s.bus = events.NewEventBus()
+	s.room = spatial.NewBasicRoom(spatial.BasicRoomConfig{
+		ID:   "meter-room",
+		Type: "dungeon",
+		Grid: spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 20, Height: 20}),
+	})
+}
+
+func (s *OpportunityAttackMeterSuite) place(id string, kind core.EntityType, x, y float64) {
+	s.Require().NoError(s.room.PlaceEntity(&oaMeterEntity{id: id, kind: kind}, spatial.Position{X: x, Y: y}))
+}
+
+func (s *OpportunityAttackMeterSuite) triggers() *[]dnd5eEvents.ReactionTriggerEvent {
+	mu := &sync.Mutex{}
+	collected := &[]dnd5eEvents.ReactionTriggerEvent{}
+	_, err := dnd5eEvents.ReactionTriggerTopic.On(s.bus).Subscribe(
+		s.ctx, func(_ context.Context, e dnd5eEvents.ReactionTriggerEvent) error {
+			mu.Lock()
+			defer mu.Unlock()
+			*collected = append(*collected, e)
+			return nil
+		})
+	s.Require().NoError(err)
+	return collected
+}
+
+// readyCtx is the context a live movement fold runs under: a room to read
+// geometry from, and the reactor readied for OA.
+func (s *OpportunityAttackMeterSuite) readyCtx(reactor string) context.Context {
+	ctx := gamectx.WithRoom(s.ctx, s.room)
+	return gamectx.WithReactionReadiness(ctx, gamectx.ReactionReadinessMap{
+		reactor: {refs.Conditions.OpportunityAttack().String(): true},
+	})
+}
+
+// walkAway folds one step that leaves the reactor's reach, which is the whole
+// predicate: adjacent at from, out of reach at to.
+func (s *OpportunityAttackMeterSuite) walkAway(ctx context.Context, mover string, from, to spatial.Position) {
+	event := &dnd5eEvents.MovementChainEvent{
+		EntityID:     mover,
+		EntityType:   "monster",
+		FromPosition: dnd5eEvents.Position{X: from.X, Y: from.Y},
+		ToPosition:   dnd5eEvents.Position{X: to.X, Y: to.Y},
+	}
+	c := events.NewStagedChain[*dnd5eEvents.MovementChainEvent](combat.ModifierStages)
+	mc, err := dnd5eEvents.MovementChain.On(s.bus).PublishWithChain(ctx, event, c)
+	s.Require().NoError(err)
+	_, err = mc.Execute(ctx, event)
+	s.Require().NoError(err)
+}
+
+// A reaction is once per round. Before this the condition had no memory at
+// all, so every enemy that fled past a fighter in one round drew its own
+// swing — the whole party's worth of free attacks.
+func (s *OpportunityAttackMeterSuite) TestASecondEnemyFleeingTheSameTurnGetsAway() {
+	s.place("fighter-1", "character", 5, 5)
+	s.place("wolf-1", "monster", 5, 6)
+	s.place("wolf-2", "monster", 4, 5)
+
+	oa := conditions.NewOpportunityAttackCondition("fighter-1")
+	oa.SetOwner(&purseless{})
+	s.Require().NoError(oa.Apply(s.ctx, s.bus))
+
+	collected := s.triggers()
+	ctx := s.readyCtx("fighter-1")
+
+	s.walkAway(ctx, "wolf-1", spatial.Position{X: 5, Y: 6}, spatial.Position{X: 5, Y: 8})
+	s.walkAway(ctx, "wolf-2", spatial.Position{X: 4, Y: 5}, spatial.Position{X: 1, Y: 5})
+
+	s.Require().Len(*collected, 1, "the second fleeing enemy must not draw a second reaction")
+	s.Equal("wolf-1", (*collected)[0].SourceEntity)
+	s.True(oa.UsedThisTurn)
+}
+
+// TURN START, not turn end. A reaction is spent on somebody else's turn, so a
+// meter cleared at the end of its holder's turn would be full again for the
+// entire window it governs. 2014 PHB: "you regain a spent reaction at the
+// start of each of your turns."
+func (s *OpportunityAttackMeterSuite) TestTheReactionRefreshesAtTheReactorsOwnTurnStart() {
+	s.place("fighter-1", "character", 5, 5)
+	s.place("wolf-1", "monster", 5, 6)
+
+	owner := &purseless{}
+	oa := conditions.NewOpportunityAttackCondition("fighter-1")
+	oa.SetOwner(owner)
+	s.Require().NoError(oa.Apply(s.ctx, s.bus))
+
+	collected := s.triggers()
+	ctx := s.readyCtx("fighter-1")
+
+	s.walkAway(ctx, "wolf-1", spatial.Position{X: 5, Y: 6}, spatial.Position{X: 5, Y: 8})
+	s.Require().Len(*collected, 1)
+	s.Require().True(oa.UsedThisTurn)
+
+	dirtiedBefore := owner.dirtied
+	s.Require().NoError(dnd5eEvents.TurnStartTopic.On(s.bus).Publish(
+		ctx, dnd5eEvents.TurnStartEvent{SubjectID: "fighter-1", Round: 2}))
+
+	s.False(oa.UsedThisTurn, "the reactor's own turn start refreshes the reaction")
+	s.Greater(owner.dirtied, dirtiedBefore, "a refreshed meter must be persisted")
+
+	s.place("wolf-2", "monster", 4, 5)
+	s.walkAway(ctx, "wolf-2", spatial.Position{X: 4, Y: 5}, spatial.Position{X: 1, Y: 5})
+	s.Len(*collected, 2, "a refreshed reaction swings again")
+}
+
+// Somebody ELSE's turn beginning is exactly the window a reaction is spent in.
+// Refreshing on it would make the meter meaningless.
+func (s *OpportunityAttackMeterSuite) TestAnotherMembersTurnStartDoesNotRefreshIt() {
+	s.place("fighter-1", "character", 5, 5)
+	s.place("wolf-1", "monster", 5, 6)
+
+	oa := conditions.NewOpportunityAttackCondition("fighter-1")
+	oa.SetOwner(&purseless{})
+	s.Require().NoError(oa.Apply(s.ctx, s.bus))
+
+	collected := s.triggers()
+	ctx := s.readyCtx("fighter-1")
+
+	s.walkAway(ctx, "wolf-1", spatial.Position{X: 5, Y: 6}, spatial.Position{X: 5, Y: 8})
+	s.Require().Len(*collected, 1)
+
+	s.Require().NoError(dnd5eEvents.TurnStartTopic.On(s.bus).Publish(
+		ctx, dnd5eEvents.TurnStartEvent{SubjectID: "wolf-2", Round: 1}))
+	s.True(oa.UsedThisTurn, "another member's turn start must not refresh this reactor")
+}
+
+// Kirk's ruling: characters pay. The slot is what makes OA and Protection
+// fighting style mutually exclusive, which they are in the rules — both spend
+// the one reaction and the second to ask finds it gone.
+func (s *OpportunityAttackMeterSuite) TestACharacterPaysTheReactionSlot() {
+	s.place("fighter-1", "character", 5, 5)
+	s.place("wolf-1", "monster", 5, 6)
+
+	owner := &fakeReactor{withPurse: true, reactions: 1}
+	oa := conditions.NewOpportunityAttackCondition("fighter-1")
+	oa.SetOwner(owner)
+	s.Require().NoError(oa.Apply(s.ctx, s.bus))
+
+	collected := s.triggers()
+	s.walkAway(s.readyCtx("fighter-1"), "wolf-1",
+		spatial.Position{X: 5, Y: 6}, spatial.Position{X: 5, Y: 8})
+
+	s.Require().Len(*collected, 1)
+	s.Equal(0, owner.reactions, "the reaction slot is spent, not merely flagged")
+	s.Equal([]coreCombat.ActionType{coreCombat.ActionReaction}, owner.spent)
+}
+
+// A fighter who already spent their reaction on Protection has none left for
+// an opportunity attack. Without the purse gate the flag alone would let them
+// do both.
+func (s *OpportunityAttackMeterSuite) TestACharacterWithNoReactionLeftDoesNotSwing() {
+	s.place("fighter-1", "character", 5, 5)
+	s.place("wolf-1", "monster", 5, 6)
+
+	owner := &fakeReactor{withPurse: true, reactions: 0}
+	oa := conditions.NewOpportunityAttackCondition("fighter-1")
+	oa.SetOwner(owner)
+	s.Require().NoError(oa.Apply(s.ctx, s.bus))
+
+	collected := s.triggers()
+	s.walkAway(s.readyCtx("fighter-1"), "wolf-1",
+		spatial.Position{X: 5, Y: 6}, spatial.Position{X: 5, Y: 8})
+
+	s.Empty(*collected, "a spent reaction cannot be spent again")
+	s.False(oa.UsedThisTurn, "a refused reaction must not consume the flag either")
+}
+
+// The asymmetry IS the rule. A monster carries no action economy at all, so
+// requiring a purse would refuse it a reaction it is entitled to, and having
+// no flag would give it an unlimited one.
+func (s *OpportunityAttackMeterSuite) TestAMonsterReactsWithNoPurseAndIsStillMetered() {
+	s.place("wolf-1", "monster", 5, 5)
+	s.place("rogue-1", "character", 5, 6)
+	s.place("rogue-2", "character", 4, 5)
+
+	oa := conditions.NewOpportunityAttackCondition("wolf-1")
+	oa.SetOwner(&purseless{})
+	s.Require().NoError(oa.Apply(s.ctx, s.bus))
+
+	collected := s.triggers()
+	ctx := s.readyCtx("wolf-1")
+
+	s.walkAway(ctx, "rogue-1", spatial.Position{X: 5, Y: 6}, spatial.Position{X: 5, Y: 8})
+	s.Require().Len(*collected, 1, "a monster with no economy still gets its reaction")
+
+	s.walkAway(ctx, "rogue-2", spatial.Position{X: 4, Y: 5}, spatial.Position{X: 1, Y: 5})
+	s.Len(*collected, 1, "and is still held to one per turn by the flag alone")
+}
+
+// An owner satisfying neither half is not an error. The condition meters
+// itself in memory and charges nothing — the same "nothing to do" default
+// every other unmet check in this package takes.
+func (s *OpportunityAttackMeterSuite) TestAnOwnerlessReactorStillMetersItself() {
+	s.place("wolf-1", "monster", 5, 5)
+	s.place("rogue-1", "character", 5, 6)
+	s.place("rogue-2", "character", 4, 5)
+
+	oa := conditions.NewOpportunityAttackCondition("wolf-1")
+	s.Require().NoError(oa.Apply(s.ctx, s.bus))
+
+	collected := s.triggers()
+	ctx := s.readyCtx("wolf-1")
+
+	s.walkAway(ctx, "rogue-1", spatial.Position{X: 5, Y: 6}, spatial.Position{X: 5, Y: 8})
+	s.walkAway(ctx, "rogue-2", spatial.Position{X: 4, Y: 5}, spatial.Position{X: 1, Y: 5})
+
+	s.Len(*collected, 1, "no owner is not an excuse to react twice")
+}
+
+// The meter is persisted for SneakAttackData's stated reason: every call
+// reconstructs the condition from JSON, so a runtime-only flag resets on each
+// RPC and meters nothing at all.
+func (s *OpportunityAttackMeterSuite) TestTheMeterSurvivesTheJSONRoundTrip() {
+	s.place("fighter-1", "character", 5, 5)
+	s.place("wolf-1", "monster", 5, 6)
+
+	oa := conditions.NewOpportunityAttackCondition("fighter-1")
+	oa.SetOwner(&purseless{})
+	s.Require().NoError(oa.Apply(s.ctx, s.bus))
+	s.walkAway(s.readyCtx("fighter-1"), "wolf-1",
+		spatial.Position{X: 5, Y: 6}, spatial.Position{X: 5, Y: 8})
+	s.Require().True(oa.UsedThisTurn)
+
+	raw, err := oa.ToJSON()
+	s.Require().NoError(err)
+
+	var data conditions.OpportunityAttackConditionData
+	s.Require().NoError(json.Unmarshal(raw, &data))
+	s.True(data.UsedThisTurn, "a spent reaction that is not written down is not spent")
+
+	reloaded, err := conditions.LoadJSON(raw)
+	s.Require().NoError(err)
+	restored, ok := reloaded.(*conditions.OpportunityAttackCondition)
+	s.Require().True(ok, "the loader must route this ref back to an OA condition")
+	s.True(restored.UsedThisTurn, "the meter must survive the load, not just the save")
+}

--- a/rulebooks/dnd5e/monster/monster.go
+++ b/rulebooks/dnd5e/monster/monster.go
@@ -189,6 +189,29 @@ func (m *Monster) MarkClean() {
 	m.dirty = false
 }
 
+// MarkDirty records that something this sheet persists has changed.
+//
+// The counterpart to MarkClean, and the write half of the owner handle a
+// condition keeping its own turn-scoped memory needs — see the conditions
+// package's selfPersisting. Every other writer here sets m.dirty inline
+// because it is also the one changing the field; a condition stores its memory
+// in its OWN fields, which are serialized as part of this sheet, so nothing
+// else notices the change and the save is dropped unless it says so.
+//
+// It exists AHEAD of its caller, deliberately and narrowly. The opportunity
+// attack is the first monster-side case — without this, a wolf that used its
+// reaction is reloaded having used nothing and the once-per-turn rule silently
+// does not exist for monsters — and the caller is the session-side seating that
+// applies that condition programmatically, in a module that pins this one by
+// version and so cannot be written until this ships. What is NOT here is the
+// owner handoff itself: monstertraits.AttachMonster routes four traits, none of
+// them OwnerAware and none of them the opportunity attack, so a SetOwner branch
+// there would be unreachable. The handoff belongs where the condition is
+// actually constructed (rpg-project#316).
+func (m *Monster) MarkDirty() {
+	m.dirty = true
+}
+
 // AbilityScores returns the monster's ability scores (implements Combatant interface)
 func (m *Monster) AbilityScores() shared.AbilityScores {
 	return m.abilityScores

--- a/rulebooks/dnd5e/monster/monster_markdirty_test.go
+++ b/rulebooks/dnd5e/monster/monster_markdirty_test.go
@@ -1,0 +1,33 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monster_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+)
+
+// A monster sheet must be able to be told it changed by something that is not
+// the code changing it. A condition keeping its own turn-scoped memory — the
+// opportunity attack's once-per-turn flag is the first — stores that memory in
+// its own fields, which are serialized as part of this sheet. Nothing else
+// notices, so a sheet that cannot be marked dirty from outside is a sheet whose
+// condition state is silently discarded on save.
+func TestAMonsterCanBeToldItsPersistedStateChanged(t *testing.T) {
+	m, err := monster.Load(context.Background(), &monster.Data{
+		ID: "wolf-1", Name: "Wolf", HitPoints: 11, MaxHitPoints: 11, ArmorClass: 13,
+	})
+	require.NoError(t, err)
+	require.False(t, m.IsDirty(), "a freshly loaded sheet has nothing to save")
+
+	m.MarkDirty()
+	require.True(t, m.IsDirty(), "MarkDirty is what stops a silent update being dropped")
+
+	m.MarkClean()
+	require.False(t, m.IsDirty(), "and MarkClean is still its counterpart")
+}


### PR DESCRIPTION
First build step of rpg-project#316 — the opportunity attack fires. Design: rpg-project#317.

## What this does

OA had **no memory at all**. Every enemy that fled past a fighter in one round drew its own
swing — the whole party's worth of free attacks. It now carries `UsedThisTurn` in its persisted
JSON, the same shape and for the same stated reason as `SneakAttackCondition`: every call
reconstructs the condition from JSON, so a runtime-only flag resets on each RPC and meters
nothing at all.

**Turn start, not turn end.** A reaction is spent on somebody else's turn — that is what makes it
a reaction — so a meter cleared at the end of its holder's turn would be full again for the entire
window it governs. 2014 PHB: *"you regain a spent reaction at the start of each of your turns."*

## Two meters, two jobs

Kirk ruled 2026-08-28: *"characters have to pay for it. the condition can still track it was used
but players have a cost."*

`SetOwner` asserts the two halves **independently**, so the asymmetry falls out of the existing
`OwnerAware` pattern with no special-casing:

| reactor | `selfPersisting` | `combat.Ledger` | metered by |
|---|---|---|---|
| `*character.Character` | yes | yes | flag **and** a spent reaction slot |
| monster | yes | **no** | the flag alone |

Monsters carry no action economy in this rulebook at all — no reaction slot for a gate to read —
so requiring a purse would refuse them a reaction they are entitled to, and having no flag would
give them an unlimited one. Paying also keeps OA and **Protection fighting style** mutually
exclusive, which they are in the rules: both spend the one reaction and the second to ask finds
it gone.

Spending happens **after** the trigger publishes. A trigger that never reached the orchestrator is
a reaction that did not happen, and charging for it would leave the reactor unable to react to the
next mover for a swing nobody made.

## `monster.MarkDirty`

Character sheets have had this handle since rpg-toolkit#1178; monster sheets had `IsDirty` and
`MarkClean` and no way to be marked. Without it a wolf that used its reaction is reloaded having
used nothing, and the once-per-turn rule silently does not exist for monsters.

It is deliberately ahead of its caller — the session-side seating that applies this condition
programmatically lives in a module that pins this one by version and cannot be written until this
ships.

**What is not here**, and the omission is the point: no `SetOwner` handoff in
`monstertraits.AttachMonster`. That loader routes four traits — immunity, vulnerability, pack
tactics, undead fortitude — none of them `OwnerAware` and none of them the opportunity attack. I
wrote that branch, then found it would be unreachable the day it shipped, which is precisely the
built-and-unwired defect this whole slice exists to undo. The handoff belongs where the condition
is actually constructed.

## Evidence

Eight new tests in `opportunity_attack_meter_test.go`, one in `monster_markdirty_test.go`, full
`rulebooks/dnd5e` suite green. Seven mutants applied and **all seven killed** — each compiled
first, so none is a build-break masquerading as coverage:

| mutant | result |
|---|---|
| drop the once-per-turn gate | killed |
| reset on **any** member's turn start | killed |
| drop the purse gate | killed |
| never spend the reaction slot | killed |
| do not persist the meter | killed |
| do not restore the meter | killed |
| `MarkDirty` does nothing | killed |

## Not in this PR

OA still has no caller — nothing constructs it, nothing publishes `MovementChain` on the live
path, nothing subscribes to `ReactionTriggerTopic`. Those are the seating and `resolution.NewMovement`
steps, which pin this module by version. This step makes the rule correct; it does not yet make it
reachable.

— platform agent, on behalf of KirkDiggler
