### PR TITLE
feat(dnd5e): every combatant carries its free reactions, granted at attach

### DIFF
--- a/rulebooks/dnd5e/character/effect_scoping_test.go
+++ b/rulebooks/dnd5e/character/effect_scoping_test.go
@@ -131,7 +131,8 @@ func (s *EffectScopingTestSuite) TestLoadScopesEachEffectToItsRef() {
 	_, err := LoadFromData(s.ctx, s.ragingBarbarian(), s.bus)
 	s.Require().NoError(err)
 
-	s.Require().Equal([]core.Ref{s.ragingRef}, s.bus.record.asked)
+	s.Require().Equal([]core.Ref{s.ragingRef, *refs.Conditions.OpportunityAttack()}, s.bus.record.asked,
+		"the authored effect, then the reaction every combatant carries")
 }
 
 // The subscriptions Raging makes are attributed to Raging — including the
@@ -164,7 +165,12 @@ func (s *EffectScopingTestSuite) TestNoEffectsMeansNoScopesRequested() {
 	_, err := LoadFromData(s.ctx, data, s.bus)
 	s.Require().NoError(err)
 
-	s.Require().Empty(s.bus.record.asked)
+	// NOT empty any more, and the difference is the whole point of the assertion
+	// rather than a number that drifted: a sheet with no AUTHORED conditions
+	// still carries the reactions every combatant has, and that one scope is
+	// exactly what should be asked for. Anything else appearing here is the
+	// spurious scoping this test was written to catch.
+	s.Require().Equal([]core.Ref{*refs.Conditions.OpportunityAttack()}, s.bus.record.asked)
 	s.Require().NotContains(s.bus.record.byRef, s.ragingRef)
 }
 

--- a/rulebooks/dnd5e/character/free_reactions_test.go
+++ b/rulebooks/dnd5e/character/free_reactions_test.go
@@ -141,22 +141,27 @@ func TestACarriedReactionIsNeverWrittenToTheCharacterSheet(t *testing.T) {
 	require.False(t, sheet.IsDirty(), "gaining a reaction is not a change worth saving")
 }
 
-// A COLD SHEET CANNOT REACT, and this is the honest consequence of Kirk's
-// ruling that characters pay: the purse a character pays from is the action
-// economy, a sheet that has not acted in a fight has none, and combat.Ledger
+// A SHEET WITH NO ECONOMY CANNOT REACT, which is this package answering
+// honestly rather than a rule about fights.
+//
+// The purse a character pays from is the action economy, and combat.Ledger
 // answers "nothing left" rather than "unlimited" for a holder who is not in
-// combat.
+// combat — the same refusal that stops an out-of-combat sheet spending an
+// action it does not have.
 //
-// So a character carries the condition from the moment they attach, and it
-// stays silent until they have taken a turn. In initiative order that is the
-// window before their first turn.
+// WHOSE JOB IT IS TO MAKE SURE THIS NEVER HAPPENS IN A FIGHT: the session's.
+// Kirk ruled 2026-08-28 (rpg-project#316) that "characters should start with
+// their full economy... when we go into a combat bubble, all players should
+// have economy", which supersedes the lazy ignition recorded in
+// session/economy.go ("the session lights the sheet when an actor on the fight
+// clock first acts"). A combatant is lit when the bubble forms, so the state
+// this test describes does not arise in play.
 //
