### PR TITLE
feat(resolution): a fold can come here for the truth — the projection entry

### DIFF
--- a/rulebooks/dnd5e/resolution/doc.go
+++ b/rulebooks/dnd5e/resolution/doc.go
@@ -231,7 +231,13 @@
 // TestNoCodePathProducesAReadinesslessInteraction hold all three structurally
 // rather than by example, by reading the door's source; a fourth,
 // TestOnlyTheDoorInstallsGameContext, holds that the door is the only installer
-// and that resolveOn reaches it. A behavioural suite cannot make any of those
+// and that every path which folds reaches it.
+//
+// There are two such paths. [Resolve] runs an interaction; [ProjectCharacter]
+// folds one derived number for a caller with no interaction to run — a
+// character joining a session, who is not standing anywhere yet and so gets a
+// context whose room is honestly ABSENT rather than invented. Both go through
+// the same door, and neither is a mode of the other. A behavioural suite cannot make any of those
 // claims: the defect is that tests supply what production does not, so the
 // tests are the last place it shows up.
 //

--- a/rulebooks/dnd5e/resolution/projection.go
+++ b/rulebooks/dnd5e/resolution/projection.go
@@ -1,0 +1,171 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/KirkDiggler/rpg-toolkit/dice"
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+)
+
+// ProjectCharacterInput is the one character a projection folds, on the way in.
+type ProjectCharacterInput struct {
+	// Character is the sheet as the host stored it. A RECORD, not a live sheet:
+	// the seam fetches records and only records, and truth is built down here.
+	// Handing a live *character.Character across this boundary instead would be
+	// the caller holding the thing this entry exists to keep it from holding.
+	Character *character.Data
+}
+
+// ProjectCharacterOutput is what the projection derived. All of it is data.
+type ProjectCharacterOutput struct {
+	// ArmorClass is the folded AC, carrying every contributor's component —
+	// the same breakdown an interaction folds, because it is folded the same
+	// way, on a bus with the same subscribers.
+	ArmorClass *combat.ACBreakdown
+}
+
+// ProjectCharacter folds one character's armour class outside any interaction:
+// attach the one character, install the truth, fold, tear down.
+//
+// FOLDS LIVE IN RESOLUTION. A fold needs game context, game context is only
+// ever installed by the one door, and the door is in here — so when a
+// computation needs truth, the computation comes to resolution rather than the
+// truth being carried out to it. The caller this was written for is session's
+// Join, which held an attached sheet and called Character.EffectiveAC where it
+// stood: a fold outside resolution, reading whatever ambient context its caller
+// happened to have, which was none at all. This is the entry that lets such a
+// caller obey the law without being handed anything it should not hold.
+//
+// THE CAST STAYS SEALED. attachAll and Participants are internal and stay
+// internal. What crosses this boundary is a record on the way in and numbers on
+// the way out; a caller holding a cast would be a caller able to fold without a
+// door, which is the disease rather than the cure.
+//
+// # There is no world here, and that is an answer rather than a gap
+//
+// A character joining a session is not standing anywhere — a join is not an
+// encounter and may never become one — so the room this installs is ABSENT.
+// Absence is the honest value, not a placeholder: [gamectx.Room] answers
+// (nil, false) and [gamectx.RequireRoom] answers ErrNoRoom, so a reader that
+// needs the world fails closed with the reason readable where it failed. That
+// is the tenant-admission rule about absent values doing what the author meant,
+// and it is why this does not install some empty room to keep a shape tidy — an
+// empty room would answer "you are nowhere, and there is nothing here", which
+// is a different and false statement. Nothing on the AC chain asks in any case:
+// Unarmored Defense and Fighting Style (Defense) both take their context as `_`.
+//
+// This is NOT the defect rpg-toolkit#1090 named, and the difference is worth
+// stating precisely because that pin is still green over this code. #1090 was
+// an interaction that HAD a world and, on a branch, chose not to install it.
+// The install below is as unconditional as every other; what differs is the
+// value, and the value tells the truth.
+func ProjectCharacter(ctx context.Context, in *ProjectCharacterInput) (*ProjectCharacterOutput, error) {
+	// One bus for this fold, created here and nowhere else — the same claim
+	// Resolve makes one file over, made the same way.
+	return projectCharacterOn(ctx, in, newSurface(events.NewEventBus()))
+}
+
+// projectCharacterOn is [ProjectCharacter] with the surface handed in, so a
+// test can hold the bus underneath and check what is left on it afterwards.
+//
+// Unexported for the reason resolveOn is unexported: a caller supplying its own
+// bus would be a caller keeping one alive, which is the thing this package
+// exists to prevent.
+func projectCharacterOn(
+	ctx context.Context, in *ProjectCharacterInput, surf *surface,
+) (*ProjectCharacterOutput, error) {
+	if in == nil {
+		return nil, ErrNilInput
+	}
+
+	// The same validation every participant gets, from the same function, for
+	// the same reason: a sheet with no ID cannot be read back out of the cast
+	// it was just put into.
+	one := Participant{Character: in.Character}
+	if err := one.validate(); err != nil {
+		return nil, err
+	}
+
+	cast, err := attachAll(ctx, surf, []Participant{one}, refusingRoller{})
+	if err != nil {
+		// Tear down whatever did attach before giving up, exactly as the
+		// interaction path does: a half-attached bus is garbage either way, and
+		// leaving revocation to an error path's silence is how leaks become
+		// normal.
+		_ = surf.teardown(ctx)
+
+		return nil, err
+	}
+
+	// THE SAME DOOR, with a cast of one and no world. Not a second installer
+	// and not a lighter one — there is exactly one function that may do this,
+	// and this is a caller of it.
+	ctx = installTruth(ctx, nil, cast)
+
+	ch, ok := cast.Character(one.ID())
+	if !ok {
+		// attachAll put it there one statement ago, under this exact ID, so
+		// this is unreachable rather than unlikely. It refuses anyway: the day
+		// that stops being true, a nil dereference is the worst available way
+		// to find out.
+		return nil, errors.Join(
+			fmt.Errorf("%w: %q attached but is not in the cast", ErrBadParticipant, one.ID()),
+			surf.teardown(ctx),
+		)
+	}
+
+	breakdown, foldErr := ch.EffectiveAC(ctx)
+
+	// Revoked on every exit whether or not the fold worked, because a
+	// subscription that outlives its interaction is the leak this package
+	// exists to prevent, and a projection is a very short interaction.
+	tearErr := surf.teardown(ctx)
+
+	if foldErr != nil {
+		return nil, errors.Join(
+			fmt.Errorf("resolution: project character %q: %w", one.ID(), foldErr),
+			tearErr,
+		)
+	}
+	if tearErr != nil {
+		return nil, fmt.Errorf("resolution: teardown: %w", tearErr)
+	}
+
+	return &ProjectCharacterOutput{ArmorClass: breakdown}, nil
+}
+
+// refusingRoller is the roller handed to attachAll on a path where nothing may
+// roll.
+//
+// The same argument RefusingStriker and RefusingAnnouncer make in resolveOn. A
+// projection attaches exactly one CHARACTER, and the roller exists for the
+// monster branch — traits like Undead Fortitude that roll when triggered. This
+// path builds its own participant and never builds a monster one, so the
+// capability is unreachable by construction. A nil would express the same
+// belief and cash it out as a panic the moment somebody proved it wrong;
+// refusing names the violation instead, which is the difference between
+// failing closed and failing over.
+type refusingRoller struct{}
+
+// Ensure refusingRoller is a complete dice.Roller — an incomplete one would not
+// compile at the attachAll call above, which is the point of stating it here.
+var _ dice.Roller = refusingRoller{}
+
+// Roll refuses, naming the path that reached it.
+func (refusingRoller) Roll(_ context.Context, size int) (int, error) {
+	return 0, fmt.Errorf("%w: a projection reached a d%d — projections fold, they do not roll",
+		ErrNoRoller, size)
+}
+
+// RollN refuses, naming the path that reached it.
+func (refusingRoller) RollN(_ context.Context, count, size int) ([]int, error) {
+	return nil, fmt.Errorf("%w: a projection reached %dd%d — projections fold, they do not roll",
+		ErrNoRoller, count, size)
+}

