### PR TITLE
feat(dnd5e): a monster can carry an ordinary condition, and is handed its sheet

### DIFF
--- a/rulebooks/dnd5e/monstertraits/loader.go
+++ b/rulebooks/dnd5e/monstertraits/loader.go
@@ -11,6 +11,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rpgerr"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
@@ -31,6 +32,29 @@ func LoadJSON(data json.RawMessage, roller dice.Roller) (dnd5eEvents.ConditionBe
 
 	if err := json.Unmarshal(data, &peek); err != nil {
 		return nil, rpgerr.Wrap(err, "failed to peek at monster trait ref")
+	}
+
+	// A CONDITION IS NOT A TRAIT, and this loader used to answer for neither.
+	//
+	// monster.Data.Conditions has always been documented as "runtime state:
+	// poisoned, hidden, etc." while this switch knew four traits and errored on
+	// everything else — so a monster that ever persisted an ordinary condition
+	// could not be loaded again. Nothing had put one there, which is why the
+	// gap was invisible; seating the universal opportunity attack is what puts
+	// one there (rpg-project#316), and without this the FIRST interaction
+	// writes an OA blob onto a wolf and the SECOND fails to load it.
+	//
+	// Routed by ref TYPE rather than by adding one more ID case, because the
+	// question "is this a condition" is answered by the ref itself, and the
+	// alternative is this switch growing a copy of the conditions package's own
+	// dispatch — the drift risk AllTraitRefs already documents, doubled.
+	if peek.Ref.Type == refs.TypeConditions {
+		condition, err := conditions.LoadJSON(data)
+		if err != nil {
+			return nil, rpgerr.Wrapf(err, "failed to load monster condition %s", peek.Ref.ID)
+		}
+
+		return condition, nil
 	}
 
 	// Route based on ref ID
@@ -219,6 +243,22 @@ func AttachMonster(
 		// The ref LoadJSON just routed on, peeked again because a
 		// ConditionBehavior cannot name itself.
 		traitBus := dnd5eEvents.BusForEffect(bus, peekTraitRef(blob))
+
+		// A condition that wants its own live sheet gets it here, before Apply
+		// subscribes it to anything — the same handoff character.Attach has made
+		// since rpg-toolkit#1178, which until now happened for characters only.
+		//
+		// The asymmetry was invisible while no monster trait implemented
+		// OwnerAware, and stops being invisible the moment a monster carries a
+		// condition that keeps turn-scoped memory: the opportunity attack's
+		// once-per-turn flag is stored on the condition, serialized as part of
+		// this sheet, and dropped unless the condition can say the sheet
+		// changed. What a monster does NOT satisfy is combat.Ledger, and that
+		// asymmetry is deliberate — Kirk ruled that characters pay a reaction
+		// slot and monsters are metered by the flag alone (rpg-project#316).
+		if aware, ok := condition.(dnd5eEvents.OwnerAware); ok {
+			aware.SetOwner(m)
+		}
 
 		if err := condition.Apply(ctx, traitBus); err != nil {
 			// Clean up any partial subscriptions from the failed Apply.

--- a/rulebooks/dnd5e/monstertraits/loader.go
+++ b/rulebooks/dnd5e/monstertraits/loader.go
@@ -18,11 +18,18 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
-// LoadJSON loads a monster trait from its JSON representation.
-// The game server stores traits as opaque JSON blobs;
-// this function deserializes them into strongly-typed structs.
+// LoadJSON loads one persisted entry of a monster's sheet — a monster TRAIT or
+// an ordinary CONDITION — from its JSON representation.
 //
-// Note: This loader requires a dice.Roller for traits like Undead Fortitude
+// Both, because monster.Data.Conditions holds both: the four traits this
+// package owns (immunity, vulnerability, pack tactics, undead fortitude), which
+// are authored on the stat block, and the runtime conditions its own field
+// comment has always named — poisoned, hidden, and now the universal
+// opportunity attack. A condition is recognised by its ref TYPE and handed to
+// conditions.LoadJSON; anything else routes through this package's own dispatch
+// and an unknown ref is refused.
+//
+// Note: this loader requires a dice.Roller for traits like Undead Fortitude
 // that need to make saving throws.
 func LoadJSON(data json.RawMessage, roller dice.Roller) (dnd5eEvents.ConditionBehavior, error) {
 	// Peek at the ref to determine trait type
@@ -153,9 +160,13 @@ func LoadMonsterConditions(
 		// A plain bus returns itself, so this is a no-op for every caller that
 		// is not an attach site keeping a registration list; a bus that
 		// implements dnd5eEvents.EffectScoper gets to record which trait made
-		// each subscription. The ref is the one LoadJSON just routed on, peeked
-		// again here because a ConditionBehavior cannot name itself.
-		traitBus := dnd5eEvents.BusForEffect(bus, peekTraitRef(data))
+		// each subscription.
+		//
+		// ASKED OF THE CONDITION, not peeked back out of its JSON.
+		// ConditionBehavior.Ref exists precisely so a live effect can name
+		// itself honestly (rpg-toolkit#971), and the comment that used to sit
+		// here — "a ConditionBehavior cannot name itself" — predated it.
+		traitBus := dnd5eEvents.BusForEffect(bus, refOf(condition))
 
 		// Apply the condition so it subscribes to events
 		if err := condition.Apply(ctx, traitBus); err != nil {
@@ -240,9 +251,10 @@ func AttachMonster(
 			return rpgerr.Wrapf(err, "failed to load monster condition %d: %s", i, blob)
 		}
 
-		// The ref LoadJSON just routed on, peeked again because a
-		// ConditionBehavior cannot name itself.
-		traitBus := dnd5eEvents.BusForEffect(bus, peekTraitRef(blob))
+		// Asked of the condition rather than peeked back out of the blob — see
+		// LoadMonsterConditions for why, and refOf for what happens when a
+		// condition breaks its own contract.
+		traitBus := dnd5eEvents.BusForEffect(bus, refOf(condition))
 
 		// A condition that wants its own live sheet gets it here, before Apply
 		// subscribes it to anything — the same handoff character.Attach has made
@@ -316,17 +328,17 @@ func unattachMonster(
 	}
 }
 
-// peekTraitRef reads the ref a persisted trait routes on, which is the same
-// field LoadJSON routes on. It returns the zero Ref for a blob that has none
-// rather than an error: LoadJSON has already accepted the blob by this point,
-// and the only thing a missing ref costs is attribution.
-func peekTraitRef(data json.RawMessage) core.Ref {
-	var peek struct {
-		Ref core.Ref `json:"ref"`
-	}
-	if err := json.Unmarshal(data, &peek); err != nil {
-		return core.Ref{}
+// refOf is ConditionBehavior.Ref with the nil case answered.
+//
+// The interface says Ref "must never return nil", and this is what happens when
+// one does anyway: the zero Ref, which is exactly what the JSON peek this
+// replaced returned for a blob with no ref, and costs the same thing —
+// attribution, not correctness. A panic here would take down an attach over a
+// label.
+func refOf(condition dnd5eEvents.ConditionBehavior) core.Ref {
+	if ref := condition.Ref(); ref != nil {
+		return *ref
 	}
 
-	return peek.Ref
+	return core.Ref{}
 }

--- a/rulebooks/dnd5e/monstertraits/monster_carries_a_condition_test.go
+++ b/rulebooks/dnd5e/monstertraits/monster_carries_a_condition_test.go
@@ -1,0 +1,125 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monstertraits_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monstertraits"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+type placed struct {
+	id   string
+	kind core.EntityType
+}
+
+func (p *placed) GetID() string            { return p.id }
+func (p *placed) GetType() core.EntityType { return p.kind }
+
+// carriedOA is the blob a seated opportunity attack leaves on a monster's
+// sheet, written by the condition itself rather than by hand so the test cannot
+// drift from the shape ToData actually produces.
+func carriedOA(t *testing.T, id string) json.RawMessage {
+	t.Helper()
+	raw, err := conditions.NewOpportunityAttackCondition(id).ToJSON()
+	require.NoError(t, err)
+
+	return raw
+}
+
+// A monster's sheet has always been documented as carrying "runtime state:
+// poisoned, hidden, etc.", and this loader knew four TRAITS and errored on
+// everything else — so a monster that ever persisted an ordinary condition
+// could not be loaded again.
+//
+// Nothing had put one there, which is why the gap was invisible. Seating the
+// universal opportunity attack puts one there, and without this the first
+// interaction writes an OA blob onto a wolf and the second refuses to load it,
+// breaking every monster in the game.
+func TestAMonsterCanCarryAnOrdinaryCondition(t *testing.T) {
+	data := &monster.Data{
+		ID: "wolf-1", Name: "Wolf", HitPoints: 11, MaxHitPoints: 11, ArmorClass: 13,
+		Conditions: []json.RawMessage{carriedOA(t, "wolf-1")},
+	}
+
+	m, err := monster.Load(context.Background(), data)
+	require.NoError(t, err, "a sheet carrying a condition must load")
+
+	bus := events.NewEventBus()
+	require.NoError(t, monstertraits.AttachMonster(context.Background(), m, bus, dice.NewRoller()),
+		"and must attach without the trait loader refusing its ref")
+
+	require.Len(t, m.GetConditions(), 1, "the condition is on the sheet, not merely loadable")
+	require.Equal(t, refs.Conditions.OpportunityAttack().String(), m.GetConditions()[0].Ref().String())
+}
+
+// The owner handoff character.Attach has made since rpg-toolkit#1178, now that
+// a monster can carry a condition that needs it.
+//
+// The opportunity attack's once-per-turn meter is stored on the condition and
+// serialized as part of this sheet, so nothing else notices when it changes:
+// without the handoff the flag is set, the sheet never goes dirty, the save is
+// dropped, and a wolf reacts again on the very next call. The meter would exist
+// and mean nothing.
+func TestACarriedConditionIsHandedItsOwnSheet(t *testing.T) {
+	ctx := context.Background()
+	data := &monster.Data{
+		ID: "wolf-1", Name: "Wolf", HitPoints: 11, MaxHitPoints: 11, ArmorClass: 13,
+		Conditions: []json.RawMessage{carriedOA(t, "wolf-1")},
+	}
+
+	m, err := monster.Load(ctx, data)
+	require.NoError(t, err)
+	require.False(t, m.IsDirty(), "a freshly loaded sheet has nothing to save")
+
+	bus := events.NewEventBus()
+	require.NoError(t, monstertraits.AttachMonster(ctx, m, bus, dice.NewRoller()))
+
+	// A room with the wolf next to a rogue who then runs, which is the
+	// condition's whole predicate.
+	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
+		ID: "r", Type: "dungeon",
+		Grid: spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 20, Height: 20}),
+	})
+	require.NoError(t, room.PlaceEntity(&placed{id: "wolf-1", kind: "monster"}, spatial.Position{X: 5, Y: 5}))
+	require.NoError(t, room.PlaceEntity(&placed{id: "rogue-1", kind: "character"}, spatial.Position{X: 5, Y: 6}))
+
+	fired := 0
+	_, err = dnd5eEvents.ReactionTriggerTopic.On(bus).Subscribe(ctx,
+		func(_ context.Context, _ dnd5eEvents.ReactionTriggerEvent) error { fired++; return nil })
+	require.NoError(t, err)
+
+	runCtx := gamectx.WithReactionReadiness(gamectx.WithRoom(ctx, room),
+		gamectx.ReactionReadinessMap{"wolf-1": {refs.Conditions.OpportunityAttack().String(): true}})
+
+	event := &dnd5eEvents.MovementChainEvent{
+		EntityID:     "rogue-1",
+		EntityType:   "character",
+		FromPosition: dnd5eEvents.Position{X: 5, Y: 6},
+		ToPosition:   dnd5eEvents.Position{X: 5, Y: 9},
+	}
+	staged := events.NewStagedChain[*dnd5eEvents.MovementChainEvent](combat.ModifierStages)
+	folded, err := dnd5eEvents.MovementChain.On(bus).PublishWithChain(runCtx, event, staged)
+	require.NoError(t, err)
+	_, err = folded.Execute(runCtx, event)
+	require.NoError(t, err)
+
+	require.Equal(t, 1, fired, "the carried condition really is live on the bus")
+	require.True(t, m.IsDirty(),
+		"the condition spent its meter and said so — a silent update is a dropped save")
+}

--- a/rulebooks/dnd5e/monstertraits/monster_carries_a_condition_test.go
+++ b/rulebooks/dnd5e/monstertraits/monster_carries_a_condition_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/damage"
 	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
@@ -108,10 +109,15 @@ func TestACarriedConditionIsHandedItsOwnSheet(t *testing.T) {
 		gamectx.ReactionReadinessMap{"wolf-1": {refs.Conditions.OpportunityAttack().String(): true}})
 
 	event := &dnd5eEvents.MovementChainEvent{
-		EntityID:     "rogue-1",
-		EntityType:   "character",
+		EntityID:   "rogue-1",
+		EntityType: "character",
+		// ONE CELL. MovementChainEvent documents a single step, and the
+		// predicate does not need more than one: the wolf is at (5,5), so
+		// (5,6) is inside its reach and (5,7) is outside it. A three-cell jump
+		// exercised a shape the event contract does not permit and would hide a
+		// step-specific bug behind the extra distance.
 		FromPosition: dnd5eEvents.Position{X: 5, Y: 6},
-		ToPosition:   dnd5eEvents.Position{X: 5, Y: 9},
+		ToPosition:   dnd5eEvents.Position{X: 5, Y: 7},
 	}
 	staged := events.NewStagedChain[*dnd5eEvents.MovementChainEvent](combat.ModifierStages)
 	folded, err := dnd5eEvents.MovementChain.On(bus).PublishWithChain(runCtx, event, staged)
@@ -122,4 +128,43 @@ func TestACarriedConditionIsHandedItsOwnSheet(t *testing.T) {
 	require.Equal(t, 1, fired, "the carried condition really is live on the bus")
 	require.True(t, m.IsDirty(),
 		"the condition spent its meter and said so — a silent update is a dropped save")
+}
+
+// The substitution this package now depends on: a loaded entry names itself
+// with the SAME ref its persisted blob routes on.
+//
+// Attribution used to be taken by peeking the ref back out of the JSON, and is
+// now taken from ConditionBehavior.Ref (rpg-toolkit#971). Those are only
+// interchangeable if every routed entry agrees with its own blob — a trait whose
+// Ref returned something else would silently file its subscriptions under the
+// wrong effect, which no behavioural test would notice because the subscriptions
+// still work.
+func TestEveryLoadedEntryNamesItselfWithItsPersistedRef(t *testing.T) {
+	built := []dnd5eEvents.ConditionBehavior{
+		monstertraits.Immunity("wolf-1", damage.Fire),
+		monstertraits.Vulnerability("wolf-1", damage.Cold),
+		monstertraits.PackTactics("wolf-1"),
+		monstertraits.UndeadFortitude("wolf-1", 3, dice.NewRoller()),
+		conditions.NewOpportunityAttackCondition("wolf-1"),
+	}
+	require.Len(t, built, len(monstertraits.AllTraitRefs())+1,
+		"every routed trait is covered here, plus the condition route this PR adds")
+
+	for _, entry := range built {
+		blob, err := entry.ToJSON()
+		require.NoError(t, err)
+
+		var peek struct {
+			Ref core.Ref `json:"ref"`
+		}
+		require.NoError(t, json.Unmarshal(blob, &peek))
+
+		loaded, err := monstertraits.LoadJSON(blob, dice.NewRoller())
+		require.NoError(t, err, "%s must round-trip through the loader", peek.Ref)
+
+		require.NotNil(t, loaded.Ref(), "%s: Ref must never return nil", peek.Ref)
+		require.Equal(t, peek.Ref.String(), loaded.Ref().String(),
+			"%s names itself differently than its blob routes on — attribution would be filed wrong",
+			peek.Ref)
+	}
 }

--- a/rulebooks/dnd5e/monstertraits/refof_internal_test.go
+++ b/rulebooks/dnd5e/monstertraits/refof_internal_test.go
@@ -1,0 +1,46 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monstertraits
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+// namelessCondition breaks ConditionBehavior's "Ref must never return nil"
+// contract, which is the only way to reach refOf's guard.
+type namelessCondition struct{ ref *core.Ref }
+
+func (n *namelessCondition) Ref() *core.Ref                                { return n.ref }
+func (n *namelessCondition) IsApplied() bool                               { return false }
+func (n *namelessCondition) Apply(context.Context, events.EventBus) error  { return nil }
+func (n *namelessCondition) Remove(context.Context, events.EventBus) error { return nil }
+func (n *namelessCondition) ToJSON() (json.RawMessage, error)              { return json.RawMessage(`{}`), nil }
+
+// The guard is defensive and therefore easy to leave unexercised — mutation
+// testing caught exactly that, with "return *condition.Ref()" surviving the
+// whole suite.
+//
+// What it buys is stated in refOf's own doc and is worth holding: attribution is
+// a LABEL. A condition that breaks its contract should cost the label, not take
+// down an attach that would otherwise have worked, and a nil dereference here
+// would panic through AttachMonster with no indication that the cause was a
+// misbehaving effect rather than the monster.
+func TestRefOfAnswersForAConditionThatWillNotNameItself(t *testing.T) {
+	require.NotPanics(t, func() {
+		require.Equal(t, core.Ref{}, refOf(&namelessCondition{ref: nil}),
+			"a nameless condition costs attribution, not the attach")
+	})
+
+	named := refs.MonsterTraits.PackTactics()
+	require.Equal(t, *named, refOf(&namelessCondition{ref: named}),
+		"and a condition that does name itself is passed straight through")
+}


### PR DESCRIPTION
Third build step of rpg-project#316 — the opportunity attack fires. Design: rpg-project#317.
Follows rpg-toolkit#1281 and #1282 (both merged).

## A landmine, found by running the seating rather than by reading the loader

`monster.Data.Conditions` has been documented since it existed as *"runtime state: poisoned,
hidden, etc."* — while `monstertraits.LoadJSON` knew four **traits** and **errored** on everything
else. So a monster that ever persisted an ordinary condition could not be loaded again.

Nothing had ever put one there, which is exactly why the gap was invisible.

Seating the universal opportunity attack is what puts one there. The next step in this slice
seats it by publishing `ConditionAppliedEvent`, which is how Rage attaches — the sheet keeper
applies it, appends it to the sheet, and marks the sheet dirty, so it persists and comes back
through the ordinary loader. That persistence is not a nicety: the condition meters itself with
`UsedThisTurn` (Kirk's ruling), a walk is one interaction *per cell*, and a meter that does not
survive between interactions cannot stop a reactor swinging at every cell of the same walk.

Without this PR, the first interaction writes an OA blob onto a wolf and **the second refuses to
load it** — breaking every monster in the game. I found it because the seating work turned a
resolution test red, not because I read the switch.

Routed by ref **type** rather than by adding one more ID case: "is this a condition" is answered
by the ref itself, and the alternative is this switch growing a copy of the `conditions` package's
own dispatch — the drift risk `AllTraitRefs` already documents in its own comment, doubled.

## The owner handoff, now that it is reachable

`AttachMonster` now honours `OwnerAware` — the handoff `character.Attach` has made since
rpg-toolkit#1178.

I wrote this branch in #1281 and then **removed it as unreachable**: at that point no monster trait
implemented `OwnerAware` and none could, so it would have been dead code the day it shipped. A
carried opportunity attack is the case that makes it reachable, which is why it lands here and not
there.

It matters concretely. The once-per-turn meter is stored on the condition and serialized as part
of the sheet, so nothing else notices when it changes: without the handoff the flag is set, the
sheet never goes dirty, the save is dropped, and a wolf reacts again on the very next call. The
meter would exist and mean nothing.

What a monster still does **not** satisfy is `combat.Ledger`, and that asymmetry is deliberate —
Kirk ruled characters pay a reaction slot and monsters are metered by the flag alone.

## Evidence

Two tests, both end-to-end through the real load-and-attach path rather than against a stub:
a monster carrying an OA blob loads and attaches, and a carried condition that spends its meter
during a real `MovementChain` fold leaves the sheet dirty. Full `rulebooks/dnd5e` suite green,
`golangci-lint` clean, both mutants killed:

| mutant | result |
|---|---|
| conditions not routed (back to trait-only) | killed |
| owner handoff skipped again | killed |

— platform agent, on behalf of KirkDiggler
