### PR TITLE
docs(gamectx): the record tells the truth about what is installed

### DIFF
--- a/docs/adr/0025-gamectx-pattern.md
+++ b/docs/adr/0025-gamectx-pattern.md
@@ -4,11 +4,15 @@ Date: 2024-12-03
 
 ## Status
 
-Superseded (2026-08-26) by the effect-context design in rpg-project
-(`ideas/session-combat/effect-context/design.md`).
+Superseded by the effect-context design in rpg-project (2026-08-26)
+
+## Superseded — what replaced this
+
+The superseding decision is not an ADR: it is the ruled design at
+`rpg-project/ideas/session-combat/effect-context/design.md`.
 
 Everything this ADR decided has since been split in two: reads of an effect's
-OWN sheet moved to owner injection at attach time (`events.OwnerAware`), and
+OWN sheet moved to owner injection at attach time (`rulebooks/dnd5e/events.OwnerAware`), and
 only facts owned by nobody stay ambient — carried by `gamectx.WithRoom`,
 `WithCast`, and `WithReactionReadiness`, installed unconditionally by
 `resolution` on every resolve path. `GameContext`, `CharacterRegistry`,

--- a/docs/adr/0025-gamectx-pattern.md
+++ b/docs/adr/0025-gamectx-pattern.md
@@ -4,7 +4,19 @@ Date: 2024-12-03
 
 ## Status
 