--- a/rulebooks/dnd5e/resolution/projection_test.go
+++ b/rulebooks/dnd5e/resolution/projection_test.go
@@ -1,0 +1,243 @@
+// Copyright (C) 2026 Kirk Diggler
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+package resolution
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+
+	"github.com/KirkDiggler/rpg-toolkit/events"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/abilities"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/character"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/classes"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/combat"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/conditions"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/gamectx"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/monster"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/races"
+	"github.com/KirkDiggler/rpg-toolkit/rulebooks/dnd5e/shared"
+)
+
+// ProjectionTestSuite proves the entry that lets a caller obey "folds live in
+// resolution" without being handed a cast.
+//
+// The case it exists for is the one that was broken: a barbarian with Unarmored
+// Defense whose AC is a DERIVED number. Read off the sheet it is 10; folded
+// with its condition attached it is 15. Every assertion below states the number
+// rather than comparing two runs of the same code, because a projection and a
+// fold that are both wrong the same way agree perfectly.
+type ProjectionTestSuite struct {
+	suite.Suite
+
+	ctx context.Context
+}
+
+func TestProjectionSuite(t *testing.T) {
+	suite.Run(t, new(ProjectionTestSuite))
+}
+
+func (s *ProjectionTestSuite) SetupTest() {
+	s.ctx = context.Background()
+}
+
+// projectedHeroID is this suite's own, so a fixture change here cannot move a
+// number in somebody else's suite.
+const projectedHeroID = "projected-hero"
+
+// barbarian is unarmoured, with DEX +2 and CON +3 — DELIBERATELY DIFFERENT, so
+// a formula that reached for the wrong ability produces a different total
+// instead of the same one by luck. Unarmored Defense makes the answer
+// 10 + 2 + 3 = 15.
+//
+// ArmorClass on the sheet says 10 and is meant to: it is the stale scalar the
+// old read path returned, so any test below that accidentally reads the sheet
+// instead of folding reports 10 and says so out loud.
+func (s *ProjectionTestSuite) barbarian(conds ...json.RawMessage) *character.Data {
+	return &character.Data{
+		ID:       projectedHeroID,
+		PlayerID: "player-1",
+		Name:     "Standre",
+		Level:    1,
+		ClassID:  classes.Barbarian,
+		RaceID:   races.Human,
+		AbilityScores: shared.AbilityScores{
+			abilities.STR: 16,
+			abilities.DEX: 14,
+			abilities.CON: 16,
+			abilities.INT: 10,
+			abilities.WIS: 12,
+			abilities.CHA: 8,
+		},
+		HitPoints:        14,
+		MaxHitPoints:     14,
+		ArmorClass:       10,
+		ProficiencyBonus: 2,
+		Conditions:       conds,
+	}
+}
+
+func (s *ProjectionTestSuite) unarmoredDefense() json.RawMessage {
+	raw, err := (&conditions.UnarmoredDefenseCondition{
+		CharacterID: projectedHeroID,
+		Type:        conditions.UnarmoredDefenseBarbarian,
+	}).ToJSON()
+	s.Require().NoError(err)
+
+	return raw
+}
+
+// TestTheProjectionFoldsTheConditionIn is the base-AC-barbarian case, stated as
+// a value.
+//
+// 15, not "whatever the sheet said" and not "whatever another call returned":
+// 10 base + 2 DEX + 3 CON, each of which appears as its own component. A
+// projection that lost the condition would answer 12 and still look like a
+// working fold, which is exactly how the original bug read.
+//
+// WHAT THIS DOES NOT PROVE, said out loud because silence here would read as a
+// claim: the number does not depend on the door. Unarmored Defense still reads
+// its own sheet through the owner handle character.Attach wires, not through
+// game context — so deleting the installTruth call from the projection leaves
+// this whole suite green. That was measured rather than assumed. What the fold
+// depends on today is the ATTACH, which is what this pins. The door is held on
+// this path structurally instead, by TestOnlyTheDoorInstallsGameContext, until
+// the reader migration moves Unarmored Defense onto the cast and the value
+// starts depending on it too.
+func (s *ProjectionTestSuite) TestTheProjectionFoldsTheConditionIn() {
+	out, err := ProjectCharacter(s.ctx, &ProjectCharacterInput{
+		Character: s.barbarian(s.unarmoredDefense()),
+	})
+	s.Require().NoError(err)
+	s.Require().NotNil(out.ArmorClass)
+
+	s.Require().Equal(15, out.ArmorClass.Total,
+		"10 base + 2 DEX + 3 CON: the condition reached the fold")
+
+	var fromFeature int
+	for _, component := range out.ArmorClass.Components {
+		if component.Type == combat.ACSourceFeature {
+			fromFeature += component.Value
+		}
+	}
+	s.Require().Equal(3, fromFeature,
+		"and the +3 arrived as a feature component, not as a bigger base")
+}
+
+// TestTheProjectionMatchesAnAttachedFold is the parity half: the number the
+// projection derives is the number the old path derived, for the same record.
+//
+// The old path is written out in full rather than called through a helper —
+// load, attach, fold — because it is the thing being replaced, and a reader
+// comparing the two should be able to see both. Both are pinned to 15
+// independently, so this cannot pass by two wrongs agreeing.
+func (s *ProjectionTestSuite) TestTheProjectionMatchesAnAttachedFold() {
+	direct, err := character.Load(s.ctx, s.barbarian(s.unarmoredDefense()))
+	s.Require().NoError(err)
+	s.Require().NoError(character.Attach(s.ctx, direct, events.NewEventBus()))
+
+	before, err := direct.EffectiveAC(s.ctx)
+	s.Require().NoError(err)
+	s.Require().Equal(15, before.Total, "the path being replaced answers 15")
+
+	out, err := ProjectCharacter(s.ctx, &ProjectCharacterInput{
+		Character: s.barbarian(s.unarmoredDefense()),
+	})
+	s.Require().NoError(err)
+
+	s.Require().Equal(15, out.ArmorClass.Total, "and so does the path replacing it")
+	s.Require().Equal(before.Total, out.ArmorClass.Total)
+	s.Require().Len(out.ArmorClass.Components, len(before.Components),
+		"component for component, not just total for total")
+}
+
+// TestTheProjectionInstallsNoWorld is the M4 pin, and the answer to "how did
+// you enter the door without a room".
+//
+// A join is not an encounter, so there is no world to install and none is
+// invented. The door is still called unconditionally; what it installs is an
+// ABSENT room, and absence is a value that states what the author meant:
+// Room answers not-ok, RequireRoom answers ErrNoRoom, and a reader that needs
+// the world fails closed with the reason readable where it failed.
+//
+// The alternative — an empty room, to keep the shape tidy — would answer "you
+// are somewhere, and there is nothing there", which is false and unfalsifiable
+// at the point a predicate reads it.
+func (s *ProjectionTestSuite) TestTheProjectionInstallsNoWorld() {
+	ctx := installTruth(s.ctx, nil, &Participants{
+		characters: map[string]*character.Character{},
+		monsters:   map[string]*monster.Monster{},
+		order:      []string{},
+	})
+
+	room, ok := gamectx.Room(ctx)
+	s.Require().False(ok, "no world was installed, and the read says so")
+	s.Require().Nil(room)
+
+	_, err := gamectx.RequireRoom(ctx)
+	s.Require().ErrorIs(err, gamectx.ErrNoRoom,
+		"and a reader that requires one fails closed, naming what is missing")
+
+	// The other two tenants are present on the same context — absence is the
+	// room's honest answer, not a projection that installs nothing.
+	_, castOK := gamectx.CastOf(ctx)
+	s.Require().True(castOK, "the cast is installed even when the world is not")
+}
+
+// TestTheProjectionLeavesNothingOnTheBus holds the teardown half.
+//
+// Asserted on the bus rather than on the teardown call, the same shape
+// TestARefusedPaymentLeavesNothingOnTheBus uses: the pin survives a change to
+// which mechanism does the work. Unarmored Defense joins the AC chain on the
+// way in, and after the projection returns that chain answers nobody — a
+// projection that leaked would keep folding a sheet its caller has forgotten.
+func (s *ProjectionTestSuite) TestTheProjectionLeavesNothingOnTheBus() {
+	inner := events.NewEventBus()
+
+	out, err := projectCharacterOn(s.ctx, &ProjectCharacterInput{
+		Character: s.barbarian(s.unarmoredDefense()),
+	}, newSurface(inner))
+	s.Require().NoError(err)
+	s.Require().Equal(15, out.ArmorClass.Total, "it folded before it tore down")
+
+	event := &combat.ACChainEvent{
+		CharacterID: projectedHeroID,
+		Breakdown:   &combat.ACBreakdown{Total: 0, Components: []combat.ACComponent{}},
+	}
+	chain := events.NewStagedChain[*combat.ACChainEvent](combat.ModifierStages)
+
+	modified, err := combat.ACChain.On(inner).PublishWithChain(s.ctx, event, chain)
+	s.Require().NoError(err)
+
+	folded, err := modified.Execute(s.ctx, event)
+	s.Require().NoError(err)
+
+	s.Require().Empty(folded.Breakdown.Components,
+		"Unarmored Defense attached during the projection and does not answer this chain")
+}
+
+// TestTheProjectionRefusesARecordItCannotName covers the validation the entry
+// borrows rather than reinvents: a sheet with no ID cannot be read back out of
+// the cast it was just put into, so it is refused on the way in.
+func (s *ProjectionTestSuite) TestTheProjectionRefusesARecordItCannotName() {
+	s.Run("nil input", func() {
+		_, err := ProjectCharacter(s.ctx, nil)
+		s.Require().ErrorIs(err, ErrNilInput)
+	})
+
+	s.Run("no character", func() {
+		_, err := ProjectCharacter(s.ctx, &ProjectCharacterInput{})
+		s.Require().ErrorIs(err, ErrBadParticipant)
+	})
+
+	s.Run("no id", func() {
+		nameless := s.barbarian()
+		nameless.ID = ""
+
+		_, err := ProjectCharacter(s.ctx, &ProjectCharacterInput{Character: nameless})
+		s.Require().ErrorIs(err, ErrBadParticipant)
+	})
+}

