### PR TITLE
feat(resolution): NewMovement — a step is an interaction, and everyone hears it

### DIFF
--- a/rulebooks/dnd5e/resolution/errors.go
+++ b/rulebooks/dnd5e/resolution/errors.go
@@ -131,6 +131,17 @@ var (
 	// replaced, so which currency ran out survives the crossing.
 	ErrCannotPay = errors.New("resolution: cost cannot be paid")
 
+	// ErrBadMovement indicates a step nobody could announce: no mover, a step
+	// that goes nowhere, or a missing capability. Wiring being wrong, never a
+	// rule saying no — a member who may not walk is refused by the composition
+	// long before a step reaches this package.
+	//
+	// A MOVEMENT WITH NO WAY TO RESOLVE A REACTION IS MALFORMED, not free.
+	// Accepting one would publish triggers and drop them on the floor, which is
+	// the exact defect this machine exists to undo: an opportunity attack that
+	// fires into nothing looks identical to one that never fired.
+	ErrBadMovement = errors.New("resolution: invalid movement")
+
 	// ErrBadActivation indicates an activation nobody could run: no member, no
 	// ability ref or an unusable one, a member who is not in the cast, a
 	// monster (whose abilities are driven rather than declared), or a target

--- a/rulebooks/dnd5e/resolution/go.mod
+++ b/rulebooks/dnd5e/resolution/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/KirkDiggler/rpg-toolkit/core v0.11.0
 	github.com/KirkDiggler/rpg-toolkit/dice v0.3.2
 	github.com/KirkDiggler/rpg-toolkit/events v0.6.3
-	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.3
+	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.106.0
 	github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0
 	github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0
 	github.com/stretchr/testify v1.11.1

--- a/rulebooks/dnd5e/resolution/go.sum
+++ b/rulebooks/dnd5e/resolution/go.sum
@@ -16,8 +16,8 @@ github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0 h1:CefHnp1Cuk9BrIxWcrrAE+q
 github.com/KirkDiggler/rpg-toolkit/play/record v0.1.0/go.mod h1:URY6tA/joFr1iUmw7QHVFN5lzV9Aa214ygGmCGXk5dE=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1 h1:MtAEpVskb0lfb+oXO8xGrSQsDoHZdQ/kjdjh7b9IOdY=
 github.com/KirkDiggler/rpg-toolkit/rpgerr v0.1.1/go.mod h1:wsyJmmf1X0iLFGy5Iyy5sUoZhXZQvuYVsKdXfc4b/T4=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.3 h1:FVZ7i4rE4Ke/Rj7/bWtsYfb7lagAcrbnISfc+4Jrlaw=
-github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.105.3/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.106.0 h1:X+W0K3FqyuYPlgE/LcLH4qxlQ4keqmgCdqG1u61421s=
+github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e v0.106.0/go.mod h1:DimIKXyoLKh2S3LO0FZBHaB5QBq4biIgVoQ0FekbXnY=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0 h1:t44TeeJm7Fkc8Ra72E2YH+OcvM2LC0PF6hHcrxNdq1g=
 github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter v0.37.0/go.mod h1:X2jxN8n3qhWAeicXEKXx6KUH3IjiwJTSYDkAY+aF7qw=
 github.com/KirkDiggler/rpg-toolkit/tools/spatial v0.11.0 h1:FzCB2NbNS/BMRuKwEr8GRnadWJvdYermOs3smTd8Ss0=

--- a/rulebooks/dnd5e/resolution/movement.go
+++ b/rulebooks/dnd5e/resolution/movement.go
@@ -318,6 +318,18 @@ func (m *movementMachine) react(i int) Step {
 
 // outcome reads the step's result off the FOLDED event rather than the input,
 // so a modifier that changed something is reported rather than echoed over.
+//
+// THE ENDPOINTS TOO, not only the flags. They are the same values today —
+// nothing in the rulebook moves a step's From or To — and that is exactly what
+// makes echoing them survive the whole suite while being wrong. runWalk's own
+// loop carries the same warning about the same mistake one layer up: the day a
+// step can land somewhere other than where it was aimed (a shove, a slide, a
+// door that opens onto a different cell), echoing the input reports a movement
+// that did not happen, and reading the answer keeps being right without anyone
+// noticing it had to change.
+//
+// The input is the fallback ONLY for a machine whose fold never ran, which is
+// the Start-without-drive path a test can reach and production cannot.
 func (m *movementMachine) outcome() MovementOutcome {
 	out := MovementOutcome{
 		Mover:     string(m.in.Mover),
@@ -326,6 +338,8 @@ func (m *movementMachine) outcome() MovementOutcome {
 		Reactions: m.reactions,
 	}
 	if m.folded != nil {
+		out.From = spatial.Position{X: m.folded.FromPosition.X, Y: m.folded.FromPosition.Y}
+		out.To = spatial.Position{X: m.folded.ToPosition.X, Y: m.folded.ToPosition.Y}
 		out.Prevented = m.folded.MovementPrevented
 		out.PreventionReason = m.folded.PreventionReason
 		out.OAPrevented = m.folded.IsOAPrevented()

--- a/rulebooks/dnd5e/resolution/movement.go
+++ b/rulebooks/dnd5e/resolution/movement.go
@@ -1,0 +1,335 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// ReactionAttacks answers what a reactor swings when its reaction fires.
+//
+// A CAPABILITY, supplied and never defaulted, for the reason every other seam
+// on this package's inputs is: what a member attacks with is read off their
+// equipped weapon, and this package holds no equipment rules. The caller that
+// owns the sheets owns the answer.
+//
+// It is asked PER REACTOR at the moment a trigger fires, not handed a
+// pre-selected list of who might react. That distinction is the point: a
+// caller who had to name the reactors in advance would be deciding which
+// effects can notice a step, which is precisely the rule-in-the-wiring this
+// machine exists to avoid.
+type ReactionAttacks interface {
+	// AttackFor returns the attack this reactor swings, or false if it has
+	// none. False is an ANSWER, not a failure: an unarmed caster with no
+	// melee attack simply does not get an opportunity attack.
+	AttackFor(reactorID string) (combatActions.Definition, bool)
+}
+
+// MovementInput is one step of a walk, offered to the rules.
+type MovementInput struct {
+	// Mover is who is stepping. Required.
+	Mover encounter.MemberID
+
+	// MoverKind is what the mover is, carried onto the chain event so a
+	// subscriber can tell a character's step from a monster's without asking.
+	MoverKind string
+
+	// From and To are the step's endpoints, dungeon-absolute — the same
+	// coordinates the Atlas draws and every other verb speaks.
+	From spatial.Position
+	To   spatial.Position
+
+	// Reactions answers what a triggered reactor swings. Required: a movement
+	// with no way to resolve a reaction would publish triggers and drop them,
+	// which is the failure this whole slice exists to undo.
+	Reactions ReactionAttacks
+
+	// Roller rolls the reaction's attack. Required.
+	Roller dice.Roller
+}
+
+// MovementOutcome is what one step produced.
+type MovementOutcome struct {
+	// Mover, From and To echo the step, so a caller reading only the outcome
+	// can say what happened without holding the input.
+	Mover string
+	From  spatial.Position
+	To    spatial.Position
+
+	// Prevented reports that a chain subscriber stopped the step, with
+	// PreventionReason saying which and why. Nothing sets it today — Sentinel
+	// is deferred — and it is carried rather than dropped so the day something
+	// does, the caller is already reading it.
+	Prevented        bool
+	PreventionReason string
+
+	// OAPrevented reports that opportunity attacks were suppressed for this
+	// step, which is how Disengage reads from out here.
+	OAPrevented bool
+
+	// Reactions are what fired, in reactor order.
+	Reactions []ReactionOutcome
+}
+
+func (MovementOutcome) isOutcome() {}
+
+// ReactionOutcome is one reaction that fired during a step.
+type ReactionOutcome struct {
+	// ReactorID is who reacted, ConditionRef is what let them, and Against is
+	// who they reacted to.
+	ReactorID    string
+	ConditionRef string
+	Against      string
+
+	// Struck is what the reaction's attack produced. A reaction that found no
+	// attack to swing does not appear in the outcome at all, so this is always
+	// populated.
+	Struck StrikeOutcome
+}
+
+// NewMovement returns the machine that offers one step of a walk to the rules.
+//
+// # It is a sibling of NewBoundary and NewActivation
+//
+// The three share the shape that matters: attach everyone, do ONE thing on the
+// interaction's own bus, collect dirty sheets. A boundary is "time happened",
+// an activation is "a member used something they carry", and this is "a member
+// entered a cell" — none of them is a declared action with a compiled profile,
+// so none of them is an arm of [NewAction].
+//
+// # Why a step needs its own machine at all
+//
+// Because the alternative was a bus at the call site with a hand-picked cast,
+// and that is a rule in the wiring. Kirk ruled it out directly (rpg-project#316,
+// 2026-08-28): "a walk should load everything. if there is a trap along the
+// path it will need to be loaded. i think the idea we know what to load on the
+// bus will hamstring us as we want to add new things in."
+//
+// Running here means attachment is [attachAll] — the same one every other
+// machine uses — so a trap, a hazard aura, a Sentinel feat and an ally's
+// Protection are each attached and each answer for themselves. The acceptance
+// test is that the NEXT thing to notice a step subscribes to MovementChain and
+// needs no change here to be heard.
+//
+// # It publishes, and encounter does not
+//
+// The natural-looking seam is [encounter.Step], which holds both endpoints. It
+// is the wrong one: that module never imports events and publishes nothing at
+// all, because determinism is its module law. So the step is walked there and
+// announced here, which is the same division [announcerSeam] already makes for
+// a clock boundary the composition noticed and cannot publish.
+//
+// # The reaction resolves INSIDE this interaction
+//
+// A trigger is answered with [Request], on this interaction's own bus and over
+// its own cast, rather than handed back for the caller to run separately. That
+// sameness is load-bearing twice over: the reactor's condition marked itself
+// used during the fold, and a separate interaction would reload that sheet from
+// data and find the meter empty; and an effect attached for this step
+// contributes to the reaction's attack exactly as it would to a declared one.
+//
+// # It runs BEFORE the step is taken, and that is a contract not a preference
+//
+// The reactor swings through the ordinary strike path, which enforces melee
+// reach against where the target IS. An opportunity attack fires precisely
+// because the mover is LEAVING reach, so a caller that walks the member first
+// and announces afterwards hands the strike a target who has already gone: the
+// swing is refused as out of range and, because a refused reaction fails the
+// interaction, the whole walk dies with it.
+//
+// So the caller announces the step, then takes it. That is also the order
+// combat.MoveEntity used on the old stack — "fires a MovementChain event before
+// each step" — and the order MovementPrevented needs to mean anything, since a
+// step already taken cannot be prevented.
+//
+// Refuses a nil input, a mover with no ID, a step that goes nowhere, and a
+// missing capability — all before the world is loaded.
+func NewMovement(in *MovementInput) (Machine, error) {
+	if in == nil {
+		return nil, ErrNilInput
+	}
+	if in.Mover == "" {
+		return nil, fmt.Errorf("%w: no member is moving", ErrBadMovement)
+	}
+	if in.From == in.To {
+		return nil, fmt.Errorf("%w: member %q stepped nowhere", ErrBadMovement, in.Mover)
+	}
+	if in.Reactions == nil {
+		return nil, fmt.Errorf("%w: member %q has no way to resolve a reaction", ErrBadMovement, in.Mover)
+	}
+	if in.Roller == nil {
+		return nil, fmt.Errorf("%w: member %q has no roller", ErrBadMovement, in.Mover)
+	}
+
+	// Copied rather than kept by pointer, for the reason NewActivation copies
+	// its ref: a caller reusing the struct must not be able to change which
+	// step this machine announces after it was constructed.
+	cloned := *in
+
+	return &movementMachine{in: &cloned}, nil
+}
+
+type movementMachine struct {
+	in *MovementInput
+
+	folded    *dnd5eEvents.MovementChainEvent
+	triggers  []dnd5eEvents.ReactionTriggerEvent
+	reactions []ReactionOutcome
+}
+
+// Start is pure preflight — NewMovement already refused what it could — and
+// yields the fold without publishing.
+func (m *movementMachine) Start(_ context.Context, _ *Participants) (Step, error) {
+	return m.announce(), nil
+}
+
+// announce publishes the step and folds what the rules did with it.
+func (m *movementMachine) announce() Step {
+	return Gather{
+		name: fmt.Sprintf("move %s from (%v,%v) to (%v,%v)",
+			m.in.Mover, m.in.From.X, m.in.From.Y, m.in.To.X, m.in.To.Y),
+		run: func(ctx context.Context, bus events.EventBus) (Step, error) {
+			// Collect triggers for the duration of the fold only. A reaction
+			// condition PUBLISHES rather than returning, because one step can
+			// trigger several reactors and a chain fold has one return value;
+			// subscribing here is what turns those publishes into an ordered
+			// list this machine can answer one at a time.
+			stop, collected, err := m.collectTriggers(ctx, bus)
+			if err != nil {
+				return nil, err
+			}
+			defer stop()
+
+			event := &dnd5eEvents.MovementChainEvent{
+				EntityID:            string(m.in.Mover),
+				EntityType:          m.in.MoverKind,
+				FromPosition:        dnd5eEvents.Position{X: m.in.From.X, Y: m.in.From.Y},
+				ToPosition:          dnd5eEvents.Position{X: m.in.To.X, Y: m.in.To.Y},
+				OAPreventionSources: make([]dnd5eEvents.MovementModifierSource, 0),
+			}
+
+			chain := events.NewStagedChain[*dnd5eEvents.MovementChainEvent](combat.ModifierStages)
+			modified, err := dnd5eEvents.MovementChain.On(bus).PublishWithChain(ctx, event, chain)
+			if err != nil {
+				return nil, fmt.Errorf("publish movement chain for %q: %w", m.in.Mover, err)
+			}
+
+			folded, err := modified.Execute(ctx, event)
+			if err != nil {
+				return nil, fmt.Errorf("fold movement chain for %q: %w", m.in.Mover, err)
+			}
+			m.folded = folded
+
+			// Sorted by reactor, then by what let them react, so identical
+			// inputs produce identical stories (C8). Subscriber order is
+			// attach order today and that is already sorted — this does not
+			// depend on it staying that way.
+			m.triggers = append(m.triggers, *collected...)
+			sort.SliceStable(m.triggers, func(i, j int) bool {
+				if m.triggers[i].ReactorID != m.triggers[j].ReactorID {
+					return m.triggers[i].ReactorID < m.triggers[j].ReactorID
+				}
+				return m.triggers[i].ConditionRef < m.triggers[j].ConditionRef
+			})
+
+			return m.react(0), nil
+		},
+	}
+}
+
+// collectTriggers subscribes to reaction triggers and returns the buffer plus
+// the unsubscribe. The buffer is a pointer because the handler appends to it
+// after this returns.
+func (m *movementMachine) collectTriggers(
+	ctx context.Context, bus events.EventBus,
+) (func(), *[]dnd5eEvents.ReactionTriggerEvent, error) {
+	buffered := &[]dnd5eEvents.ReactionTriggerEvent{}
+	subID, err := dnd5eEvents.ReactionTriggerTopic.On(bus).Subscribe(
+		ctx, func(_ context.Context, e dnd5eEvents.ReactionTriggerEvent) error {
+			*buffered = append(*buffered, e)
+			return nil
+		})
+	if err != nil {
+		return nil, nil, fmt.Errorf("subscribe reaction triggers for %q: %w", m.in.Mover, err)
+	}
+
+	return func() { _ = bus.Unsubscribe(ctx, subID) }, buffered, nil
+}
+
+// react answers trigger i, or finishes when they are exhausted.
+//
+// One step per trigger rather than one step resolving all of them, for the
+// reason boundaryMachine yields one per crossing: each is a separate thing that
+// happened, and every yield point is a legal suspension point — which is what
+// the reaction WINDOW will need when a player is asked rather than told
+// (rpg-project#316 defers the prompt; this shape is what it returns to).
+func (m *movementMachine) react(i int) Step {
+	for ; i < len(m.triggers); i++ {
+		trigger := m.triggers[i]
+		definition, ok := m.in.Reactions.AttackFor(trigger.ReactorID)
+		if !ok {
+			// No attack to swing is an ANSWER. The reactor's condition already
+			// spent its meter deciding to react, and that is not refunded here:
+			// this machine does not know why the capability declined, and
+			// unwinding another package's economy on a guess is worse than a
+			// reactor who swung at nothing.
+			continue
+		}
+
+		return Request{
+			name: fmt.Sprintf("%s reacts to %s", trigger.ReactorID, trigger.SourceEntity),
+			machine: NewStrike(&StrikeInput{
+				AttackerID: trigger.ReactorID,
+				TargetID:   trigger.SourceEntity,
+				Definition: definition,
+				Roller:     m.in.Roller,
+			}),
+			next: func(_ context.Context, out Outcome) (Step, error) {
+				struck, ok := out.(StrikeOutcome)
+				if !ok {
+					return nil, fmt.Errorf("%w: reaction by %q produced %T, not a strike",
+						ErrBadMovement, trigger.ReactorID, out)
+				}
+				m.reactions = append(m.reactions, ReactionOutcome{
+					ReactorID:    trigger.ReactorID,
+					ConditionRef: trigger.ConditionRef,
+					Against:      trigger.SourceEntity,
+					Struck:       struck,
+				})
+
+				return m.react(i + 1), nil
+			},
+		}
+	}
+
+	return Done{Outcome: m.outcome()}
+}
+
+// outcome reads the step's result off the FOLDED event rather than the input,
+// so a modifier that changed something is reported rather than echoed over.
+func (m *movementMachine) outcome() MovementOutcome {
+	out := MovementOutcome{
+		Mover:     string(m.in.Mover),
+		From:      m.in.From,
+		To:        m.in.To,
+		Reactions: m.reactions,
+	}
+	if m.folded != nil {
+		out.Prevented = m.folded.MovementPrevented
+		out.PreventionReason = m.folded.PreventionReason
+		out.OAPrevented = m.folded.IsOAPrevented()
+	}
+
+	return out
+}

--- a/rulebooks/dnd5e/resolution/movement_test.go
+++ b/rulebooks/dnd5e/resolution/movement_test.go
@@ -309,3 +309,31 @@ func (s *MovementTestSuite) TestTheStepIsCopiedNotBorrowed() {
 	s.Contains(step.(Gather).Name(), "to (5,1)",
 		"changing the caller's struct must not change what this machine announces")
 }
+
+// The outcome must READ the folded event, endpoints included, not echo the
+// input back. They are the same values today — nothing in the rulebook moves a
+// step's endpoints — which is exactly what lets an echo survive the whole suite
+// while being wrong. The same warning is written into runWalk's loop one layer
+// up, about the same mistake.
+func (s *MovementTestSuite) TestTheOutcomeReportsWhereTheStepACTUALLYWent() {
+	out, err := s.runStep(s.stepInput(), func(ctx context.Context, bus events.EventBus) {
+		_, _ = dnd5eEvents.MovementChain.On(bus).SubscribeWithChain(ctx,
+			func(_ context.Context, _ *dnd5eEvents.MovementChainEvent,
+				c chain.Chain[*dnd5eEvents.MovementChainEvent],
+			) (chain.Chain[*dnd5eEvents.MovementChainEvent], error) {
+				// A shove, a slide, a door that opens onto a different cell.
+				err := c.Add(combat.StageConditions, "test_shove",
+					func(_ context.Context, e *dnd5eEvents.MovementChainEvent) (*dnd5eEvents.MovementChainEvent, error) {
+						e.ToPosition = dnd5eEvents.Position{X: 7, Y: 3}
+						return e, nil
+					})
+				return c, err
+			})
+	})
+	s.Require().NoError(err)
+
+	moved := out.Outcome.(MovementOutcome)
+	s.Equal(spatial.Position{X: 7, Y: 3}, moved.To,
+		"a modifier moved the step and the outcome must say so, not repeat the request")
+	s.Equal(spatial.Position{X: 2, Y: 1}, moved.From, "the origin was untouched and still reads back")
+}

--- a/rulebooks/dnd5e/resolution/movement_test.go
+++ b/rulebooks/dnd5e/resolution/movement_test.go
@@ -1,0 +1,311 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/core/chain"
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	combatActions "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat/actions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// everyoneSwings answers with one attack for anybody who asks.
+type everyoneSwings struct{ asked []string }
+
+func (e *everyoneSwings) AttackFor(reactorID string) (combatActions.Definition, bool) {
+	e.asked = append(e.asked, reactorID)
+	return validMeleeDefinition(), true
+}
+
+// nobodySwings is the empty-handed caster: it answers, and the answer is no.
+type nobodySwings struct{ asked []string }
+
+func (n *nobodySwings) AttackFor(reactorID string) (combatActions.Definition, bool) {
+	n.asked = append(n.asked, reactorID)
+	return combatActions.Definition{}, false
+}
+
+type MovementTestSuite struct {
+	suite.Suite
+	ctx context.Context
+}
+
+func TestMovementSuite(t *testing.T) { suite.Run(t, new(MovementTestSuite)) }
+
+func (s *MovementTestSuite) SetupTest() { s.ctx = context.Background() }
+
+func (s *MovementTestSuite) world() encounter.EncounterData {
+	enc, err := encounter.NewEncounter(&encounter.SetupInput{
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{}, Striker: noAttacksExpected{},
+		Announcer: quietAnnouncer{}, Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Field: encounter.FieldInput{
+			Canvas:  hexCanvas(),
+			Regions: []encounter.RegionInput{rectRegion("room-1", 0, 0, 10, 10)},
+		},
+		Members: []encounter.MemberInput{
+			{ID: heroID, Kind: encounter.KindPlayer, Position: spatial.Position{X: 1, Y: 1}},
+			{ID: wolfID, Kind: encounter.KindMonster, Position: spatial.Position{X: 2, Y: 1}},
+			{ID: "alice", Kind: encounter.KindPlayer, Position: spatial.Position{X: 3, Y: 1}},
+			{ID: "zara", Kind: encounter.KindPlayer, Position: spatial.Position{X: 2, Y: 2}},
+		},
+		Endings: []encounter.EndingInput{{Key: "done", Trigger: encounter.TriggerExternal{}}},
+	})
+	s.Require().NoError(err)
+
+	return enc.ToData()
+}
+
+// runStep drives one movement interaction on a bus the test holds, so it can
+// subscribe the way a condition would.
+func (s *MovementTestSuite) runStep(
+	in *MovementInput, listen func(context.Context, events.EventBus),
+) (*Output, error) {
+	machine, err := NewMovement(in)
+	s.Require().NoError(err)
+
+	bus := events.NewEventBus()
+	if listen != nil {
+		listen(s.ctx, bus)
+	}
+
+	return resolveOn(s.ctx, &Input{
+		World: s.world(),
+		Participants: []Participant{
+			{Character: probeSheet(heroID)}, {Character: probeSheet(wolfID)},
+			{Character: probeSheet("alice")}, {Character: probeSheet("zara")},
+		},
+		Initiative: orderAsGiven{}, TurnDriver: passDriver{},
+		Standing: everyoneStanding{}, Sight: everyoneSeesTheWholeMap{},
+		Roller:  dice.NewRoller(),
+		Machine: machine,
+	}, newSurface(bus))
+}
+
+func (s *MovementTestSuite) stepInput() *MovementInput {
+	return &MovementInput{
+		Mover: wolfID, MoverKind: "monster",
+		From: spatial.Position{X: 2, Y: 1}, To: spatial.Position{X: 5, Y: 1},
+		Reactions: &everyoneSwings{}, Roller: dice.NewRoller(),
+	}
+}
+
+// subscribeMovement attaches a MovementChain subscriber that mutates nothing,
+// which is how a condition that only WATCHES a step behaves.
+func watchSteps(seen *[]dnd5eEvents.MovementChainEvent) func(context.Context, events.EventBus) {
+	return func(ctx context.Context, bus events.EventBus) {
+		_, _ = dnd5eEvents.MovementChain.On(bus).SubscribeWithChain(ctx,
+			func(_ context.Context, e *dnd5eEvents.MovementChainEvent,
+				c chain.Chain[*dnd5eEvents.MovementChainEvent],
+			) (chain.Chain[*dnd5eEvents.MovementChainEvent], error) {
+				*seen = append(*seen, *e)
+				return c, nil
+			})
+	}
+}
+
+// THE POINT OF THE WHOLE MACHINE, and the acceptance test named in
+// rpg-project#316's Done-when: something that wants to notice a step subscribes
+// to MovementChain and is heard, with no change to the caller to make it so.
+//
+// Before this machine the live walk published nothing at all, so a condition
+// with a perfect predicate and its own green suite could not fire in a real
+// game — which is exactly what happened to the opportunity attack.
+func (s *MovementTestSuite) TestAStepReachesEverythingListeningForOne() {
+	var seen []dnd5eEvents.MovementChainEvent
+	_, err := s.runStep(s.stepInput(), watchSteps(&seen))
+	s.Require().NoError(err)
+
+	s.Require().Len(seen, 1, "one step, one publish")
+	s.Equal(wolfID, seen[0].EntityID)
+	s.Equal("monster", seen[0].EntityType)
+	s.EqualValues(2, seen[0].FromPosition.X)
+	s.EqualValues(5, seen[0].ToPosition.X)
+}
+
+// The sixth uninstalled registry (rpg-toolkit#1251's family). gamectx
+// IsReactionReady fails closed, so until this was installed every reaction
+// condition was gated behind a map nobody supplied — the reason the opportunity
+// attack's own suite is green while the game's is not is that each of those
+// tests installs one by hand.
+func (s *MovementTestSuite) TestEveryParticipantIsReadiedForTheFreeReactions() {
+	readied := map[string]bool{}
+	_, err := s.runStep(s.stepInput(), func(ctx context.Context, bus events.EventBus) {
+		_, _ = dnd5eEvents.MovementChain.On(bus).SubscribeWithChain(ctx,
+			func(inner context.Context, _ *dnd5eEvents.MovementChainEvent,
+				c chain.Chain[*dnd5eEvents.MovementChainEvent],
+			) (chain.Chain[*dnd5eEvents.MovementChainEvent], error) {
+				oa := refs.Conditions.OpportunityAttack().String()
+				readied[heroID] = gamectx.IsReactionReady(inner, heroID, oa)
+				readied[wolfID] = gamectx.IsReactionReady(inner, wolfID, oa)
+				readied["shield"] = gamectx.IsReactionReady(inner, heroID, refs.Spells.Shield().String())
+				return c, nil
+			})
+	})
+	s.Require().NoError(err)
+
+	s.True(readied[heroID], "a free reaction is readied by being in the interaction")
+	s.True(readied[wolfID], "for monsters too — the gate is not a character rule")
+	s.False(readied["shield"], "a COSTED reaction is not opted into on the player's behalf")
+}
+
+// A reaction resolves inside this interaction, on its own bus and over its own
+// cast, rather than being handed back for the caller to run separately.
+func (s *MovementTestSuite) TestATriggeredReactionSwingsWithinTheSameInteraction() {
+	out, err := s.runStep(s.stepInput(), triggerFrom(heroID, wolfID))
+	s.Require().NoError(err)
+
+	moved, ok := out.Outcome.(MovementOutcome)
+	s.Require().True(ok, "a movement interaction reports a movement outcome")
+	s.Require().Len(moved.Reactions, 1)
+
+	got := moved.Reactions[0]
+	s.Equal(heroID, got.ReactorID)
+	s.Equal(wolfID, got.Against, "the reaction answers the mover")
+	s.Equal(refs.Conditions.OpportunityAttack().String(), got.ConditionRef)
+	s.Equal(heroID, got.Struck.AttackerID, "the strike really ran; this is its outcome")
+	s.Equal(wolfID, got.Struck.TargetID)
+	s.Positive(got.Struck.Total, "a strike that never rolled is not a strike")
+}
+
+// triggerFrom publishes a reaction trigger during the fold, which is exactly
+// what OpportunityAttackCondition does when its predicate matches — the
+// condition itself is not used here because this module cannot seat one, and
+// standing in for its PUBLISH is what keeps this a test of the machine.
+func triggerFrom(reactor, mover string) func(context.Context, events.EventBus) {
+	return func(ctx context.Context, bus events.EventBus) {
+		_, _ = dnd5eEvents.MovementChain.On(bus).SubscribeWithChain(ctx,
+			func(inner context.Context, e *dnd5eEvents.MovementChainEvent,
+				c chain.Chain[*dnd5eEvents.MovementChainEvent],
+			) (chain.Chain[*dnd5eEvents.MovementChainEvent], error) {
+				err := dnd5eEvents.ReactionTriggerTopic.On(bus).Publish(inner,
+					dnd5eEvents.ReactionTriggerEvent{
+						ReactorID:    reactor,
+						ConditionRef: refs.Conditions.OpportunityAttack().String(),
+						TriggerKind:  dnd5eEvents.TriggerKindMovementOA,
+						SourceEntity: mover,
+						Payload:      *e,
+					})
+				return c, err
+			})
+	}
+}
+
+// A reactor with nothing to swing is an ANSWER, not a failure. The step still
+// completes and the walk still happened.
+func (s *MovementTestSuite) TestAReactorWithNoAttackIsSkippedNotFailed() {
+	in := s.stepInput()
+	empty := &nobodySwings{}
+	in.Reactions = empty
+
+	out, err := s.runStep(in, triggerFrom(heroID, wolfID))
+	s.Require().NoError(err, "an empty-handed reactor must not break the walk")
+
+	moved := out.Outcome.(MovementOutcome)
+	s.Empty(moved.Reactions, "nothing was swung, so nothing is reported as swung")
+	s.Equal([]string{heroID}, empty.asked, "the capability was still asked, per reactor")
+}
+
+// Disengage reads from out here: the fold says opportunity attacks were
+// suppressed for this step, and the caller learns it without knowing what
+// Disengage is.
+func (s *MovementTestSuite) TestASuppressedStepReportsItsSuppression() {
+	out, err := s.runStep(s.stepInput(), func(ctx context.Context, bus events.EventBus) {
+		_, _ = dnd5eEvents.MovementChain.On(bus).SubscribeWithChain(ctx,
+			func(_ context.Context, _ *dnd5eEvents.MovementChainEvent,
+				c chain.Chain[*dnd5eEvents.MovementChainEvent],
+			) (chain.Chain[*dnd5eEvents.MovementChainEvent], error) {
+				err := c.Add(combat.StageConditions, "test_disengage",
+					func(_ context.Context, e *dnd5eEvents.MovementChainEvent) (*dnd5eEvents.MovementChainEvent, error) {
+						e.OAPreventionSources = append(e.OAPreventionSources,
+							dnd5eEvents.MovementModifierSource{Name: "Test Disengage", SourceType: "condition", EntityID: wolfID})
+						return e, nil
+					})
+				return c, err
+			})
+	})
+	s.Require().NoError(err)
+
+	s.True(out.Outcome.(MovementOutcome).OAPrevented,
+		"the outcome is read off the FOLDED event, not echoed from the input")
+}
+
+// Identical inputs must produce identical stories (C8), so two reactors to one
+// step are answered in a fixed order rather than in subscriber order.
+func (s *MovementTestSuite) TestTwoReactorsAreAnsweredInADeterministicOrder() {
+	swings := &everyoneSwings{}
+	in := s.stepInput()
+	in.Reactions = swings
+
+	out, err := s.runStep(in, func(ctx context.Context, bus events.EventBus) {
+		// Published deliberately in reverse-alphabetical order.
+		triggerFrom("zara", wolfID)(ctx, bus)
+		triggerFrom("alice", wolfID)(ctx, bus)
+	})
+	s.Require().NoError(err)
+
+	moved := out.Outcome.(MovementOutcome)
+	s.Require().Len(moved.Reactions, 2)
+	s.Equal("alice", moved.Reactions[0].ReactorID)
+	s.Equal("zara", moved.Reactions[1].ReactorID)
+}
+
+// Wiring being wrong is refused at the door, before the world is loaded — and a
+// movement with no way to resolve a reaction is wiring being wrong, not a free
+// movement. Accepting one would publish triggers and drop them, which looks
+// exactly like an opportunity attack that never fired.
+func (s *MovementTestSuite) TestMalformedMovementsAreRefusedAtTheDoor() {
+	here := spatial.Position{X: 2, Y: 1}
+	there := spatial.Position{X: 5, Y: 1}
+
+	cases := map[string]*MovementInput{
+		"no input at all": nil,
+		"no mover": {
+			From: here, To: there, Reactions: &everyoneSwings{}, Roller: dice.NewRoller(),
+		},
+		"a step that goes nowhere": {
+			Mover: wolfID, From: here, To: here,
+			Reactions: &everyoneSwings{}, Roller: dice.NewRoller(),
+		},
+		"no way to resolve a reaction": {
+			Mover: wolfID, From: here, To: there, Roller: dice.NewRoller(),
+		},
+		"no roller": {
+			Mover: wolfID, From: here, To: there, Reactions: &everyoneSwings{},
+		},
+	}
+
+	for name, in := range cases {
+		s.Run(name, func() {
+			machine, err := NewMovement(in)
+			s.Require().Error(err)
+			s.Nil(machine, "a refused movement hands back no machine to drive")
+		})
+	}
+}
+
+// A machine constructed from a reused input must keep announcing the step it
+// was built for, the same guarantee NewActivation makes about its ref.
+func (s *MovementTestSuite) TestTheStepIsCopiedNotBorrowed() {
+	in := s.stepInput()
+	machine, err := NewMovement(in)
+	s.Require().NoError(err)
+
+	in.To = spatial.Position{X: 9, Y: 9}
+
+	step, err := machine.Start(s.ctx, nil)
+	s.Require().NoError(err)
+	s.Contains(step.(Gather).Name(), "to (5,1)",
+		"changing the caller's struct must not change what this machine announces")
+}

--- a/rulebooks/dnd5e/resolution/readiness_test.go
+++ b/rulebooks/dnd5e/resolution/readiness_test.go
@@ -1,0 +1,65 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestNoCodePathProducesAReadinesslessInteraction is the STRUCTURAL half of the
+// readiness install, and it is the SIXTH member of the family
+// TestNoCodePathProducesACastlessInteraction was written for.
+//
+// gamectx had five registries and one install. This is the one that was missed:
+// WithReactionReadiness had zero non-test callers in either repo, and
+// IsReactionReady fails closed — so every reaction condition in the rulebook was
+// gated behind a map nobody supplied, and the opportunity attack could not fire
+// in any real interaction. Its own six-case suite is green because every one of
+// those tests installs a readiness map by hand.
+//
+// That is the same failure a behavioural suite is structurally unable to catch,
+// for the same reason: the tests supply what production does not. So the source
+// is the assertion. The install is one statement at the top level of resolveOn's
+// body, and a condition wrapped around it is the defect by construction —
+// whatever the condition said, there would be inputs it answered no for.
+func TestNoCodePathProducesAReadinesslessInteraction(t *testing.T) {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, "resolve.go", nil, 0)
+	require.NoError(t, err)
+
+	fn := funcDecl(t, file, "resolveOn")
+
+	var installs []token.Pos
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "WithReactionReadiness" {
+			installs = append(installs, call.Pos())
+		}
+
+		return true
+	})
+	require.Len(t, installs, 1, "reaction readiness is installed in exactly one place")
+
+	ast.Inspect(fn, func(n ast.Node) bool {
+		branch, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		require.False(t, branch.Pos() <= installs[0] && installs[0] < branch.End(),
+			"resolve.go:%d installs reaction readiness inside a condition — some input "+
+				"answers no, and a reaction gate that is sometimes absent fails CLOSED, "+
+				"which is a reaction that silently never fires",
+			fset.Position(installs[0]).Line)
+
+		return true
+	})
+}

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
@@ -16,6 +17,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monstertraits"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
 // Participant is one member's sheet on the way in. Exactly one of Character or
@@ -371,6 +373,27 @@ func resolveOn(ctx context.Context, in *Input, surf *surface) (*Output, error) {
 	// ask their questions at fold time, which is after this line.
 	ctx = gamectx.WithCast(ctx, &castView{cast: cast})
 
+	// The SIXTH registry in the family rpg-toolkit#1251 was about, installed
+	// zero times until now.
+	//
+	// gamectx.IsReactionReady fails closed by design, so every reaction
+	// condition in the rulebook has been gated behind a map nobody supplied —
+	// the opportunity attack could not fire in any real interaction, and the
+	// only reason its own suite is green is that each test installs a map by
+	// hand. That is the same shape as the barbarian who fought at base AC in
+	// every real fight, and it gets the same fix: ALWAYS PRESENT, derived
+	// here, held structurally by TestNoCodePathProducesAReadinesslessInteraction
+	// rather than by example.
+	//
+	// Free reactions are readied for everyone; costed ones are not readied at
+	// all. That is the Wave 2.11d ruling reused rather than re-derived — "free-
+	// cost reactions like OA are default-on for melee combatants, spell-cost
+	// reactions like Shield are default-off" — and it is why Shield is absent
+	// from the set below rather than present-and-false. Opting INTO a costed
+	// reaction is a decision a player makes, and this package is not where a
+	// player is asked anything.
+	ctx = gamectx.WithReactionReadiness(ctx, defaultReadiness(cast))
+
 	// Start is pure preflight and runs before payment. Invalid participant,
 	// delivery, or condition declarations therefore consume nothing.
 	first, startErr := start(ctx, in.Machine, cast)
@@ -541,4 +564,35 @@ func dirtyMonsters(cast *Participants) []*monster.Data {
 	}
 
 	return out
+}
+
+// freeReactions are the reactions a member has readied simply by being in the
+// interaction, because they cost nothing to hold ready.
+//
+// ONE ENTRY, and the list is the rule rather than an optimisation of it. A
+// costed reaction — Shield burns a spell slot, Uncanny Dodge burns the class
+// feature — is not readied by existing, so adding one here would silently opt
+// every caster into spending a slot they never agreed to spend.
+var freeReactions = []*core.Ref{
+	refs.Conditions.OpportunityAttack(),
+}
+
+// defaultReadiness readies every participant for every free reaction.
+//
+// EVERY participant, not "every melee combatant". Whether a particular member
+// can actually take an opportunity attack is the condition's own predicate —
+// it is only seated on someone who has it, it checks its own reach, its own
+// meter and its own purse — and deciding it out here would put a rule in the
+// wiring, which is the same objection boundaryCast makes one file over.
+func defaultReadiness(cast *Participants) gamectx.ReactionReadinessMap {
+	ready := make(gamectx.ReactionReadinessMap, len(cast.order))
+	for _, id := range cast.order {
+		per := make(map[string]bool, len(freeReactions))
+		for _, ref := range freeReactions {
+			per[ref.String()] = true
+		}
+		ready[id] = per
+	}
+
+	return ready
 }


### PR DESCRIPTION
Second build step of rpg-project#316 — the opportunity attack fires. Design: rpg-project#317.
Follows rpg-toolkit#1281 (merged, `rulebooks/dnd5e/v0.106.0`, pinned here).

## The live walk published nothing at all

That is the root cause under the four documented break points. A condition with a perfect
predicate and its own green suite could not fire in a real game, because `Move` was the one write
verb that never built the shared bus every other interaction builds — so nobody but the walker
was listening.

`NewMovement` is the **third sibling** of `NewBoundary` and `NewActivation`, sharing what
`NewActivation`'s own doc calls the shape that matters: *attach everyone, do ONE thing on the
interaction's own bus, collect dirty sheets.* A boundary is "time happened", an activation is "a
member used something they carry", and this is "a member entered a cell".

Kirk ruled the alternative out directly:

> "a walk should load everything. if there is a trap along the path it will need to be loaded. i
> think the idea we know what to load on the bus will hamstring us as we want to add new things in"

Running here means attachment is `attachAll`, the same one every other machine uses, so **nobody
decides who is relevant to movement**. That is already R3 — `announcer.go` wrote it down for the
boundary path: *"everyone in, applicability is the effect's own predicate... deciding it out here
would put a rule in the wiring."*

The acceptance test is `TestAStepReachesEverythingListeningForOne`: something that wants to notice
a step subscribes to `MovementChain` and is heard, with no change here to make it so.

## The reaction resolves inside the interaction

A trigger is answered with `Request`, on this interaction's bus and over its cast, rather than
handed back for the caller to run. That sameness is load-bearing twice over: the reactor's
condition marked itself used during the fold, and a separate interaction would reload that sheet
from data and find the meter empty; and an effect attached for this step contributes to the
reaction's attack exactly as it would to a declared one.

`ReactionAttacks` is a supplied capability, asked **per reactor at the moment a trigger fires** —
not handed a pre-selected list of who might react, which would be the same rule-in-the-wiring
under a different name.

## Reaction readiness, installed for the first time

`gamectx.WithReactionReadiness` had **zero non-test callers**, and `IsReactionReady` fails closed.
So every reaction condition in the rulebook has been gated behind a map nobody supplied — the
sixth registry in the family rpg-toolkit#1251 was about, and the reason those conditions' suites
are green while the game's behaviour is not is that each test installs a map by hand.

Same fix as #1251: always present, derived here from the cast. Free reactions are readied for
everyone; costed ones are not readied at all — the Wave 2.11d ruling reused rather than
re-derived, which is why Shield is *absent* from the set rather than present-and-false. Opting
into spending a spell slot is a decision a player makes, and this package is not where a player is
asked anything.

## What the tests found that the design did not predict

**The announcement must happen BEFORE the step is taken.** The reactor swings through the ordinary
strike path, which enforces melee reach against where the target *is*. An opportunity attack fires
precisely because the mover is *leaving* reach — so a caller that walks the member first and
announces afterwards hands the strike a target who has already gone, the swing is refused as out
of range, and because a refused reaction fails the interaction, the whole walk dies with it.

That surfaced as a test failure, not as foresight. It is now a documented contract on
`NewMovement`, and it is also the order `combat.MoveEntity` used on the old stack, and the only
order in which `MovementPrevented` can mean anything.

## Evidence

9 test cases, full `resolution` suite green, `golangci-lint` clean. Seven mutants applied, **all
seven killed**, each compiling first:

| mutant | result |
|---|---|
| readiness never installed | killed |
| Shield readied by default too | killed |
| triggers answered in publish order | killed |
| outcome echoes the input instead of the fold | killed |
| missing capability accepted | killed |
| input borrowed instead of copied | killed |
| a no-attack reactor aborts the walk | killed |

## Not in this PR

`session.runWalk` still calls `encounter.Step` directly and never runs this machine, and nothing
seats the OA condition. That is the next step, in a module that pins this one by version.

— platform agent, on behalf of KirkDiggler
