### PR TITLE
feat(resolution): one door installs the truth — gamectx has a single writer

### DIFF
--- a/rulebooks/dnd5e/resolution/README.md
+++ b/rulebooks/dnd5e/resolution/README.md
@@ -49,13 +49,15 @@ out, err := resolution.Resolve(ctx, &resolution.Input{
 Order:
 
 1. validate input;
-2. load the active encounter world and install its room;
+2. load the active encounter world and take its room;
 3. attach all sheets/effects on one instrumented bus;
-4. call `Machine.Start` as pure preflight;
-5. pay the declared cost only after preflight succeeds;
-6. drive `Gather | Request | Done` steps;
-7. tear down newest-first;
-8. return world, dirty sheets, outcome, and hook ledger.
+4. install the game context through the one door, `installTruth` — the room,
+   the cast, and the reaction readiness derived from that cast;
+5. call `Machine.Start` as pure preflight;
+6. pay the declared cost only after preflight succeeds;
+7. drive `Gather | Request | Done` steps;
+8. tear down newest-first;
+9. return world, dirty sheets, outcome, and hook ledger.
 
 `Start` may validate and read attached sheets. It may not roll, spend, publish,
 or mutate. Invalid definitions, participants, delivery range, or condition

--- a/rulebooks/dnd5e/resolution/cast_test.go
+++ b/rulebooks/dnd5e/resolution/cast_test.go
@@ -27,15 +27,20 @@ import (
 //
 // That is the failure mode a behavioural suite is structurally unable to catch:
 // the tests supply what production does not. So the source is the assertion.
-// The install is one statement at the top level of resolveOn's body, and a
+// The install is one statement at the top level of the door's body, and a
 // condition wrapped around it is the defect by construction — whatever the
 // condition said, there would be inputs it answered no for.
+//
+// It reads [installTruth] rather than resolveOn because that is where the
+// install moved when the door was extracted. That the door is reached at all —
+// the half this test cannot see from inside it — is
+// TestOnlyTheDoorInstallsGameContext's.
 func TestNoCodePathProducesACastlessInteraction(t *testing.T) {
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "resolve.go", nil, 0)
+	file, err := parser.ParseFile(fset, doorFile, nil, 0)
 	require.NoError(t, err)
 
-	fn := funcDecl(t, file, "resolveOn")
+	fn := funcDecl(t, doorFile, file, "installTruth")
 
 	var installs []token.Pos
 	ast.Inspect(fn, func(n ast.Node) bool {
@@ -51,16 +56,7 @@ func TestNoCodePathProducesACastlessInteraction(t *testing.T) {
 	})
 	require.Len(t, installs, 1, "the cast is installed in exactly one place")
 
-	ast.Inspect(fn, func(n ast.Node) bool {
-		branch, ok := n.(*ast.IfStmt)
-		if !ok {
-			return true
-		}
-		require.False(t, branch.Pos() <= installs[0] && installs[0] < branch.End(),
-			"resolve.go:%d installs the cast inside a condition — some input answers no, "+
-				"and an ambient dependency that is sometimes absent is rpg-toolkit#1251",
-			fset.Position(installs[0]).Line)
-
-		return true
-	})
+	requireUnconditional(t, fset, fn, installs[0],
+		"installs the cast inside a condition — some input answers no, and an ambient "+
+			"dependency that is sometimes absent is rpg-toolkit#1251")
 }

--- a/rulebooks/dnd5e/resolution/cast_test.go
+++ b/rulebooks/dnd5e/resolution/cast_test.go
@@ -4,7 +4,6 @@
 package resolution
 
 import (
-	"go/ast"
 	"go/parser"
 	"go/token"
 	"testing"
@@ -42,18 +41,7 @@ func TestNoCodePathProducesACastlessInteraction(t *testing.T) {
 
 	fn := funcDecl(t, doorFile, file, "installTruth")
 
-	var installs []token.Pos
-	ast.Inspect(fn, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "WithCast" {
-			installs = append(installs, call.Pos())
-		}
-
-		return true
-	})
+	installs := installsOf(fn, "WithCast")
 	require.Len(t, installs, 1, "the cast is installed in exactly one place")
 
 	requireUnconditional(t, fset, fn, installs[0],

--- a/rulebooks/dnd5e/resolution/doc.go
+++ b/rulebooks/dnd5e/resolution/doc.go
@@ -181,7 +181,8 @@
 // outcome), so the case where the answer comes from outside the process is a
 // new step rather than a redesign of this one.
 //
-// Two game-context installers are populated, both unconditionally.
+// Three game-context installers are populated, all unconditionally, and all
+// through one function: [installTruth], the door.
 //
 // This paragraph used to say "No game context is installed", and describe five
 // gamectx registries waiting for a predicate to force them: the first predicate
@@ -205,7 +206,7 @@
 // registries nothing populates is the same mistake as populating registries
 // nothing reads, and it fails silently instead of loudly.
 //
-// What is installed now, on every path and inside no condition:
+// What the door installs, on every path and inside no condition:
 //
 //   - [gamectx.WithRoom] — the world the interaction happens on. ONE world,
 //     installed EVERY time, and it is THE world rather than a copy of it. The
@@ -220,11 +221,18 @@
 //   - [gamectx.WithCast] — who the participants are to each other. This
 //     package is the only one that can answer it: R3 passes everyone in, so
 //     this is the only place that holds them all. See [castView].
+//   - [gamectx.WithReactionReadiness] — which reactions each member is holding
+//     ready. Derived from the cast, which is why it is installed after it.
+//     Free reactions are readied for everybody and costed ones for nobody;
+//     [defaultReadiness] carries the ruling that says so.
 //
-// TestNoCodePathProducesARoomlessInteraction and
-// TestNoCodePathProducesACastlessInteraction hold both structurally rather than
-// by example, by reading this file's source. A behavioural suite cannot make
-// the claim: the defect is that tests supply what production does not, so the
+// TestNoCodePathProducesARoomlessInteraction,
+// TestNoCodePathProducesACastlessInteraction and
+// TestNoCodePathProducesAReadinesslessInteraction hold all three structurally
+// rather than by example, by reading the door's source; a fourth,
+// TestOnlyTheDoorInstallsGameContext, holds that the door is the only installer
+// and that resolveOn reaches it. A behavioural suite cannot make any of those
+// claims: the defect is that tests supply what production does not, so the
 // tests are the last place it shows up.
 //
 // This package builds no geometry of its own. It held a room it assembled out

--- a/rulebooks/dnd5e/resolution/readiness_test.go
+++ b/rulebooks/dnd5e/resolution/readiness_test.go
@@ -25,15 +25,20 @@ import (
 //
 // That is the same failure a behavioural suite is structurally unable to catch,
 // for the same reason: the tests supply what production does not. So the source
-// is the assertion. The install is one statement at the top level of resolveOn's
+// is the assertion. The install is one statement at the top level of the door's
 // body, and a condition wrapped around it is the defect by construction —
 // whatever the condition said, there would be inputs it answered no for.
+//
+// It reads [installTruth] rather than resolveOn because that is where the
+// install moved when the door was extracted. That the door is reached at all —
+// the half this test cannot see from inside it — is
+// TestOnlyTheDoorInstallsGameContext's.
 func TestNoCodePathProducesAReadinesslessInteraction(t *testing.T) {
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "resolve.go", nil, 0)
+	file, err := parser.ParseFile(fset, doorFile, nil, 0)
 	require.NoError(t, err)
 
-	fn := funcDecl(t, file, "resolveOn")
+	fn := funcDecl(t, doorFile, file, "installTruth")
 
 	var installs []token.Pos
 	ast.Inspect(fn, func(n ast.Node) bool {
@@ -49,17 +54,8 @@ func TestNoCodePathProducesAReadinesslessInteraction(t *testing.T) {
 	})
 	require.Len(t, installs, 1, "reaction readiness is installed in exactly one place")
 
-	ast.Inspect(fn, func(n ast.Node) bool {
-		branch, ok := n.(*ast.IfStmt)
-		if !ok {
-			return true
-		}
-		require.False(t, branch.Pos() <= installs[0] && installs[0] < branch.End(),
-			"resolve.go:%d installs reaction readiness inside a condition — some input "+
-				"answers no, and a reaction gate that is sometimes absent fails CLOSED, "+
-				"which is a reaction that silently never fires",
-			fset.Position(installs[0]).Line)
-
-		return true
-	})
+	requireUnconditional(t, fset, fn, installs[0],
+		"installs reaction readiness inside a condition — some input answers no, and a "+
+			"reaction gate that is sometimes absent fails CLOSED, which is a reaction "+
+			"that silently never fires")
 }

--- a/rulebooks/dnd5e/resolution/readiness_test.go
+++ b/rulebooks/dnd5e/resolution/readiness_test.go
@@ -4,7 +4,6 @@
 package resolution
 
 import (
-	"go/ast"
 	"go/parser"
 	"go/token"
 	"testing"
@@ -40,18 +39,7 @@ func TestNoCodePathProducesAReadinesslessInteraction(t *testing.T) {
 
 	fn := funcDecl(t, doorFile, file, "installTruth")
 
-	var installs []token.Pos
-	ast.Inspect(fn, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "WithReactionReadiness" {
-			installs = append(installs, call.Pos())
-		}
-
-		return true
-	})
+	installs := installsOf(fn, "WithReactionReadiness")
 	require.Len(t, installs, 1, "reaction readiness is installed in exactly one place")
 
 	requireUnconditional(t, fset, fn, installs[0],

--- a/rulebooks/dnd5e/resolution/resolve.go
+++ b/rulebooks/dnd5e/resolution/resolve.go
@@ -9,15 +9,12 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/KirkDiggler/rpg-toolkit/core"
 	"github.com/KirkDiggler/rpg-toolkit/dice"
 	"github.com/KirkDiggler/rpg-toolkit/events"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/encounter"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
 	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monstertraits"
-	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
 )
 
 // Participant is one member's sheet on the way in. Exactly one of Character or
@@ -319,23 +316,12 @@ func resolveOn(ctx context.Context, in *Input, surf *surface) (*Output, error) {
 		return nil, fmt.Errorf("resolution: load world: %w", err)
 	}
 
-	// INSTALL THE WORLD. One world, and it is installed every time.
-	//
-	// This is the map the encounter itself runs on — its own room, handed over
-	// to be read (rpg-toolkit#1114). Not a reconstruction of it: this package
-	// used to build a room out of the encounter's persisted description, with
-	// its own copy of grid construction and a comment promising the two would
-	// be kept in step, and no walls in it at all. What the rules read now is
-	// what the composition enforces, because they are the same object.
-	//
-	// EVERY TIME, which is the other half. "Which room describes this
-	// interaction" used to be a question, and the answer this package gave
-	// when it could not decide — install nothing — silently switched off every
-	// predicate that reads positions the moment one party member wandered off,
-	// which in a dungeon is most of the time (rpg-toolkit#1090). There is one
-	// map, so there is nothing to choose between, and no input can produce an
-	// interaction without a world. TestNoCodePathProducesARoomlessInteraction
-	// holds that structurally rather than by example.
+	// The map the encounter itself runs on — its own room, handed over to be
+	// read (rpg-toolkit#1114). Not a reconstruction of it: this package used to
+	// build a room out of the encounter's persisted description, with its own
+	// copy of grid construction and a comment promising the two would be kept in
+	// step, and no walls in it at all. What the rules read now is what the
+	// composition enforces, because they are the same object.
 	//
 	// It is READ-ONLY: the composition refuses a write through it by name, and
 	// this package has no business making one. Moving somebody is a verb of the
@@ -344,7 +330,6 @@ func resolveOn(ctx context.Context, in *Input, surf *surface) (*Output, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %w", ErrBadWorld, err)
 	}
-	ctx = gamectx.WithRoom(ctx, room)
 
 	cast, err := attachAll(ctx, surf, in.Participants, roller)
 	if err != nil {
@@ -355,44 +340,13 @@ func resolveOn(ctx context.Context, in *Input, surf *surface) (*Output, error) {
 		return nil, err
 	}
 
-	// The other half of the read channel: the room says where everyone is
-	// standing, and this says who they are to each other.
-	//
-	// EVERY TIME, for the same reason and with the same pin. Five registries
-	// in gamectx and a sixth in combat tried to answer pieces of this and
-	// between them were installed zero times, so three conditions read a
-	// registry nobody supplied and returned its error into a chain fold that
-	// swallows errors — a barbarian fought at base AC in every real fight and
-	// nothing was logged (rpg-toolkit#1251). An ambient dependency that is
-	// SOMETIMES present is the defect; being always present is the fix, and
-	// TestNoCodePathProducesACastlessInteraction holds that structurally
-	// rather than by example.
-	//
-	// It goes in after attachAll because that is the call that loads the
-	// sheets. Nothing reads it before then: effects subscribe during Apply and
-	// ask their questions at fold time, which is after this line.
-	ctx = gamectx.WithCast(ctx, &castView{cast: cast})
-
-	// The SIXTH registry in the family rpg-toolkit#1251 was about, installed
-	// zero times until now.
-	//
-	// gamectx.IsReactionReady fails closed by design, so every reaction
-	// condition in the rulebook has been gated behind a map nobody supplied —
-	// the opportunity attack could not fire in any real interaction, and the
-	// only reason its own suite is green is that each test installs a map by
-	// hand. That is the same shape as the barbarian who fought at base AC in
-	// every real fight, and it gets the same fix: ALWAYS PRESENT, derived
-	// here, held structurally by TestNoCodePathProducesAReadinesslessInteraction
-	// rather than by example.
-	//
-	// Free reactions are readied for everyone; costed ones are not readied at
-	// all. That is the Wave 2.11d ruling reused rather than re-derived — "free-
-	// cost reactions like OA are default-on for melee combatants, spell-cost
-	// reactions like Shield are default-off" — and it is why Shield is absent
-	// from the set below rather than present-and-false. Opting INTO a costed
-	// reaction is a decision a player makes, and this package is not where a
-	// player is asked anything.
-	ctx = gamectx.WithReactionReadiness(ctx, defaultReadiness(cast))
+	// INSTALL THE TRUTH, through the one door. Every ambient fact this
+	// interaction can be asked about goes in here, in one call, on the only path
+	// there is: the room the encounter compiled, the cast attachAll just loaded,
+	// and the readiness derived from that cast. What goes in, why each of them is
+	// unconditional, and why the order reads the way it does are all in
+	// installTruth — this line's job is to be the only place it is called from.
+	ctx = installTruth(ctx, room, cast)
 
 	// Start is pure preflight and runs before payment. Invalid participant,
 	// delivery, or condition declarations therefore consume nothing.
@@ -564,35 +518,4 @@ func dirtyMonsters(cast *Participants) []*monster.Data {
 	}
 
 	return out
-}
-
-// freeReactions are the reactions a member has readied simply by being in the
-// interaction, because they cost nothing to hold ready.
-//
-// ONE ENTRY, and the list is the rule rather than an optimisation of it. A
-// costed reaction — Shield burns a spell slot, Uncanny Dodge burns the class
-// feature — is not readied by existing, so adding one here would silently opt
-// every caster into spending a slot they never agreed to spend.
-var freeReactions = []*core.Ref{
-	refs.Conditions.OpportunityAttack(),
-}
-
-// defaultReadiness readies every participant for every free reaction.
-//
-// EVERY participant, not "every melee combatant". Whether a particular member
-// can actually take an opportunity attack is the condition's own predicate —
-// it is only seated on someone who has it, it checks its own reach, its own
-// meter and its own purse — and deciding it out here would put a rule in the
-// wiring, which is the same objection boundaryCast makes one file over.
-func defaultReadiness(cast *Participants) gamectx.ReactionReadinessMap {
-	ready := make(gamectx.ReactionReadinessMap, len(cast.order))
-	for _, id := range cast.order {
-		per := make(map[string]bool, len(freeReactions))
-		for _, ref := range freeReactions {
-			per[ref.String()] = true
-		}
-		ready[id] = per
-	}
-
-	return ready
 }

--- a/rulebooks/dnd5e/resolution/truth.go
+++ b/rulebooks/dnd5e/resolution/truth.go
@@ -1,0 +1,138 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+
+	"github.com/KirkDiggler/rpg-toolkit/core"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/refs"
+	"github.com/KirkDiggler/rpg-toolkit/tools/spatial"
+)
+
+// installTruth is THE DOOR: the one function allowed to call a gamectx.With*,
+// and TestOnlyTheDoorInstallsGameContext says so by reading this package's
+// source rather than by convention.
+//
+// ONE FUNCTION, because the defect it exists to prevent is a fact that is
+// SOMETIMES installed. gamectx once carried five registries and a sixth in
+// combat, and between them they were installed zero times: three conditions
+// read one nobody supplied and returned its error into a chain fold that
+// swallows errors, so a barbarian fought at base AC in every real fight and
+// nothing was logged (rpg-toolkit#1251). Spreading installs across the call
+// sites that happen to need them is how that state is reached — every site is
+// individually reasonable, and the set of them is what nobody checks. Collected
+// here, "did this path install the truth" is one question with one answer, and
+// a path that skips this function is a bug rather than a mode.
+//
+// EVERYTHING IT INSTALLS IS DERIVED FROM WHAT THE INTERACTION ALREADY HOLDS.
+// The room is the canvas the composition compiled, the cast is the participants
+// attachAll loaded, and readiness is a function of the cast. Nothing here
+// reaches for a repository: a fact that needs one is a record the caller loads,
+// not a tenant of this function. A new tenant is a design decision, not a
+// pattern to follow — bring it to the design before writing it.
+//
+// DEPENDENCY ORDER IS THE DOCUMENTATION. The body is plain sequential code
+// because the order is the whole story: readiness is derived from the cast, so
+// it follows the cast, and nothing else here has an order to respect.
+//
+// It is called AFTER attachAll, because that is the call that loads the sheets
+// and there is no cast before it. The world does not have to wait and used to
+// not: nothing on the attach path reads game context, and nothing on it
+// publishes. Effects subscribe during Apply and ask their questions at fold
+// time, and a CHAIN handler is handed the PUBLISHER's context — events'
+// chainedTopic carries the ctx it was published with — so the earliest any of
+// this is read is the first fold, which is after every line below.
+//
+// The word CHAIN is load-bearing there. A plain typed subscription is the other
+// way round: typedTopic.Subscribe closes over the context it was SUBSCRIBED
+// with and simpleEventBus.Publish drops the publisher's, so a turn-start or
+// damage-received handler sees whatever was installed when its sheet attached —
+// which, from where this function is called, is nothing. Every gamectx reader in
+// the rulebook today is a chain handler, and every typed handler that could
+// reach one takes its context as `_`, so nothing is gated on that. It is still
+// the sharp edge nearest this function: a reader added to a typed handler would
+// fail closed and log nothing, which is rpg-toolkit#1251 said back to us.
+func installTruth(ctx context.Context, room spatial.Room, cast *Participants) context.Context {
+	// INSTALL THE WORLD. One world, and it is installed every time.
+	//
+	// EVERY TIME is the half that bit. "Which room describes this interaction"
+	// used to be a question, and the answer this package gave when it could not
+	// decide — install nothing — silently switched off every predicate that
+	// reads positions the moment one party member wandered off, which in a
+	// dungeon is most of the time (rpg-toolkit#1090). There is one map, so
+	// there is nothing to choose between, and no input can produce an
+	// interaction without a world. TestNoCodePathProducesARoomlessInteraction
+	// holds that structurally rather than by example.
+	ctx = gamectx.WithRoom(ctx, room)
+
+	// The other half of the read channel: the room says where everyone is
+	// standing, and this says who they are to each other.
+	//
+	// EVERY TIME, for the same reason and with the same pin. Five registries in
+	// gamectx and a sixth in combat tried to answer pieces of this and between
+	// them were installed zero times, so three conditions read a registry
+	// nobody supplied and returned its error into a chain fold that swallows
+	// errors — a barbarian fought at base AC in every real fight and nothing
+	// was logged (rpg-toolkit#1251). An ambient dependency that is SOMETIMES
+	// present is the defect; being always present is the fix, and
+	// TestNoCodePathProducesACastlessInteraction holds that structurally rather
+	// than by example.
+	ctx = gamectx.WithCast(ctx, &castView{cast: cast})
+
+	// The SIXTH registry in the family rpg-toolkit#1251 was about, installed
+	// zero times until it was wired here.
+	//
+	// gamectx.IsReactionReady fails closed by design, so every reaction
+	// condition in the rulebook has been gated behind a map nobody supplied —
+	// the opportunity attack could not fire in any real interaction, and the
+	// only reason its own suite is green is that each test installs a map by
+	// hand. That is the same shape as the barbarian who fought at base AC in
+	// every real fight, and it gets the same fix: ALWAYS PRESENT, derived
+	// here, held structurally by TestNoCodePathProducesAReadinesslessInteraction
+	// rather than by example.
+	//
+	// Free reactions are readied for everyone; costed ones are not readied at
+	// all. That is the Wave 2.11d ruling reused rather than re-derived — "free-
+	// cost reactions like OA are default-on for melee combatants, spell-cost
+	// reactions like Shield are default-off" — and it is why Shield is absent
+	// from the set below rather than present-and-false. Opting INTO a costed
+	// reaction is a decision a player makes, and this package is not where a
+	// player is asked anything.
+	ctx = gamectx.WithReactionReadiness(ctx, defaultReadiness(cast))
+
+	return ctx
+}
+
+// freeReactions are the reactions a member has readied simply by being in the
+// interaction, because they cost nothing to hold ready.
+//
+// ONE ENTRY, and the list is the rule rather than an optimisation of it. A
+// costed reaction — Shield burns a spell slot, Uncanny Dodge burns the class
+// feature — is not readied by existing, so adding one here would silently opt
+// every caster into spending a slot they never agreed to spend.
+var freeReactions = []*core.Ref{
+	refs.Conditions.OpportunityAttack(),
+}
+
+// defaultReadiness readies every participant for every free reaction.
+//
+// EVERY participant, not "every melee combatant". Whether a particular member
+// can actually take an opportunity attack is the condition's own predicate —
+// it is only seated on someone who has it, it checks its own reach, its own
+// meter and its own purse — and deciding it out here would put a rule in the
+// wiring, which is the same objection boundaryCast makes one file over.
+func defaultReadiness(cast *Participants) gamectx.ReactionReadinessMap {
+	ready := make(gamectx.ReactionReadinessMap, len(cast.order))
+	for _, id := range cast.order {
+		per := make(map[string]bool, len(freeReactions))
+		for _, ref := range freeReactions {
+			per[ref.String()] = true
+		}
+		ready[id] = per
+	}
+
+	return ready
+}

--- a/rulebooks/dnd5e/resolution/truth_test.go
+++ b/rulebooks/dnd5e/resolution/truth_test.go
@@ -40,8 +40,25 @@ const doorFile = "truth.go"
 // each call site that needed a fact installed it where it stood, every one of
 // them individually reasonable, and the set of them was what nobody checked
 // (rpg-toolkit#1251). The count is the assertion, so the source is the
-// assertion: this reads every file in the package, test files included, because
-// "the tests supply what production does not" is the shape of the original bug.
+// assertion.
+//
+// TEST FILES ARE INCLUDED, and that is the half worth defending. "Every test
+// installed a registry by hand that production never installed" is not a
+// footnote to rpg-toolkit#1251, it is the whole reason the bug survived two
+// releases with a green suite — so a pin that exempts _test.go cannot see the
+// thing it was written for. A test in THIS package that needs an installed
+// context calls installTruth, the same door production calls. There is no
+// second way in, for tests either, and that is the point.
+//
+// ITS SCOPE IS THIS PACKAGE. It reads the .go files in resolution and no
+// others. conditions/ and monstertraits/ hand-install a context 43 times
+// between their suites, and none of that is in violation or even visible here:
+// they are separate modules whose sources are not on disk at test time, and
+// standing one fold up without running Resolve is what those tests are for.
+// Phase 3 takes those readers off the hand-installed path. Until then they are
+// out of this pin's reach rather than exempt from it — a distinction worth
+// keeping, because the day resolution grows a test that installs by hand is the
+// day this pin has something real to say.
 func TestOnlyTheDoorInstallsGameContext(t *testing.T) {
 	fset := token.NewFileSet()
 

--- a/rulebooks/dnd5e/resolution/truth_test.go
+++ b/rulebooks/dnd5e/resolution/truth_test.go
@@ -42,6 +42,14 @@ const doorFile = "truth.go"
 // (rpg-toolkit#1251). The count is the assertion, so the source is the
 // assertion.
 //
+// REFERENCES, NOT CALLS. It matches any mention of a gamectx.With* name, not
+// just a call of one — Copilot's finding on this PR, and correct: a pin that
+// only walks *ast.CallExpr lets `with := gamectx.WithRoom` past, along with
+// gamectx.WithRoom handed to something else as a value, either of which installs
+// a fact from outside the door while reading as clean. Nothing in resolution may
+// so much as NAME those functions except truth.go, which is both easier to check
+// and easier to obey than a rule about how they are invoked.
+//
 // TEST FILES ARE INCLUDED, and that is the half worth defending. "Every test
 // installed a registry by hand that production never installed" is not a
 // footnote to rpg-toolkit#1251, it is the whole reason the bug survived two
@@ -68,7 +76,7 @@ func TestOnlyTheDoorInstallsGameContext(t *testing.T) {
 	var offenders []string
 	for _, entry := range entries {
 		name := entry.Name()
-		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || name == doorFile {
 			continue
 		}
 
@@ -81,11 +89,7 @@ func TestOnlyTheDoorInstallsGameContext(t *testing.T) {
 		}
 
 		ast.Inspect(file, func(n ast.Node) bool {
-			call, ok := n.(*ast.CallExpr)
-			if !ok {
-				return true
-			}
-			sel, ok := call.Fun.(*ast.SelectorExpr)
+			sel, ok := n.(*ast.SelectorExpr)
 			if !ok {
 				return true
 			}
@@ -93,19 +97,17 @@ func TestOnlyTheDoorInstallsGameContext(t *testing.T) {
 			if !ok || pkg.Name != local || !strings.HasPrefix(sel.Sel.Name, "With") {
 				return true
 			}
-			if name == doorFile {
-				return true
-			}
 
 			offenders = append(offenders, fmt.Sprintf("%s: %s.%s",
-				fset.Position(call.Pos()), local, sel.Sel.Name))
+				fset.Position(sel.Pos()), local, sel.Sel.Name))
 
 			return true
 		})
 	}
 	require.Empty(t, offenders,
-		"%s is the only file allowed to install game context — a second installer is "+
-			"how gamectx got five registries and one install (rpg-toolkit#1251). If the "+
+		"%s is the only file allowed to name a game-context installer — a second "+
+			"installer is how gamectx got five registries and one install "+
+			"(rpg-toolkit#1251), and taking one as a value is still being one. If the "+
 			"new fact belongs in context, it goes through installTruth; if it needs a "+
 			"repository it is a record, not a tenant, and admission is a ruling either way",
 		doorFile)
@@ -135,6 +137,32 @@ func TestOnlyTheDoorInstallsGameContext(t *testing.T) {
 		"calls the door inside a condition — an interaction that skips it reads a "+
 			"world, a cast and a readiness map that nobody installed, which is every "+
 			"failure the three pins beside this one were written for at once")
+}
+
+// installsOf returns every position in fn where the installer called name is
+// NAMED — called, assigned to a variable, or handed over as a value.
+//
+// References rather than calls, for the reason
+// TestOnlyTheDoorInstallsGameContext gives at length and one this side has to
+// state for itself. For a pin asserting an install is PRESENT, aliasing the only
+// install is loud: the count falls to zero and the test fails. The case that
+// would pass in silence is a SECOND install added by alias beside the direct one
+// — the call count stays at one, the fact is installed twice, and "installed in
+// exactly one place" is false with nothing to say so. Inside the door, which
+// TestOnlyTheDoorInstallsGameContext exempts by design, that is the only pin
+// left to catch it. Counting names costs nothing: an ordinary call names its
+// function exactly once.
+func installsOf(fn *ast.FuncDecl, name string) []token.Pos {
+	var installs []token.Pos
+	ast.Inspect(fn, func(n ast.Node) bool {
+		if sel, ok := n.(*ast.SelectorExpr); ok && sel.Sel.Name == name {
+			installs = append(installs, sel.Pos())
+		}
+
+		return true
+	})
+
+	return installs
 }
 
 // importedAs reports the local name a file imports path under, and whether it

--- a/rulebooks/dnd5e/resolution/truth_test.go
+++ b/rulebooks/dnd5e/resolution/truth_test.go
@@ -1,0 +1,177 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// gamectxPath is the package the door is the only caller of. Matched by import
+// path rather than by the name "gamectx", so aliasing the import does not walk
+// an install past this pin.
+const gamectxPath = "github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+
+// doorFile is the file [installTruth] lives in. Every gamectx.With* in this
+// package belongs to it.
+const doorFile = "truth.go"
+
+// TestOnlyTheDoorInstallsGameContext is the R5 pin: exactly one function
+// installs game context, and it is [installTruth].
+//
+// The three pins it sits with — TestNoCodePathProducesARoomlessInteraction,
+// TestNoCodePathProducesACastlessInteraction and
+// TestNoCodePathProducesAReadinesslessInteraction — each say that ONE fact is
+// installed once and unconditionally. None of them can say what this one says:
+// that no SECOND installer exists, and that the resolve path reaches the door
+// at all. Drop the call to installTruth and all three still pass, because each
+// of them is reading the door's own body.
+//
+// That gap is the defect they were written for, seen from the other side.
+// gamectx reached five registries and a sixth in combat by exactly this route —
+// each call site that needed a fact installed it where it stood, every one of
+// them individually reasonable, and the set of them was what nobody checked
+// (rpg-toolkit#1251). The count is the assertion, so the source is the
+// assertion: this reads every file in the package, test files included, because
+// "the tests supply what production does not" is the shape of the original bug.
+func TestOnlyTheDoorInstallsGameContext(t *testing.T) {
+	fset := token.NewFileSet()
+
+	entries, err := os.ReadDir(".")
+	require.NoError(t, err)
+
+	var offenders []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") {
+			continue
+		}
+
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		require.NoError(t, err)
+
+		local, imported := importedAs(t, name, file, gamectxPath)
+		if !imported {
+			continue
+		}
+
+		ast.Inspect(file, func(n ast.Node) bool {
+			call, ok := n.(*ast.CallExpr)
+			if !ok {
+				return true
+			}
+			sel, ok := call.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			pkg, ok := sel.X.(*ast.Ident)
+			if !ok || pkg.Name != local || !strings.HasPrefix(sel.Sel.Name, "With") {
+				return true
+			}
+			if name == doorFile {
+				return true
+			}
+
+			offenders = append(offenders, fmt.Sprintf("%s: %s.%s",
+				fset.Position(call.Pos()), local, sel.Sel.Name))
+
+			return true
+		})
+	}
+	require.Empty(t, offenders,
+		"%s is the only file allowed to install game context — a second installer is "+
+			"how gamectx got five registries and one install (rpg-toolkit#1251). If the "+
+			"new fact belongs in context, it goes through installTruth; if it needs a "+
+			"repository it is a record, not a tenant, and admission is a ruling either way",
+		doorFile)
+
+	// And the door is ON the path. Everything above is about who may install;
+	// this is the half that says the installing happens.
+	file, err := parser.ParseFile(fset, "resolve.go", nil, 0)
+	require.NoError(t, err)
+
+	fn := funcDecl(t, "resolve.go", file, "resolveOn")
+
+	var calls []token.Pos
+	ast.Inspect(fn, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		if ident, ok := call.Fun.(*ast.Ident); ok && ident.Name == "installTruth" {
+			calls = append(calls, call.Pos())
+		}
+
+		return true
+	})
+	require.Len(t, calls, 1, "resolveOn goes through the door exactly once")
+
+	requireUnconditional(t, fset, fn, calls[0],
+		"calls the door inside a condition — an interaction that skips it reads a "+
+			"world, a cast and a readiness map that nobody installed, which is every "+
+			"failure the three pins beside this one were written for at once")
+}
+
+// importedAs reports the local name a file imports path under, and whether it
+// imports it at all.
+//
+// A dot import is refused rather than resolved: it would let `WithRoom(ctx, r)`
+// install without naming a package, and a pin that cannot see an install is
+// worse than no pin.
+func importedAs(t *testing.T, filename string, file *ast.File, path string) (string, bool) {
+	t.Helper()
+
+	quoted := `"` + path + `"`
+	for _, spec := range file.Imports {
+		if spec.Path.Value != quoted {
+			continue
+		}
+		if spec.Name == nil {
+			return path[strings.LastIndex(path, "/")+1:], true
+		}
+		require.NotEqual(t, ".", spec.Name.Name,
+			"%s dot-imports gamectx, which hides installs from this pin", filename)
+
+		if spec.Name.Name == "_" {
+			return "", false
+		}
+
+		return spec.Name.Name, true
+	}
+
+	return "", false
+}
+
+// requireUnconditional fails when the install at pos sits inside an if
+// statement in fn.
+//
+// The shared half of all four pins in this family, and the reason each of them
+// is structural rather than behavioural: whatever the condition said, there
+// would be inputs it answered no for, and the interactions that hit those
+// inputs are exactly the ones no test happens to write. msg carries the caller's
+// own reason, because "sometimes absent" costs something different for each
+// fact — a silent base AC, a reaction that never fires, a positional predicate
+// switched off the moment somebody wanders into the next room.
+func requireUnconditional(t *testing.T, fset *token.FileSet, fn *ast.FuncDecl, pos token.Pos, msg string) {
+	t.Helper()
+
+	where := fset.Position(pos)
+	ast.Inspect(fn, func(n ast.Node) bool {
+		branch, ok := n.(*ast.IfStmt)
+		if !ok {
+			return true
+		}
+		require.False(t, branch.Pos() <= pos && pos < branch.End(),
+			"%s:%d %s", where.Filename, where.Line, msg)
+
+		return true
+	})
+}

--- a/rulebooks/dnd5e/resolution/world_test.go
+++ b/rulebooks/dnd5e/resolution/world_test.go
@@ -225,16 +225,21 @@ func TestTheInstalledWorldRefusesToBeWrittenTo(t *testing.T) {
 // spanned two rooms, which no test in this package did, for two releases.
 //
 // So the source is the assertion. The install is one statement at the top level
-// of resolveOn's body, and a condition wrapped around it is the defect, by
+// of the door's body, and a condition wrapped around it is the defect, by
 // construction: whatever the condition said, there would be inputs it answered
 // no for. Reintroducing one fails here whether or not anybody writes a scene
 // that reaches it.
+//
+// It reads [installTruth] rather than resolveOn because that is where the
+// install moved when the door was extracted. That the door is reached at all —
+// the half this test cannot see from inside it — is
+// TestOnlyTheDoorInstallsGameContext's.
 func TestNoCodePathProducesARoomlessInteraction(t *testing.T) {
 	fset := token.NewFileSet()
-	file, err := parser.ParseFile(fset, "resolve.go", nil, 0)
+	file, err := parser.ParseFile(fset, doorFile, nil, 0)
 	require.NoError(t, err)
 
-	fn := funcDecl(t, file, "resolveOn")
+	fn := funcDecl(t, doorFile, file, "installTruth")
 
 	var installs []token.Pos
 	ast.Inspect(fn, func(n ast.Node) bool {
@@ -250,23 +255,14 @@ func TestNoCodePathProducesARoomlessInteraction(t *testing.T) {
 	})
 	require.Len(t, installs, 1, "the world is installed in exactly one place")
 
-	ast.Inspect(fn, func(n ast.Node) bool {
-		branch, ok := n.(*ast.IfStmt)
-		if !ok {
-			return true
-		}
-		require.False(t, branch.Pos() <= installs[0] && installs[0] < branch.End(),
-			"resolve.go:%d installs the world inside a condition — some input answers no, "+
-				"and that is rpg-toolkit#1090",
-			fset.Position(installs[0]).Line)
-
-		return true
-	})
+	requireUnconditional(t, fset, fn, installs[0],
+		"installs the world inside a condition — some input answers no, and that is "+
+			"rpg-toolkit#1090")
 }
 
-// funcDecl finds a top-level function by name, and says so if it has been
-// renamed out from under the pin above.
-func funcDecl(t *testing.T, file *ast.File, name string) *ast.FuncDecl {
+// funcDecl finds a top-level function by name in filename's parsed source, and
+// says so if it has been renamed out from under the pin that asked for it.
+func funcDecl(t *testing.T, filename string, file *ast.File, name string) *ast.FuncDecl {
 	t.Helper()
 
 	for _, decl := range file.Decls {
@@ -276,7 +272,7 @@ func funcDecl(t *testing.T, file *ast.File, name string) *ast.FuncDecl {
 		}
 	}
 
-	t.Fatalf("resolve.go has no function %q — if it was renamed, this pin must follow it", name)
+	t.Fatalf("%s has no function %q — if it was renamed, this pin must follow it", filename, name)
 
 	return nil
 }

--- a/rulebooks/dnd5e/resolution/world_test.go
+++ b/rulebooks/dnd5e/resolution/world_test.go
@@ -241,18 +241,7 @@ func TestNoCodePathProducesARoomlessInteraction(t *testing.T) {
 
 	fn := funcDecl(t, doorFile, file, "installTruth")
 
-	var installs []token.Pos
-	ast.Inspect(fn, func(n ast.Node) bool {
-		call, ok := n.(*ast.CallExpr)
-		if !ok {
-			return true
-		}
-		if sel, ok := call.Fun.(*ast.SelectorExpr); ok && sel.Sel.Name == "WithRoom" {
-			installs = append(installs, call.Pos())
-		}
-
-		return true
-	})
+	installs := installsOf(fn, "WithRoom")
 	require.Len(t, installs, 1, "the world is installed in exactly one place")
 
 	requireUnconditional(t, fset, fn, installs[0],


### PR DESCRIPTION
## Phase 1 of the game-context design: the door

Part of rpg-project#319. Design and plan:
`rpg-project/ideas/session-combat/game-context/design.md` (rpg-project#318,
ruled by Kirk 2026-08-28). **R5** of that design says exactly one function
installs game context and no other code calls a `gamectx.With*`. This PR is that
function, and nothing else.

`resolveOn` installed three tenants inline — the room before `attachAll`, the
cast and the reaction readiness after it. They are now one call:

```go
func installTruth(ctx context.Context, room spatial.Room, cast *Participants) context.Context
```

in `rulebooks/dnd5e/resolution/truth.go`, called from exactly one line in
`resolveOn`. `freeReactions` and `defaultReadiness` move with it: the door's file
holds every fact it installs and every derivation that feeds one. The rich
comments at the three sites moved with their installs rather than being
rewritten.

**The world moved from before `attachAll` to after it**, so the door is one call
rather than two phases. That was checked, not assumed: nothing on the attach path
reads game context or publishes, and every `gamectx` reader in the rulebook —
Prone, Sneak Attack, Pack Tactics, the opportunity attack, Fighting Style
(Protection), Shield — is a `SubscribeWithChain` handler, which `chainedTopic`
hands the **publisher's** context. The earliest any tenant can be read is the
first fold, which is after every line of the door.

That check turned up a sharp edge worth naming, and `installTruth`'s doc names
it: a plain `typedTopic.Subscribe` is the other way round. It closes over the
**subscribe-time** context, and `simpleEventBus.Publish` drops the publisher's —
so a `gamectx` reader added to a turn-start or damage-received handler would see
nothing installed, fail closed, and log nothing. No such reader exists today
(every typed handler that could reach one takes its context as `_`), so this
changes no behaviour; it is flagged because Phase 3 moves readers around, and
this is rpg-toolkit#1251's shape waiting to happen.

## The new pin

`TestOnlyTheDoorInstallsGameContext` says what the three
`TestNoCodePathProduces*lessInteraction` pins structurally cannot:

1. **No second installer.** Every `.go` file in the package is parsed, test files
   included — "the tests supply what production does not" is the shape of the
   original bug — and every `gamectx.With*` call must be in `truth.go`. Matched by
   import path, so an alias does not walk an install past it; a dot import is
   refused rather than resolved.
2. **The door is reached.** `resolveOn` calls `installTruth` exactly once, and not
   inside a condition.

**How far the pin can see, and why test files are in.** Its scope is this
package: the `.go` files in `resolution` and no others. Including `_test.go` is
the deliberate half — "every test installed a registry by hand that production
never installed" is why rpg-toolkit#1251 survived two releases behind a green
suite, so a pin that exempts tests cannot see the thing it exists for. A test in
this package that needs an installed context calls `installTruth`, the same door
production calls. `conditions/` and `monstertraits/` hand-install a context 43
times between their suites; none of it is in violation or even visible here —
separate modules, sources not on disk at test time, and standing one fold up
without running `Resolve` is what those tests are for. Phase 3 takes those
readers off the hand-installed path. Documented on the test in `56a824a`.

Half 2 is not redundant: **delete the `installTruth` call and all three existing
pins still pass**, because each is reading the door's own body. That was verified
by mutation, below.

The three existing pins follow the install into `truth.go` unchanged in claim.
Their shared "not inside an `if`" walk is now one helper, `requireUnconditional`,
which keeps each pin's own reason in its own failure message.

## No behaviour change — evidence

Same tenants, same values, same order; the only ordering change is the room's,
argued above. Full gate run from `rulebooks/dnd5e/resolution/`:

```
go build ./...        clean
go vet ./...          clean
gofmt -l .            clean
goimports -l .        clean
go mod tidy           no diff
golangci-lint run     0 issues
go test ./...         ok — 32 top-level tests, all green
```

The four structural pins by name:

```
--- PASS: TestNoCodePathProducesARoomlessInteraction
--- PASS: TestNoCodePathProducesACastlessInteraction
--- PASS: TestNoCodePathProducesAReadinesslessInteraction
--- PASS: TestOnlyTheDoorInstallsGameContext
```

The intermediate state is evidence too: after the extraction and before the pins
were retargeted, exactly those three failed with "installed in exactly one place,
but has 0" and every other test in the package stayed green. The pins followed
the code; nothing else noticed the move.

**Mutation-tested**, four mutants, each reverted from a copy:

| Mutant | Caught by |
|---|---|
| a second `gamectx.WithRoom` in `world_test.go` | `TestOnlyTheDoorInstallsGameContext` — `world_test.go:281:9: gamectx.WithRoom` |
| `installTruth` call wrapped in `if` | `TestOnlyTheDoorInstallsGameContext` — "calls the door inside a condition" |
| `installTruth` call removed entirely | `TestOnlyTheDoorInstallsGameContext` only — **the three tenant pins stayed green**, which is the gap this test exists to close |
| `WithReactionReadiness` wrapped in `if` inside the door | `TestNoCodePathProducesAReadinesslessInteraction` — "truth.go:94 installs reaction readiness inside a condition" |

Docs follow the same day: `doc.go` said "two game-context installers" and pointed
at `resolve.go`'s source; it now says three, names the door, adds the missing
`WithReactionReadiness` bullet, and points at the door's source. `README.md`'s
numbered order gains the install step in its new position.

## Not in this PR

No new tenant, no signature change on `Resolve`, no file touched outside
`rulebooks/dnd5e/resolution`, no `go.mod`/`go.sum` change. Verb-level install is
Phase 2; the reader migration is Phase 3.

— platform agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)