--- a/rulebooks/dnd5e/resolution/truth_test.go
+++ b/rulebooks/dnd5e/resolution/truth_test.go
@@ -9,6 +9,7 @@ import (
 	"go/parser"
 	"go/token"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 
@@ -31,9 +32,17 @@ const doorFile = "truth.go"
 // TestNoCodePathProducesACastlessInteraction and
 // TestNoCodePathProducesAReadinesslessInteraction — each say that ONE fact is
 // installed once and unconditionally. None of them can say what this one says:
-// that no SECOND installer exists, and that the resolve path reaches the door
+// that no SECOND installer exists, and that the paths which fold reach the door
 // at all. Drop the call to installTruth and all three still pass, because each
 // of them is reading the door's own body.
+//
+// "The paths which fold" is a list now, not a single function — see
+// [foldEntries]. Resolution grew a second entry when the projection landed, and
+// the law it serves is that FOLDS LIVE IN RESOLUTION: a caller that needs a
+// derived number brings the computation here rather than carrying truth out to
+// itself. This pin holds the near half of that law, the half resolution can
+// see — every fold that starts here starts by opening the door, and nothing
+// else opens it.
 //
 // That gap is the defect they were written for, seen from the other side.
 // gamectx reached five registries and a sixth in combat by exactly this route —
@@ -112,13 +121,62 @@ func TestOnlyTheDoorInstallsGameContext(t *testing.T) {
 			"repository it is a record, not a tenant, and admission is a ruling either way",
 		doorFile)
 
-	// And the door is ON the path. Everything above is about who may install;
-	// this is the half that says the installing happens.
-	file, err := parser.ParseFile(fset, "resolve.go", nil, 0)
-	require.NoError(t, err)
+	// And the door is ON every path that reaches a fold. Everything above is
+	// about who may install; this is the half that says the installing happens.
+	for _, entry := range foldEntries {
+		file, err := parser.ParseFile(fset, entry.file, nil, 0)
+		require.NoError(t, err)
 
-	fn := funcDecl(t, "resolve.go", file, "resolveOn")
+		fn := funcDecl(t, entry.file, file, entry.fn)
 
+		calls := doorCalls(fn)
+		require.Len(t, calls, 1, "%s goes through the door exactly once", entry.fn)
+
+		requireUnconditional(t, fset, fn, calls[0],
+			"calls the door inside a condition — a fold that skips it reads a world, "+
+				"a cast and a readiness map that nobody installed, which is every "+
+				"failure the three pins beside this one were written for at once")
+	}
+
+	// And nothing ELSE reaches the door, which is what makes the list above a
+	// list rather than a sample. A new entry that folds is a design moment: it
+	// either goes through installTruth and gets named here, or it folds without
+	// truth, which is the bug R6 is about.
+	require.Equal(t, entryNames(foldEntries), doorCallers(t, fset, entries),
+		"every non-test caller of installTruth is a declared fold entry, and every "+
+			"declared fold entry calls it — a fold reached any other way is a fold "+
+			"outside the door")
+}
+
+// foldEntries are the functions in this package that stand a fold up from
+// nothing, and therefore the functions that must go through the door first.
+//
+// TWO of them, and the second is why this is a table. Resolve runs an
+// interaction; ProjectCharacter folds one derived number for a caller that has
+// no interaction to run — a character joining a session, who is not standing
+// anywhere yet. Both need the truth installed for the same reason and install
+// it the same way; neither is a mode of the other.
+//
+// The functions named are the *On forms rather than their exported wrappers,
+// because those are where the bus is held and the door is called. A wrapper
+// that stopped delegating would fail funcDecl or the count, loudly.
+var foldEntries = []struct{ file, fn string }{
+	{"resolve.go", "resolveOn"},
+	{"projection.go", "projectCharacterOn"},
+}
+
+func entryNames(entries []struct{ file, fn string }) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.fn)
+	}
+	sort.Strings(names)
+
+	return names
+}
+
+// doorCalls returns every position in fn where installTruth is called.
+func doorCalls(fn *ast.FuncDecl) []token.Pos {
 	var calls []token.Pos
 	ast.Inspect(fn, func(n ast.Node) bool {
 		call, ok := n.(*ast.CallExpr)
@@ -131,12 +189,43 @@ func TestOnlyTheDoorInstallsGameContext(t *testing.T) {
 
 		return true
 	})
-	require.Len(t, calls, 1, "resolveOn goes through the door exactly once")
 
-	requireUnconditional(t, fset, fn, calls[0],
-		"calls the door inside a condition — an interaction that skips it reads a "+
-			"world, a cast and a readiness map that nobody installed, which is every "+
-			"failure the three pins beside this one were written for at once")
+	return calls
+}
+
+// doorCallers returns the sorted names of every non-test top-level function in
+// the package that calls installTruth.
+//
+// TEST FILES ARE EXCLUDED here, and the asymmetry with the scan above is
+// deliberate rather than an oversight. That scan asks who may INSTALL, where a
+// test installing by hand is the original defect wearing a disguise. This one
+// asks which production paths fold, and a test calling the door is a test using
+// the sanctioned entrance — the one this file tells authors to use. Counting
+// those would turn a correct test into a failure and teach the wrong lesson.
+func doorCallers(t *testing.T, fset *token.FileSet, entries []os.DirEntry) []string {
+	t.Helper()
+
+	var callers []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+
+		file, err := parser.ParseFile(fset, name, nil, 0)
+		require.NoError(t, err)
+
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || len(doorCalls(fn)) == 0 {
+				continue
+			}
+			callers = append(callers, fn.Name.Name)
+		}
+	}
+	sort.Strings(callers)
+
+	return callers
 }
 
 // installsOf returns every position in fn where the installer called name is