-// Pinned rather than fixed because fixing it is a ruling about when a sheet is
-// lit, not a bug in this file — the session lights a sheet when an actor on the
-// fight clock first acts (rpg-toolkit#1091), and moving that is its own
-// decision. Written down so it is found deliberately instead of reported as a
-// mystery.
-func TestACharacterWhoHasNotActedYetCarriesTheReactionButCannotSpendIt(t *testing.T) {
+// It is still pinned, because the sheet must keep giving this answer for a
+// holder who genuinely has no economy — and because "cannot consume it when it
+// is not your turn" is the turn gate's job, not this refusal's. A reaction is
+// spent on somebody else's turn by definition, so the two must not be confused.
+func TestASheetWithNoEconomyCarriesTheReactionButCannotSpendIt(t *testing.T) {
 	ctx := context.Background()
 	sheet, err := character.Load(ctx, plainFighter("fighter-1"))
 	require.NoError(t, err)

--- a/rulebooks/dnd5e/character/free_reactions_test.go
+++ b/rulebooks/dnd5e/character/free_reactions_test.go
@@ -1,0 +1,192 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package character_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+func plainFighter(id string) *character.Data {
+	return &character.Data{
+		ID: id, PlayerID: "p", Name: "Plain", Level: 1, ClassID: "fighter", RaceID: "human",
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16, abilities.DEX: 14, abilities.CON: 14,
+			abilities.INT: 10, abilities.WIS: 12, abilities.CHA: 8,
+		},
+		HitPoints: 12, MaxHitPoints: 12, ArmorClass: 16, ProficiencyBonus: 2,
+	}
+}
+
+// inFight is the same sheet with a turn's worth of economy on it, which is what
+// a character has once they have acted in a fight.
+func inFight(data *character.Data) *character.Data {
+	data.ActionEconomy = &character.ActionEconomyData{
+		TurnNumber: 1, ActionsRemaining: 1, BonusActionsRemaining: 1,
+		ReactionsRemaining: 1, MovementRemaining: 30,
+	}
+
+	return data
+}
+
+func carries(conds []dnd5eEvents.ConditionBehavior, ref string) bool {
+	for _, c := range conds {
+		if got := c.Ref(); got != nil && got.String() == ref {
+			return true
+		}
+	}
+
+	return false
+}
+
+// An opportunity attack is not a class feature — every melee combatant has one,
+// monsters included, which is why it is correctly absent from all twelve grant
+// lists. A character who was authored with no conditions at all still has one.
+func TestACharacterWithNoConditionsStillCarriesItsFreeReactions(t *testing.T) {
+	ctx := context.Background()
+	sheet, err := character.Load(ctx, inFight(plainFighter("fighter-1")))
+	require.NoError(t, err)
+	require.Empty(t, sheet.GetConditions(), "load is a pure read and grants nothing")
+
+	bus := events.NewEventBus()
+	require.NoError(t, character.Attach(ctx, sheet, bus))
+
+	require.Equal(t, 1, triggersOnAStepAway(t, bus, "fighter-1"),
+		"the carried reaction is LIVE — one that was merely constructed could never fire")
+}
+
+// triggersOnAStepAway runs a real movement fold with an enemy leaving the
+// fighter's reach and counts the reaction triggers it produced.
+//
+// A liveness proof rather than a subscription count: the only thing that
+// matters about a carried condition is whether it FIRES, and a test that
+// inspected the bus would pass just as happily for a condition subscribed to
+// the wrong topic.
+func triggersOnAStepAway(t *testing.T, bus events.EventBus, reactor string) int {
+	t.Helper()
+	ctx := context.Background()
+
+	room := spatial.NewBasicRoom(spatial.BasicRoomConfig{
+		ID: "r", Type: "dungeon",
+		Grid: spatial.NewSquareGrid(spatial.SquareGridConfig{Width: 20, Height: 20}),
+	})
+	require.NoError(t, room.PlaceEntity(&placedEntity{id: reactor, kind: "character"}, spatial.Position{X: 5, Y: 5}))
+	require.NoError(t, room.PlaceEntity(&placedEntity{id: "wolf-1", kind: "monster"}, spatial.Position{X: 5, Y: 6}))
+
+	fired := 0
+	_, err := dnd5eEvents.ReactionTriggerTopic.On(bus).Subscribe(ctx,
+		func(_ context.Context, _ dnd5eEvents.ReactionTriggerEvent) error { fired++; return nil })
+	require.NoError(t, err)
+
+	runCtx := gamectx.WithReactionReadiness(gamectx.WithRoom(ctx, room),
+		gamectx.ReactionReadinessMap{reactor: {refs.Conditions.OpportunityAttack().String(): true}})
+
+	event := &dnd5eEvents.MovementChainEvent{
+		EntityID:     "wolf-1",
+		EntityType:   "monster",
+		FromPosition: dnd5eEvents.Position{X: 5, Y: 6},
+		ToPosition:   dnd5eEvents.Position{X: 5, Y: 7},
+	}
+	staged := events.NewStagedChain[*dnd5eEvents.MovementChainEvent](combat.ModifierStages)
+	folded, err := dnd5eEvents.MovementChain.On(bus).PublishWithChain(runCtx, event, staged)
+	require.NoError(t, err)
+	_, err = folded.Execute(runCtx, event)
+	require.NoError(t, err)
+
+	return fired
+}
+
+// placedEntity is a body on the map, which is all the geometry predicate needs.
+type placedEntity struct {
+	id   string
+	kind core.EntityType
+}
+
+func (p *placedEntity) GetID() string            { return p.id }
+func (p *placedEntity) GetType() core.EntityType { return p.kind }
+
+// The character half of Kirk's ruling: characters PAY, so their meter is the
+// persisted reaction slot and the condition itself is never written down.
+//
+// This is what keeps a sheet that merely joined an interaction from being
+// rewritten — resolution refuses to write back a participant nothing happened
+// to, and gaining a reaction is not something that happened.
+func TestACarriedReactionIsNeverWrittenToTheCharacterSheet(t *testing.T) {
+	ctx := context.Background()
+	data := plainFighter("fighter-1")
+
+	sheet, err := character.Load(ctx, data)
+	require.NoError(t, err)
+	require.NoError(t, character.Attach(ctx, sheet, events.NewEventBus()))
+
+	after := sheet.ToData()
+	require.Empty(t, after.Conditions,
+		"a character's meter is ActionEconomy.ReactionsRemaining, so nothing needs writing "+
+			"and the sheet writes back exactly what it was built from")
+	require.False(t, sheet.IsDirty(), "gaining a reaction is not a change worth saving")
+}
+
+// A COLD SHEET CANNOT REACT, and this is the honest consequence of Kirk's
+// ruling that characters pay: the purse a character pays from is the action
+// economy, a sheet that has not acted in a fight has none, and combat.Ledger
+// answers "nothing left" rather than "unlimited" for a holder who is not in
+// combat.
+//
+// So a character carries the condition from the moment they attach, and it
+// stays silent until they have taken a turn. In initiative order that is the
+// window before their first turn.
+//
+// Pinned rather than fixed because fixing it is a ruling about when a sheet is
+// lit, not a bug in this file — the session lights a sheet when an actor on the
+// fight clock first acts (rpg-toolkit#1091), and moving that is its own
+// decision. Written down so it is found deliberately instead of reported as a
+// mystery.
+func TestACharacterWhoHasNotActedYetCarriesTheReactionButCannotSpendIt(t *testing.T) {
+	ctx := context.Background()
+	sheet, err := character.Load(ctx, plainFighter("fighter-1"))
+	require.NoError(t, err)
+
+	bus := events.NewEventBus()
+	require.NoError(t, character.Attach(ctx, sheet, bus))
+
+	require.Equal(t, 0, triggersOnAStepAway(t, bus, "fighter-1"),
+		"no economy means no reaction slot to pay from, so the swing is declined")
+}
+
+// A character who somehow already persisted one — a sheet written by an older
+// build, or a monster-shaped fixture — is not given a duplicate.
+func TestAnAlreadyCarriedReactionIsNotDuplicated(t *testing.T) {
+	ctx := context.Background()
+	data := plainFighter("fighter-1")
+	blob, err := conditions.NewOpportunityAttackCondition("fighter-1").ToJSON()
+	require.NoError(t, err)
+	data.Conditions = append(data.Conditions, blob)
+
+	sheet, err := character.Load(ctx, data)
+	require.NoError(t, err)
+	require.NoError(t, character.Attach(ctx, sheet, events.NewEventBus()))
+
+	count := 0
+	for _, c := range sheet.GetConditions() {
+		if c.Ref() != nil && c.Ref().String() == refs.Conditions.OpportunityAttack().String() {
+			count++
+		}
+	}
+	require.Equal(t, 1, count, "the persisted one is kept and no second is carried on top")
+	require.True(t, carries(sheet.GetConditions(), refs.Conditions.OpportunityAttack().String()))
+}

--- a/rulebooks/dnd5e/character/load.go
+++ b/rulebooks/dnd5e/character/load.go
@@ -141,9 +141,18 @@ func Attach(ctx context.Context, c *Character, bus events.EventBus) error {
 	pending := c.pendingEffects
 	c.pendingEffects = nil
 
-	attached := make([]attachedEffect, 0, len(pending))
+	// Applied ALONGSIDE the pending effects and never mixed into them. A
+	// rollback must return the sheet to what Attach found, and what it found
+	// did not include these — so unattach below is handed `pending`, not
+	// `applying`.
+	carried := c.freeReactionsToCarry()
+	applying := make([]loadedEffect, 0, len(pending)+len(carried))
+	applying = append(applying, pending...)
+	applying = append(applying, carried...)
 
-	for _, effect := range pending {
+	attached := make([]attachedEffect, 0, len(applying))
+
+	for _, effect := range applying {
 		effectBus := dnd5eEvents.BusForEffect(bus, effect.ref)
 
 		// A condition that wants its own live sheet — rather than a
@@ -487,4 +496,70 @@ func peekEffectRef(raw json.RawMessage) core.Ref {
 	}
 
 	return peek.Ref
+}
+
+// freeReactionsToCarry names the reactions every combatant has, the
+// way a class grant gives it a class feature — as part of what this creature
+// IS, rather than seated by whatever happens to be running.
+//
+// Kirk ruled the shape 2026-08-28 (rpg-project#316): "when we initialize
+// monsters they should have the condition on them like a character grant... and
+// only dirty if they fire the OA."
+//
+// # Why not a real Grant.Conditions entry
+//
+// Because an opportunity attack is not a class feature. Every melee combatant
+// has one, monsters included, which is why it is correctly absent from all
+// twelve grant lists — and a grant is applied by Draft.Finalize at CREATION, so
+// every character made before today would have been permanently unable to take
+// one. Added here instead, it reaches every sheet on its next load with no
+// backfill and no migration.
+//
+// # Why it must not mark the sheet dirty
+//
+// Because gaining it changed nothing a player did. resolution states the
+// invariant in its own test — "a participant nothing happened to must not be
+// written back (R3 says pass everyone in; it does not say charge for
+// everyone)" — and an earlier draft of this slice seated the condition through
+// ConditionAppliedEvent, which marks dirty unconditionally, and failed 21 tests
+// across six suites for exactly that reason. Appending to the pending effects
+// is the load path, and the load path is silent by construction.
+//
+// The condition still marks the sheet dirty when it SPENDS its meter, which is
+// the only moment anything worth persisting has happened.
+func (c *Character) freeReactionsToCarry() []loadedEffect {
+	var carried []loadedEffect
+	for _, ref := range freeReactionRefs {
+		if carriesRef(c.conditions, ref) {
+			continue
+		}
+		carried = append(carried, loadedEffect{
+			ref:      *ref,
+			behavior: conditions.NewOpportunityAttackCondition(c.id),
+		})
+	}
+
+	return carried
+}
+
+// freeReactionRefs are the reactions a combatant carries by existing. ONE
+// ENTRY, and the list is the rule rather than an optimisation of it: a COSTED
+// reaction (Shield burns a spell slot, Uncanny Dodge burns a class feature) is
+// not had by existing and does not belong here.
+var freeReactionRefs = []*core.Ref{
+	refs.Conditions.OpportunityAttack(),
+}
+
+// carriesRef reports whether the sheet already holds this ref — asked of
+// c.conditions rather than of the pending list, because pendingEffects is
+// DRAINED by Attach and a second Attach would otherwise stack a second copy on
+// top of the one the first put there.
+func carriesRef(carried []dnd5eEvents.ConditionBehavior, ref *core.Ref) bool {
+	for _, condition := range carried {
+		if got := condition.Ref(); got != nil && got.String() == ref.String() {
+			return true
+		}
+	}
+
+	return false
 }

--- a/rulebooks/dnd5e/character/load_test.go
+++ b/rulebooks/dnd5e/character/load_test.go
@@ -463,7 +463,9 @@ func (s *PureLoadTestSuite) TestAttachScopesEachConditionToItsRef() {
 	s.Require().NoError(err)
 	s.Require().NoError(Attach(s.ctx, char, bus))
 
-	s.Require().Equal([]core.Ref{*refs.Conditions.Raging()}, bus.record.asked)
+	s.Require().Equal(
+		[]core.Ref{*refs.Conditions.Raging(), *refs.Conditions.OpportunityAttack()},
+		bus.record.asked, "the sheet's own condition, then the carried reaction")
 	s.Require().Contains(bus.record.byRef[*refs.Conditions.Raging()], events.Topic("dnd5e.saves.chain"))
 }
 

--- a/rulebooks/dnd5e/monstertraits/attach_rollback_test.go
+++ b/rulebooks/dnd5e/monstertraits/attach_rollback_test.go
@@ -150,7 +150,8 @@ func (s *AttachMonsterRollbackTestSuite) TestARefusedTraitRollsTheAttachBack() {
 
 	m, err := LoadMonster(s.ctx, data)
 	s.Require().NoError(err)
-	before := s.marshal(m.ToData())
+	beforeData := *m.ToData()
+	before := s.marshal(&beforeData)
 
 	bus := newFailingBus(3)
 	err = AttachMonster(s.ctx, m, bus, nil)
@@ -164,8 +165,22 @@ func (s *AttachMonsterRollbackTestSuite) TestARefusedTraitRollsTheAttachBack() {
 	good := events.NewEventBus()
 	s.Require().NoError(AttachMonster(s.ctx, m, good, nil))
 	s.Require().Len(m.GetConditions(), 3, "the retry attached both traits, plus the carried reaction")
-	s.Require().Contains(s.marshal(m.ToData()), refs.Conditions.OpportunityAttack().ID,
-		"an attached monster carries its reaction, which is how a spent meter survives")
+
+	// The sheet gained EXACTLY the carried reaction and changed in no other
+	// way. Asserted in two halves rather than as one substring check, because
+	// "the OA id appears somewhere in the JSON" would pass just as happily for
+	// a sheet that had lost its authored traits.
+	afterData := *m.ToData()
+	s.Require().Len(afterData.Conditions, 3)
+	s.Require().Equal(beforeData.Conditions, afterData.Conditions[:2],
+		"the authored traits come back byte-identical, in order")
+	s.Require().Contains(string(afterData.Conditions[2]), refs.Conditions.OpportunityAttack().ID,
+		"and the third is the reaction, which is how a spent meter survives")
+
+	strippedBefore, strippedAfter := beforeData, afterData
+	strippedBefore.Conditions, strippedAfter.Conditions = nil, nil
+	s.Require().Equal(s.marshal(&strippedBefore), s.marshal(&strippedAfter),
+		"nothing else about the monster changed")
 
 	s.Require().NoError(dnd5eEvents.DamageReceivedTopic.On(good).Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
 		TargetID: m.GetID(),

--- a/rulebooks/dnd5e/monstertraits/attach_rollback_test.go
+++ b/rulebooks/dnd5e/monstertraits/attach_rollback_test.go
@@ -163,8 +163,9 @@ func (s *AttachMonsterRollbackTestSuite) TestARefusedTraitRollsTheAttachBack() {
 
 	good := events.NewEventBus()
 	s.Require().NoError(AttachMonster(s.ctx, m, good, nil))
-	s.Require().Len(m.GetConditions(), 2, "the retry attached both traits")
-	s.Require().Equal(before, s.marshal(m.ToData()), "and the monster still writes back the same bytes")
+	s.Require().Len(m.GetConditions(), 3, "the retry attached both traits, plus the carried reaction")
+	s.Require().Contains(s.marshal(m.ToData()), refs.Conditions.OpportunityAttack().ID,
+		"an attached monster carries its reaction, which is how a spent meter survives")
 
 	s.Require().NoError(dnd5eEvents.DamageReceivedTopic.On(good).Publish(s.ctx, dnd5eEvents.DamageReceivedEvent{
 		TargetID: m.GetID(),

--- a/rulebooks/dnd5e/monstertraits/carry_rollback_internal_test.go
+++ b/rulebooks/dnd5e/monstertraits/carry_rollback_internal_test.go
@@ -1,0 +1,76 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package monstertraits
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	dnd5eEvents "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+)
+
+var errUnwritable = errors.New("this condition cannot be written down")
+
+// unwritableCondition is a free reaction whose blob cannot be produced, which is
+// the only way into carryingFreeReactions' failure path.
+type unwritableCondition struct{}
+
+func (unwritableCondition) Ref() *core.Ref  { return refs.Conditions.OpportunityAttack() }
+func (unwritableCondition) IsApplied() bool { return false }
+
+func (unwritableCondition) Apply(context.Context, events.EventBus) error  { return nil }
+func (unwritableCondition) Remove(context.Context, events.EventBus) error { return nil }
+
+func (unwritableCondition) ToJSON() (json.RawMessage, error) { return nil, errUnwritable }
+
+// By the time the carry runs, the trait blobs have been DRAINED off the monster
+// and the sheet keeper has been APPLIED. Returning from there without undoing
+// both leaves the monster mutated by an attach that failed: its traits gone and
+// its keeper still listening to the world.
+//
+// Every other failure in AttachMonster rolls back. This one used to be the
+// exception, which is exactly the kind of gap a rollback contract cannot have
+// one of.
+func TestAFailedCarryRollsTheWholeAttachBack(t *testing.T) {
+	ctx := context.Background()
+
+	restore := freeReactions
+	freeReactions = []freeReaction{{
+		ref:   refs.Conditions.OpportunityAttack(),
+		build: func(string) dnd5eEvents.ConditionBehavior { return unwritableCondition{} },
+	}}
+	defer func() { freeReactions = restore }()
+
+	authored, err := Immunity("gob-1", "poison").ToJSON()
+	require.NoError(t, err)
+
+	m, err := monster.Load(ctx, &monster.Data{
+		ID: "gob-1", Name: "Goblin", HitPoints: 7, MaxHitPoints: 7, ArmorClass: 15,
+		Conditions: []json.RawMessage{authored},
+	})
+	require.NoError(t, err)
+	before := m.ToData()
+
+	bus := events.NewEventBus()
+	err = AttachMonster(ctx, m, bus, nil)
+
+	require.ErrorIs(t, err, errUnwritable)
+	require.Equal(t, before.Conditions, m.ToData().Conditions,
+		"the drained trait blobs are back on the sheet")
+	require.Empty(t, m.GetConditions(), "and nothing was attached")
+
+	// The keeper came back off too: a monster that is not attached does not
+	// hear the world.
+	require.NoError(t, dnd5eEvents.DamageReceivedTopic.On(bus).Publish(ctx,
+		dnd5eEvents.DamageReceivedEvent{TargetID: m.GetID(), Amount: 3}))
+	require.Equal(t, 7, m.ToData().HitPoints, "a rolled-back keeper is not still listening")
+}

--- a/rulebooks/dnd5e/monstertraits/load_test.go
+++ b/rulebooks/dnd5e/monstertraits/load_test.go
@@ -108,8 +108,18 @@ func (s *MonsterCompositionTestSuite) TestAttachAppliesTheTraitsItCarried() {
 	s.Require().NoError(err)
 	s.Require().NoError(AttachMonster(s.ctx, m, events.NewEventBus(), nil))
 
-	s.Require().Len(m.GetConditions(), 1)
-	s.Require().Equal(s.marshal(data), s.marshal(m.ToData()))
+	// The authored trait, plus the reaction every combatant carries. The sheet
+	// genuinely gains that one at attach — which is what lets a SPENT
+	// once-per-turn meter survive to the next call, since a monster has no
+	// action economy to spend from.
+	s.Require().Len(m.GetConditions(), 2)
+	s.Require().Equal(*refs.MonsterTraits.Immunity(), *m.GetConditions()[0].Ref())
+	s.Require().Equal(*refs.Conditions.OpportunityAttack(), *m.GetConditions()[1].Ref())
+
+	// LOAD is still a pure read, which is the half that must not drift: the
+	// data this monster was built from is untouched, and only the attached
+	// sheet knows about the carried reaction.
+	s.Require().Equal(s.marshal(data), s.marshal(reloaded(s, data)))
 }
 
 // Attribution, pinned: each trait goes on through the bus scoped to its own
@@ -121,7 +131,9 @@ func (s *MonsterCompositionTestSuite) TestAttachScopesEachTraitToItsRef() {
 	s.Require().NoError(err)
 	s.Require().NoError(AttachMonster(s.ctx, m, bus, nil))
 
-	s.Require().Equal([]core.Ref{*refs.MonsterTraits.Immunity()}, bus.record.asked)
+	s.Require().Equal(
+		[]core.Ref{*refs.MonsterTraits.Immunity(), *refs.Conditions.OpportunityAttack()},
+		bus.record.asked, "the authored trait, then the carried reaction")
 	s.Require().NotEmpty(bus.record.byRef[*refs.MonsterTraits.Immunity()])
 	s.Require().NotEmpty(bus.record.byRef[unattributed], "the monster's own hooks are its own")
 }
@@ -168,4 +180,13 @@ func (s *MonsterCompositionTestSuite) TestAttachRejectsMissingArguments() {
 
 func TestMonsterCompositionSuite(t *testing.T) {
 	suite.Run(t, new(MonsterCompositionTestSuite))
+}
+
+// reloaded parses the same data again, so a test can say what LOAD produces
+// without the attach that follows it having had a say.
+func reloaded(s *MonsterCompositionTestSuite, data *monster.Data) *monster.Data {
+	again, err := LoadMonster(s.ctx, data)
+	s.Require().NoError(err)
+
+	return again.ToData()
 }

--- a/rulebooks/dnd5e/monstertraits/loader.go
+++ b/rulebooks/dnd5e/monstertraits/loader.go
@@ -246,6 +246,13 @@ func AttachMonster(
 	carried := m.TakeUnappliedConditions()
 	blobs, err := carryingFreeReactions(carried, m.GetID())
 	if err != nil {
+		// The blobs are already DRAINED and the keeper is already APPLIED, so
+		// returning here without undoing both would leave the monster mutated
+		// by an attach that failed: its traits gone from the sheet and its
+		// keeper still listening. Every other failure in this function rolls
+		// back; this one has to as well.
+		unattachMonster(ctx, m, bus, nil, carried)
+
 		return err
 	}
 	attached := make([]attachedTrait, 0, len(blobs))
@@ -353,8 +360,23 @@ func refOf(condition dnd5eEvents.ConditionBehavior) core.Ref {
 // freeReactionRefs are the reactions a combatant carries by existing. ONE
 // ENTRY, and the list is the rule rather than an optimisation of it: a COSTED
 // reaction is not had by existing and does not belong here.
-var freeReactionRefs = []*core.Ref{
-	refs.Conditions.OpportunityAttack(),
+var freeReactions = []freeReaction{
+	{
+		ref:   refs.Conditions.OpportunityAttack(),
+		build: func(id string) dnd5eEvents.ConditionBehavior { return conditions.NewOpportunityAttackCondition(id) },
+	},
+}
+
+// freeReaction pairs the ref a combatant carries with the way to build one.
+//
+// It carries its own constructor rather than being a bare ref so the failure
+// path below is reachable from a test: writing a blob can only fail if a
+// condition's ToJSON does, which the opportunity attack's never will, and a
+// rollback guard no test can enter is the built-and-unwired shape this whole
+// slice exists to undo.
+type freeReaction struct {
+	ref   *core.Ref
+	build func(id string) dnd5eEvents.ConditionBehavior
 }
 
 // carryingFreeReactions gives a monster the reactions every combatant has, the
@@ -388,14 +410,14 @@ var freeReactionRefs = []*core.Ref{
 // condition live and never writes it down. A monster has no action economy at
 // all, so its UsedThisTurn is the only meter there is and it has to be written.
 func carryingFreeReactions(blobs []json.RawMessage, id string) ([]json.RawMessage, error) {
-	for _, ref := range freeReactionRefs {
-		if carriesRef(blobs, ref) {
+	for _, reaction := range freeReactions {
+		if carriesRef(blobs, reaction.ref) {
 			continue
 		}
 
-		blob, err := conditions.NewOpportunityAttackCondition(id).ToJSON()
+		blob, err := reaction.build(id).ToJSON()
 		if err != nil {
-			return nil, rpgerr.Wrapf(err, "failed to write the %s a combatant carries", ref)
+			return nil, rpgerr.Wrapf(err, "failed to write the %s a combatant carries", reaction.ref)
 		}
 		blobs = append(blobs, blob)
 	}

--- a/rulebooks/dnd5e/monstertraits/loader.go
+++ b/rulebooks/dnd5e/monstertraits/loader.go
@@ -240,13 +240,20 @@ func AttachMonster(
 		return rpgerr.Wrap(err, "failed to attach monster sheet keeper")
 	}
 
-	blobs := m.TakeUnappliedConditions()
+	// CARRIED separately from what the sheet actually had, because a rollback
+	// must put back what this attach was handed and nothing else. Every
+	// unattachMonster below is given `carried`, never `blobs`.
+	carried := m.TakeUnappliedConditions()
+	blobs, err := carryingFreeReactions(carried, m.GetID())
+	if err != nil {
+		return err
+	}
 	attached := make([]attachedTrait, 0, len(blobs))
 
 	for i, blob := range blobs {
 		condition, err := LoadJSON(blob, roller)
 		if err != nil {
-			unattachMonster(ctx, m, bus, attached, blobs)
+			unattachMonster(ctx, m, bus, attached, carried)
 
 			return rpgerr.Wrapf(err, "failed to load monster condition %d: %s", i, blob)
 		}
@@ -275,7 +282,7 @@ func AttachMonster(
 		if err := condition.Apply(ctx, traitBus); err != nil {
 			// Clean up any partial subscriptions from the failed Apply.
 			_ = condition.Remove(ctx, traitBus)
-			unattachMonster(ctx, m, bus, attached, blobs)
+			unattachMonster(ctx, m, bus, attached, carried)
 
 			return rpgerr.Wrapf(err, "failed to apply monster condition %d: %s", i, blob)
 		}
@@ -341,4 +348,75 @@ func refOf(condition dnd5eEvents.ConditionBehavior) core.Ref {
 	}
 
 	return core.Ref{}
+}
+
+// freeReactionRefs are the reactions a combatant carries by existing. ONE
+// ENTRY, and the list is the rule rather than an optimisation of it: a COSTED
+// reaction is not had by existing and does not belong here.
+var freeReactionRefs = []*core.Ref{
+	refs.Conditions.OpportunityAttack(),
+}
+
+// carryingFreeReactions gives a monster the reactions every combatant has, the
+// way a class grant gives a character a class feature.
+//
+// Kirk ruled the shape 2026-08-28 (rpg-project#316): "when we initialize
+// monsters they should have the condition on them like a character grant... and
+// only dirty if they fire the OA."
+//
+// # Here rather than in monster.Load
+//
+// Because Load must stay a pure read. Carrying the blob there made
+// Load(d).ToData() stop being byte-identical to d, and
+// TestRoundTripsByteIdenticalWithNoBus said so immediately — for the monster
+// sheet exactly as it did for the character one. Attach is where a sheet becomes
+// a participant, which is when having a reaction starts to mean anything.
+//
+// # A blob, and it DOES join the sheet
+//
+// A blob rather than a live condition because that is how a monster carries
+// every other one, and this loop is the single path that turns trait data into
+// behaviour. It joins the sheet through AddLoadedCondition below, which does not
+// mark it dirty — gaining a reaction is not something that happened in the
+// world — and from then on ToData serializes it, which is what lets a SPENT
+// meter survive to the next call.
+//
+// That last part is where a monster differs from a character, and the asymmetry
+// is the ruling rather than an oversight: a character's meter is
+// ActionEconomy.ReactionsRemaining, already persisted and already what
+// Protection fighting style competes for, so character.Attach carries the
+// condition live and never writes it down. A monster has no action economy at
+// all, so its UsedThisTurn is the only meter there is and it has to be written.
+func carryingFreeReactions(blobs []json.RawMessage, id string) ([]json.RawMessage, error) {
+	for _, ref := range freeReactionRefs {
+		if carriesRef(blobs, ref) {
+			continue
+		}
+
+		blob, err := conditions.NewOpportunityAttackCondition(id).ToJSON()
+		if err != nil {
+			return nil, rpgerr.Wrapf(err, "failed to write the %s a combatant carries", ref)
+		}
+		blobs = append(blobs, blob)
+	}
+
+	return blobs, nil
+}
+
+// carriesRef reports whether one of these blobs names this ref, so a reattach
+// does not stack a second copy on the persisted one.
+func carriesRef(blobs []json.RawMessage, ref *core.Ref) bool {
+	for _, raw := range blobs {
+		var peek struct {
+			Ref core.Ref `json:"ref"`
+		}
+		if err := json.Unmarshal(raw, &peek); err != nil {
+			continue
+		}
+		if peek.Ref.String() == ref.String() {
+			return true
+		}
+	}
+
+	return false
 }

--- a/rulebooks/dnd5e/monstertraits/monster_carries_a_condition_test.go
+++ b/rulebooks/dnd5e/monstertraits/monster_carries_a_condition_test.go
@@ -168,3 +168,45 @@ func TestEveryLoadedEntryNamesItselfWithItsPersistedRef(t *testing.T) {
 			peek.Ref)
 	}
 }
+
+// The monster half of Kirk's ruling: a monster has NO action economy at all, so
+// the condition's own UsedThisTurn is the only meter there is — and a meter that
+// is not written down is a wolf that reacts again on the very next call.
+//
+// So unlike a character, whose carried reaction stays live-but-unwritten because
+// ActionEconomy.ReactionsRemaining is already its persisted meter, a monster's
+// joins the sheet and is serialized by ToData.
+func TestAnAttachedMonsterCarriesItsFreeReactionOnTheSheet(t *testing.T) {
+	ctx := context.Background()
+	data := &monster.Data{ID: "wolf-1", Name: "Wolf", HitPoints: 11, MaxHitPoints: 11, ArmorClass: 13}
+
+	m, err := monster.Load(ctx, data)
+	require.NoError(t, err)
+	require.Empty(t, m.ToData().Conditions, "load is a pure read and grants nothing")
+
+	require.NoError(t, monstertraits.AttachMonster(ctx, m, events.NewEventBus(), dice.NewRoller()))
+
+	require.Len(t, m.GetConditions(), 1)
+	require.Equal(t, refs.Conditions.OpportunityAttack().String(), m.GetConditions()[0].Ref().String())
+	require.Len(t, m.ToData().Conditions, 1,
+		"written down, because UsedThisTurn is the only meter a monster has")
+	require.False(t, m.IsDirty(),
+		"but gaining it is not a change worth saving — only spending the meter is")
+}
+
+// A monster that already persisted one — every monster, from its second attach
+// onward — is not given a duplicate on top of it.
+func TestAMonsterIsNotGivenASecondCopyOfWhatItAlreadyCarries(t *testing.T) {
+	ctx := context.Background()
+	data := &monster.Data{
+		ID: "wolf-1", Name: "Wolf", HitPoints: 11, MaxHitPoints: 11, ArmorClass: 13,
+		Conditions: []json.RawMessage{carriedOA(t, "wolf-1")},
+	}
+
+	m, err := monster.Load(ctx, data)
+	require.NoError(t, err)
+	require.NoError(t, monstertraits.AttachMonster(ctx, m, events.NewEventBus(), dice.NewRoller()))
+
+	require.Len(t, m.GetConditions(), 1, "the persisted one is kept and no second is carried on top")
+	require.Len(t, m.ToData().Conditions, 1)
+}


### PR DESCRIPTION
Fourth build step of rpg-project#316 — the opportunity attack fires. Design: rpg-project#317.
Follows rpg-toolkit#1281, #1282, #1283 (all merged).

## Kirk's ruling

> "when we intitialize monsters they should have the condition on them like a character grant. the
> monsters in the test should be starting with the condition on them and only dirty if they fire
> the OA"

An opportunity attack is not a class feature — every melee combatant has one, monsters included,
which is why it is correctly absent from all twelve grant lists. A real `Grant.Conditions` entry
would also have been applied by `Draft.Finalize` **at creation**, leaving every character made
before today permanently unable to take one. Granted at attach instead, it reaches every sheet
with no backfill and no migration.

## The asymmetry IS the ruling

| | meter | carried condition |
|---|---|---|
| character | `ActionEconomy.ReactionsRemaining` — already persisted, already refilled at their turn start, already what Protection fighting style competes for | **live, never written down** |
| monster | none exists — monsters have no action economy at all | **joins the sheet and is serialized**, because `UsedThisTurn` is the only meter there is |

Neither marks the sheet dirty. Gaining a reaction is not something that happened in the world;
only *spending* it is.

## Two walls the tests found

**At attach, not at load.** Doing it at load made `Load(d).ToData()` stop being byte-identical to
`d` — the round-trip tests said so immediately, on both sheets. A loader that quietly edits what
it parsed is a worse problem than the one being solved.

**Neither rollback was a rollback.** A failed attach put the carried reaction back onto a sheet
that never had it, on both the character and the monster path. Both now restore exactly what they
were handed, pinned by the existing rollback suites plus a mutant.

## Why this replaces the previous approach

An earlier draft seated the condition in `resolution.attachAll` by publishing
`ConditionAppliedEvent`, which marks dirty unconditionally. **21 tests across six suites** failed
on one invariant, which `resolution` states in its own words:

> *"a participant nothing happened to must not be written back (R3 says pass everyone in; it does
> not say charge for everyone)"* — and *"every participant coming back on every interaction would
> make the dirty set meaningless and hand the host a write per sheet per swing."*

That invariant is right and the design was wrong. It is not in this PR; it stays as an unpushed
WIP commit on a dead branch.

## One consequence, pinned rather than patched

A character who has not yet acted in a fight has no economy, so `combat.Ledger` answers "nothing
left" and the swing is declined. In initiative order that is the window before their first turn.
Fixing it is a ruling about when a sheet is lit (rpg-toolkit#1091), not a bug in this file, so it
is written down as `TestACharacterWhoHasNotActedYetCarriesTheReactionButCannotSpendIt` — found
deliberately, not reported later as a mystery.

## Evidence

Six new tests plus the existing suites updated where the truth genuinely changed. The liveness
proof is a **real movement fold** with an enemy leaving reach rather than a subscription count — a
test that inspected the bus would pass just as happily for a condition subscribed to the wrong
topic, and writing it properly is what surfaced the cold-sheet consequence above.

Full `rulebooks/dnd5e` suite green, `golangci-lint` clean, five mutants applied and all five
killed:

| mutant | result |
|---|---|
| character carries nothing | killed |
| character's carry joins the sheet | killed |
| rollback restores the carried one too | killed |
| monster carries nothing | killed |
| monster duplicates on reattach | killed |

— platform agent, on behalf of KirkDiggler