-Accepted
+Superseded (2026-08-26) by the effect-context design in rpg-project
+(`ideas/session-combat/effect-context/design.md`).
+
+Everything this ADR decided has since been split in two: reads of an effect's
+OWN sheet moved to owner injection at attach time (`events.OwnerAware`), and
+only facts owned by nobody stay ambient — carried by `gamectx.WithRoom`,
+`WithCast`, and `WithReactionReadiness`, installed unconditionally by
+`resolution` on every resolve path. `GameContext`, `CharacterRegistry`,
+`RequireCharacters`, and `AddCharacter` shown below no longer exist
+(rpg-toolkit#1251 deleted the never-installed registries). The current
+contract is stated in `rulebooks/dnd5e/gamectx/doc.go`; the reasoning is in
+the effect-context brainstorm/design. The text below is preserved as the
+record of what was decided in 2024 and why.
 
 ## Context
 

--- a/rulebooks/dnd5e/gamectx/cast.go
+++ b/rulebooks/dnd5e/gamectx/cast.go
@@ -12,10 +12,11 @@ import (
 // Cast is what an effect may ask about the OTHER participants in the
 // interaction it is resolving.
 //
-// Resolution will install it on every path, exactly like the room, and it will
-// die with that call. That wiring is rpg-toolkit#1252 and is NOT in the tree
-// yet: there is no WithCast call site today, so CastOf currently returns
-// ok=false everywhere and every consumer takes its "cannot answer" branch.
+// Resolution installs it on every path, exactly like the room, and it dies
+// with that call — the rpg-toolkit#1252 wiring, landed in #1256 at
+// resolution/resolve.go. On paths no resolution raised (session's standing
+// and preflight attaches), CastOf still answers ok=false and every consumer
+// keeps its "cannot answer" branch, which is why that branch stays.
 //
 // Two registries answered pieces of this question before and neither was ever
 // installed either — gamectx.CharacterRegistry (character-shaped, so it could
@@ -102,18 +103,19 @@ type castContextKey struct{}
 // that there is no "no cast" mode — an ambient dependency that is sometimes
 // absent fails silently, which is the defect this seam exists to replace.
 //
-// That call site does not exist yet (rpg-toolkit#1252). Until it lands, read
-// CastOf's second return exactly as documented rather than assuming a cast is
-// present.
+// Resolution does exactly that (resolve.go, since rpg-toolkit#1256), and
+// TestNoCodePathProducesACastlessInteraction holds it structurally. Still
+// read CastOf's second return exactly as documented rather than assuming a
+// cast is present — not every attach happens under a resolution.
 func WithCast(ctx context.Context, c Cast) context.Context {
 	return context.WithValue(ctx, castContextKey{}, c)
 }
 
 // CastOf retrieves the Cast from the context, and whether one was there.
 //
-// Read it defensively. Nothing installs a cast yet (rpg-toolkit#1252), and
-// even once resolution does, an effect can be attached by something other than
-// a resolution — session's standing and preflight paths both do. "I could not
+// Read it defensively. Resolution installs a cast on every resolve path
+// (rpg-toolkit#1256), but an effect can be attached by something other than a
+// resolution — session's standing and preflight paths both do. "I could not
 // ask" has to stay expressible rather than becoming a panic or a rule invented
 // out of missing data.
 func CastOf(ctx context.Context) (Cast, bool) {

--- a/rulebooks/dnd5e/gamectx/doc.go
+++ b/rulebooks/dnd5e/gamectx/doc.go
@@ -17,12 +17,14 @@
 //   - [WithReactionReadiness] / [IsReactionReady] — who has opted in to spend
 //     a reaction.
 //
-// Resolution installs [WithRoom] on every path today. [WithCast] is defined
-// here but NOT yet installed anywhere — that wiring is rpg-toolkit#1252 — so
-// [CastOf] currently returns ok=false and every consumer takes its "cannot
-// answer" branch. When it lands it goes in unconditionally beside the room,
-// because an ambient dependency that is sometimes present is exactly what went
-// wrong here before.
+// Resolution installs all three unconditionally on every resolve path — the
+// room first, the cast beside it once the sheets are loaded, and a default
+// readiness map derived from the cast (resolution/resolve.go; the #1252
+// wiring landed in #1256, readiness in #1282). There is no "sometimes
+// present" mode, because an ambient dependency that is sometimes present is
+// exactly what went wrong here before —
+// TestNoCodePathProducesACastlessInteraction and its room and readiness
+// siblings hold that structurally rather than by example.
 //
 // # What used to live here
 //
@@ -44,14 +46,17 @@
 // healthiest thing in this package. It is that an ambient dependency must be
 // MANDATORY and SINGULAR, and its absent value must say what the author meant.
 //
-// # Reaction readiness is the counter-example, and it stays
+// # Reaction readiness fails closed, and that is the point
 //
-// [IsReactionReady] returns false when no map is installed, and no map is ever
-// installed today. It survived the deletion above because that is not the same
-// bug: not-ready is the CORRECT answer while nothing in the stack lets a
-// player ready a reaction, and the code says so at the point of failure rather
-// than leaving it to be discovered. Opportunity Attack and Shield decline to
-// fire, on purpose, and will keep declining until reactions are built.
+// [IsReactionReady] returns false when no map is installed, or when the map is
+// silent about a member or a reaction. It survived the deletion above because
+// that is not the same bug: not-ready is the CORRECT answer for a reaction
+// nobody has opted into, and the code says so at the point of failure rather
+// than leaving it to be discovered. Since rpg-toolkit#1282, resolution
+// installs a default map on every path — free reactions readied for everyone,
+// costed ones absent from the set (the Wave 2.11d ruling reused) — so the
+// opportunity attack fires, while Shield keeps declining on purpose until
+// opting into a costed reaction is something a player can be asked.
 //
 // Fail-closed by design is not fail-silent by accident. The test for an
 // ambient dependency is not "is it installed" — it is "does its absent value

--- a/rulebooks/dnd5e/gamectx/doc.go
+++ b/rulebooks/dnd5e/gamectx/doc.go
@@ -14,8 +14,9 @@
 //
 //   - [WithRoom] / [Room] — the world the interaction happens on.
 //   - [WithCast] / [CastOf] — the participants in it.
-//   - [WithReactionReadiness] / [IsReactionReady] — who has opted in to spend
-//     a reaction.
+//   - [WithReactionReadiness] / [IsReactionReady] — who is ready to spend a
+//     reaction (free reactions are default-ready for everyone; costed ones
+//     require opting in — see below).
 //
 // Resolution installs all three unconditionally on every resolve path — the
 // room first, the cast beside it once the sheets are loaded, and a default


### PR DESCRIPTION
First exercise of the record-hygiene rule Kirk set 2026-08-28: stale decision status actively misleads the next reader, so it gets fixed the day the truth changes.

## The three stale claims

1. **ADR-0025 was still Accepted** while `GameContext`, `CharacterRegistry`, `RequireCharacters`, and `AddCharacter` are all deleted (#1251). Now marked **Superseded**, pointing at the effect-context design (`rpg-project/ideas/session-combat/effect-context/design.md`) and at `gamectx/doc.go` for the current contract. Body preserved as the 2024 record.

2. **`gamectx/doc.go` claimed `WithCast` "is NOT yet installed anywhere"** and that no readiness map is ever installed — both landed a day after those lines were written (#1256 installed the cast, #1282 the default readiness). The docs now state what `resolution/resolve.go` actually does on every path, and cite the `TestNoCodePathProduces*lessInteraction` family that holds it structurally. #1252's own body warned that leaving that paragraph stale is how the drift goes unnoticed; it recurred within a day.

3. **`cast.go`'s `WithCast`/`CastOf` comments** said the call site "does not exist yet" — updated to the installed reality, keeping the defensive-read guidance (session's standing and preflight attaches still raise no cast).

The third record fix from the same ruling — promoting #1284's grant-at-attach ruling out of PR prose — lands as a comment on rpg-project#317, the design issue for that slice.

## One open question, flagged rather than decided

The repo convention says superseded ADRs get a "Superseded by ADR-NNN" note. The superseding decision here is not an ADR — it is the ruled effect-context design in rpg-project. I pointed at that design rather than minting a shadow ADR that would duplicate a canonical doc. If you'd rather have an ADR-numbered marker in-repo, say so and I'll add one that is purely a pointer.

Doc-only; no behavior change. `gamectx` builds, vets, and tests green.

— platform agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ShtA8hCUv9jB48DJnmBPHh