### PR DESCRIPTION
## Phase 2, PR-A: the projection entry

Part of rpg-project#319. Design: `rpg-project/ideas/session-combat/game-context/design.md` (rpg-project#318, Kirk's final form 2026-08-28 — *"having session do loading that should be happening in resolution is not a solid foundation we can build on"*). Phase 1 was rpg-toolkit#1286.

This is the resolution half only. Session's reroute is PR-B, after this merges and tags.

```go
func ProjectCharacter(ctx context.Context, in *ProjectCharacterInput) (*ProjectCharacterOutput, error)

type ProjectCharacterInput struct {
	Character *character.Data      // a RECORD, not a live sheet
}
type ProjectCharacterOutput struct {
	ArmorClass *combat.ACBreakdown  // the folded AC, components and all
}
```

in `rulebooks/dnd5e/resolution/projection.go`. It attaches the one character, installs the truth, folds, tears down — the design's four verbs, in that order. `ProjectCharacter` creates the bus; `projectCharacterOn` takes a surface so a test can hold it underneath, mirroring the `Resolve`/`resolveOn` split rather than inventing a second one.

**It serves R6.** A fold needs game context; game context is installed only by the door; the door is in here. So a caller that needs a derived number brings the computation to resolution instead of carrying truth out to itself. `session.Join` held an attached sheet and called `EffectiveAC` where it stood — a fold outside resolution, reading whatever ambient context its caller happened to have, which was none.

**D6 holds: the cast stays sealed.** `attachAll` and `Participants` stay internal. A record goes in, numbers come out. Attach goes *through* `attachAll` — not beside it — so there is no second attach mechanism.

## How it enters the door without a room

The same door, unchanged, called with an absent room:

```go
ctx = installTruth(ctx, nil, cast)
```

That is not a nil-as-present lie, and it was verified rather than assumed. `gamectx.Room` guards with `ok && room != nil`, so an absent room reads as absent: `Room` answers `(nil, false)`, `RequireRoom` answers `ErrNoRoom`. A reader needing the world fails closed with the reason readable at the point of failure — M4 exactly. `TestTheProjectionInstallsNoWorld` pins all three, and pins that the cast *is* installed on the same context, so this is absence of a world rather than absence of an install.

Installing an empty room instead would answer "you are somewhere, and there is nothing there" — false, and unfalsifiable where a predicate reads it. A join is not an encounter and may never become one.

**This is not rpg-toolkit#1090.** That was an interaction which *had* a world and declined to install it on a branch. Here the install is as unconditional as every other; only the value differs, and the value is true. `TestNoCodePathProducesARoomlessInteraction` stays green untouched.

Behaviourally clean, as the spike predicted and I re-verified: nothing on the AC chain reads the room. `UnarmoredDefenseCondition.onACChain` and `FightingStyleDefenseCondition.onACChain` both take their context as `_`.

## The roller

`attachAll` wants a `dice.Roller`. The projection hands it a `refusingRoller` — the argument `RefusingStriker` and `RefusingAnnouncer` make in `resolveOn` one file over. The projection builds its own participant and never a monster one, so the roller (which exists for monster traits that roll when triggered) is unreachable by construction. A nil would express the same belief and cash it out as a panic the day somebody proved it wrong; refusing names the violation instead.

## Structural pin, extended for the second entry

`TestOnlyTheDoorInstallsGameContext` grows a `foldEntries` table:

1. Both `resolveOn` and `projectCharacterOn` call `installTruth` exactly once, and not inside a condition.
2. Those two are the **only** non-test callers of the door — so a third fold entry either joins the list deliberately or fails the pin.

Test files are excluded from (2) and included in the "who may install `gamectx.With*`" scan above it. The asymmetry is deliberate: that scan asks who may *install*, where a hand-installing test is the original defect in disguise; this one asks which production paths fold, and a test calling the door is a test using the sanctioned entrance.

## Evidence

Gates from `rulebooks/dnd5e/resolution/`: `go build`, `go vet`, `gofmt -l`, `goimports -l`, `go mod tidy` (no diff), `golangci-lint` (0 issues), full suite green.

Mutation-verified, each reverted from a copy:

| Mutant | Caught by |
|---|---|
| projection skips the door | `TestOnlyTheDoorInstallsGameContext` — "projectCharacterOn goes through the door exactly once" |
| door call wrapped in `if` | same — "projection.go:111 calls the door inside a condition" |
| undeclared third entry calling the door | same — "every non-test caller of installTruth is a declared fold entry" |
| condition dropped from the record | `TestTheProjectionFoldsTheConditionIn` — expected 15, got 12 |

## Stated, not implied: what the AC pin does not prove

**The AC value does not depend on the door today.** Unarmored Defense still reads its own sheet through the `OwnerAware` handle `character.Attach` wires, not through game context — so deleting the `installTruth` call leaves the whole projection suite green. That was *measured*, not assumed, and it is written into the test's doc comment rather than left for someone to discover.

What the value pins today is the **attach**: 10 base + 2 DEX + 3 CON = 15, each as its own component, and 12 if the condition is dropped. The door is held on this path structurally until Phase 3 moves that read onto the cast, at which point the value starts depending on it too. Parity is pinned both ways — the old path (load, attach, fold) and the projection are each asserted to 15 independently, so it cannot pass by two wrongs agreeing.

## Not in this PR

No session change (PR-B). No new gamectx tenant. No change to `Resolve`'s signature, to `installTruth`'s, or to the sealed cast. Nothing touched outside `rulebooks/dnd5e/resolution`; no `go.mod`/`go.sum` change.

— platform agent, on behalf of KirkDiggler

🤖 Generated with [Claude Code](https://claude.com/claude-code)
